### PR TITLE
Add support to set the window title bmp looks for.

### DIFF
--- a/FFBardMusicPlayer/FFBardMusicPlayer.csproj
+++ b/FFBardMusicPlayer/FFBardMusicPlayer.csproj
@@ -75,6 +75,9 @@
     <ApplicationIcon>Icon.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="CommandLine, Version=2.6.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
+      <HintPath>..\packages\CommandLineParser.2.6.0\lib\net461\CommandLine.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/FFBardMusicPlayer/Forms/BmpProcessSelect.cs
+++ b/FFBardMusicPlayer/Forms/BmpProcessSelect.cs
@@ -149,6 +149,10 @@ namespace FFBardMusicPlayer {
                 		{
                     			processes.Add(process);
                 		}
+				else if (Program.overrideWindowTitle == "BMPdefaultWindowCheck" && process.ProcessName == "ffxiv_dx11")
+				{
+					processes.Add(process);
+				}
             		}
 			foreach(Process process in processes.ToList()) {
 				Mutex mutex = new Mutex(true, string.Format("bard-music-player-{0}", process.Id));

--- a/FFBardMusicPlayer/Forms/BmpProcessSelect.cs
+++ b/FFBardMusicPlayer/Forms/BmpProcessSelect.cs
@@ -140,16 +140,16 @@ namespace FFBardMusicPlayer {
 				}
 				return;
 			}
-			// Get a list of all ffxiv processes
-            Process[] currentProcesses = Process.GetProcesses();
-            List<Process> processes = new List<Process>();
-            foreach (var process in currentProcesses)
-            {
-                if (process.MainWindowTitle == Program.overrideWindowTitle)
-                {
-                    processes.Add(process);
-                }
-            }
+			// Get a list of all ffxiv_dx11 processes
+            		Process[] currentProcesses = Process.GetProcesses();
+            		List<Process> processes = new List<Process>();
+            		foreach (var process in currentProcesses)
+            		{
+                		if (process.MainWindowTitle == Program.overrideWindowTitle && process.ProcessName == "ffxiv_dx11")
+                		{
+                    			processes.Add(process);
+                		}
+            		}
 			foreach(Process process in processes.ToList()) {
 				Mutex mutex = new Mutex(true, string.Format("bard-music-player-{0}", process.Id));
 				if(!mutex.WaitOne(TimeSpan.Zero, true)) {

--- a/FFBardMusicPlayer/Forms/BmpProcessSelect.cs
+++ b/FFBardMusicPlayer/Forms/BmpProcessSelect.cs
@@ -141,7 +141,15 @@ namespace FFBardMusicPlayer {
 				return;
 			}
 			// Get a list of all ffxiv processes
-			List<Process> processes = new List<Process>(Process.GetProcessesByName("ffxiv_dx11"));
+            Process[] currentProcesses = Process.GetProcesses();
+            List<Process> processes = new List<Process>();
+            foreach (var process in currentProcesses)
+            {
+                if (process.MainWindowTitle == Program.overrideWindowTitle)
+                {
+                    processes.Add(process);
+                }
+            }
 			foreach(Process process in processes.ToList()) {
 				Mutex mutex = new Mutex(true, string.Format("bard-music-player-{0}", process.Id));
 				if(!mutex.WaitOne(TimeSpan.Zero, true)) {

--- a/FFBardMusicPlayer/Program.cs
+++ b/FFBardMusicPlayer/Program.cs
@@ -30,20 +30,20 @@ namespace FFBardMusicPlayer {
         [STAThread]
         static void Main(string[] args)
         {
-            /*
+            		/*
 			if(!mutex.WaitOne(TimeSpan.Zero, true)) {
 				PostMessage((IntPtr) HWND_BROADCAST, App.WM_SHOWME, IntPtr.Zero, IntPtr.Zero);
 				return;
 			}
 			*/
             
-            Parser.Default.ParseArguments<Options>(args)
-                   .WithParsed<Options>(options =>
-                   {
-                       if (!string.IsNullOrEmpty(options.OverrideWindowTitle)) overrideWindowTitle = options.OverrideWindowTitle;
-                   });
+            		Parser.Default.ParseArguments<Options>(args)
+           		        .WithParsed<Options>(options =>
+            		       {
+            		           if (!string.IsNullOrEmpty(options.OverrideWindowTitle)) overrideWindowTitle = options.OverrideWindowTitle;
+             		      });
 
-            Application.EnableVisualStyles();
+          		  Application.EnableVisualStyles();
 
 			CultureInfo nonInvariantCulture = new CultureInfo("en-US");
 			Thread.CurrentThread.CurrentCulture = nonInvariantCulture;

--- a/FFBardMusicPlayer/Program.cs
+++ b/FFBardMusicPlayer/Program.cs
@@ -1,4 +1,5 @@
-﻿using FFBardMusicPlayer.Forms;
+﻿using CommandLine;
+using FFBardMusicPlayer.Forms;
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -13,21 +14,36 @@ namespace FFBardMusicPlayer {
 		public static string urlBase = "http://bmp.sqnya.se/";
 		public static string appBase = Application.CommonAppDataPath;
 
+        public static string overrideWindowTitle="FINAL FANTASY XIV";
+
 		[DllImport("kernel32.dll")]
 		static extern IntPtr GetConsoleWindow();
 
-		//static Mutex mutex = new Mutex(true, "{FC7C9ABB-4F98-43F6-891B-F4161097C939}");
+        //static Mutex mutex = new Mutex(true, "{FC7C9ABB-4F98-43F6-891B-F4161097C939}");
 
-		[STAThread]
-		static void Main(string[] args) {
-			/*
+        public class Options
+        {
+            [Option('t', "override-window-title", Required = false, HelpText = "Override the ffxiv window process title to look for. Useful for custom sandboxed game instances.")]
+            public string OverrideWindowTitle { get; set; }
+        }
+
+        [STAThread]
+        static void Main(string[] args)
+        {
+            /*
 			if(!mutex.WaitOne(TimeSpan.Zero, true)) {
 				PostMessage((IntPtr) HWND_BROADCAST, App.WM_SHOWME, IntPtr.Zero, IntPtr.Zero);
 				return;
 			}
 			*/
+            
+            Parser.Default.ParseArguments<Options>(args)
+                   .WithParsed<Options>(options =>
+                   {
+                       if (!string.IsNullOrEmpty(options.OverrideWindowTitle)) overrideWindowTitle = options.OverrideWindowTitle;
+                   });
 
-			Application.EnableVisualStyles();
+            Application.EnableVisualStyles();
 
 			CultureInfo nonInvariantCulture = new CultureInfo("en-US");
 			Thread.CurrentThread.CurrentCulture = nonInvariantCulture;

--- a/FFBardMusicPlayer/Program.cs
+++ b/FFBardMusicPlayer/Program.cs
@@ -14,7 +14,7 @@ namespace FFBardMusicPlayer {
 		public static string urlBase = "http://bmp.sqnya.se/";
 		public static string appBase = Application.CommonAppDataPath;
 
-        public static string overrideWindowTitle="FINAL FANTASY XIV";
+        public static string overrideWindowTitle="BMPdefaultWindowCheck";
 
 		[DllImport("kernel32.dll")]
 		static extern IntPtr GetConsoleWindow();

--- a/FFBardMusicPlayer/packages.config
+++ b/FFBardMusicPlayer/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CommandLineParser" version="2.6.0" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net45" />
   <package id="NLog" version="4.5.10" targetFramework="net461" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net45" requireReinstallation="true" />


### PR DESCRIPTION
 Add support to set the window title bmp looks for.

By default it uses the standard "FINAL FANTASY XIV" that any non modded client would use. ISBOXER and other such tools can let you override the window title, and this is useful to auto hook specific game instances.

usage:
FFBardMusicPlayer.exe -t "OTHER FFXIV WINDOW TITLE"