### PR TITLE
WIP: Playlist Maintenance

### DIFF
--- a/FFBardMusicPlayer/Components/BmpOctaveShift.cs
+++ b/FFBardMusicPlayer/Components/BmpOctaveShift.cs
@@ -22,7 +22,9 @@ namespace FFBardMusicPlayer.Components {
 		}
 
 		protected override void UpdateEditText() {
+            this.ChangingText = true;
 			this.Text = string.Format("ø{0:+#;-#;0}", this.Value);
+            this.ChangingText = false;
 		}
 	}
 }

--- a/FFBardMusicPlayer/Components/BmpSpeedShift.cs
+++ b/FFBardMusicPlayer/Components/BmpSpeedShift.cs
@@ -24,7 +24,9 @@ namespace FFBardMusicPlayer.Controls {
 			this.TextAlign = HorizontalAlignment.Center;
 		}
 		protected override void UpdateEditText() {
+            this.ChangingText = true;
 			this.Text = this.Value.ToString() + "%";
+            this.ChangingText = false;
 		}
 	}
 }

--- a/FFBardMusicPlayer/Components/BmpTrackShift.cs
+++ b/FFBardMusicPlayer/Components/BmpTrackShift.cs
@@ -20,7 +20,9 @@ namespace FFBardMusicPlayer.Components {
 		}
 
 		protected override void UpdateEditText() {
+            this.ChangingText = true;
 			this.Text = "t" + this.Value.ToString();
+            this.ChangingText = false;
 		}
 	}
 }

--- a/FFBardMusicPlayer/Controls/BmpPlaylist.Designer.cs
+++ b/FFBardMusicPlayer/Controls/BmpPlaylist.Designer.cs
@@ -23,280 +23,281 @@
 		/// the contents of this method with the code editor.
 		/// </summary>
 		private void InitializeComponent() {
-			this.components = new System.ComponentModel.Container();
-			System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-			this.Playlist = new System.Windows.Forms.GroupBox();
-			this.PlaylistView = new System.Windows.Forms.DataGridView();
-			this.filePathDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.MidiEntrySource = new System.Windows.Forms.BindingSource(this.components);
-			this.Playlist_Remove = new System.Windows.Forms.Button();
-			this.Playlist_Add = new System.Windows.Forms.Button();
-			this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.Playlist_Export = new System.Windows.Forms.Button();
-			this.Playlist_Import = new System.Windows.Forms.Button();
-			this.ButtonPanel = new System.Windows.Forms.Panel();
-			this.Playlist_Random = new FFBardMusicPlayer.Components.BmpCheckButton(this.components);
-			this.ButtonBindSource = new System.Windows.Forms.BindingSource(this.components);
-			this.Playlist_Loop = new FFBardMusicPlayer.Components.BmpCheckButton(this.components);
-			this.dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-			this.AutoPlayToggle = new System.Windows.Forms.CheckBox();
-			this.Playlist.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.PlaylistView)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.MidiEntrySource)).BeginInit();
-			this.ButtonPanel.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.ButtonBindSource)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// Playlist
-			// 
-			this.Playlist.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.components = new System.ComponentModel.Container();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+            this.Playlist = new System.Windows.Forms.GroupBox();
+            this.PlaylistView = new System.Windows.Forms.DataGridView();
+            this.filePathDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dataGridViewTextBoxColumn5 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.MidiEntrySource = new System.Windows.Forms.BindingSource(this.components);
+            this.Playlist_Remove = new System.Windows.Forms.Button();
+            this.Playlist_Add = new System.Windows.Forms.Button();
+            this.dataGridViewTextBoxColumn1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Playlist_Export = new System.Windows.Forms.Button();
+            this.Playlist_Import = new System.Windows.Forms.Button();
+            this.ButtonPanel = new System.Windows.Forms.Panel();
+            this.AutoPlayToggle = new System.Windows.Forms.CheckBox();
+            this.Playlist_Random = new FFBardMusicPlayer.Components.BmpCheckButton(this.components);
+            this.ButtonBindSource = new System.Windows.Forms.BindingSource(this.components);
+            this.Playlist_Loop = new FFBardMusicPlayer.Components.BmpCheckButton(this.components);
+            this.dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Playlist.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.PlaylistView)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.MidiEntrySource)).BeginInit();
+            this.ButtonPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.ButtonBindSource)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // Playlist
+            // 
+            this.Playlist.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.Playlist.Controls.Add(this.PlaylistView);
-			this.Playlist.Controls.Add(this.Playlist_Remove);
-			this.Playlist.Controls.Add(this.Playlist_Add);
-			this.Playlist.Font = new System.Drawing.Font("Segoe UI", 12F);
-			this.Playlist.Location = new System.Drawing.Point(0, 0);
-			this.Playlist.Name = "Playlist";
-			this.Playlist.Padding = new System.Windows.Forms.Padding(3, 3, 3, 0);
-			this.Playlist.Size = new System.Drawing.Size(253, 207);
-			this.Playlist.TabIndex = 0;
-			this.Playlist.TabStop = false;
-			this.Playlist.Text = "PLAYLIST";
-			// 
-			// PlaylistView
-			// 
-			this.PlaylistView.AllowDrop = true;
-			this.PlaylistView.AllowUserToAddRows = false;
-			this.PlaylistView.AllowUserToDeleteRows = false;
-			this.PlaylistView.AllowUserToResizeColumns = false;
-			this.PlaylistView.AllowUserToResizeRows = false;
-			this.PlaylistView.AutoGenerateColumns = false;
-			this.PlaylistView.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.AllCells;
-			this.PlaylistView.BorderStyle = System.Windows.Forms.BorderStyle.None;
-			this.PlaylistView.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
-			this.PlaylistView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
-			this.PlaylistView.ColumnHeadersVisible = false;
-			this.PlaylistView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.Playlist.Controls.Add(this.PlaylistView);
+            this.Playlist.Controls.Add(this.Playlist_Remove);
+            this.Playlist.Controls.Add(this.Playlist_Add);
+            this.Playlist.Font = new System.Drawing.Font("Segoe UI", 12F);
+            this.Playlist.Location = new System.Drawing.Point(0, 0);
+            this.Playlist.Name = "Playlist";
+            this.Playlist.Padding = new System.Windows.Forms.Padding(3, 3, 3, 0);
+            this.Playlist.Size = new System.Drawing.Size(253, 207);
+            this.Playlist.TabIndex = 0;
+            this.Playlist.TabStop = false;
+            this.Playlist.Text = "PLAYLIST";
+            // 
+            // PlaylistView
+            // 
+            this.PlaylistView.AllowDrop = true;
+            this.PlaylistView.AllowUserToAddRows = false;
+            this.PlaylistView.AllowUserToDeleteRows = false;
+            this.PlaylistView.AllowUserToResizeColumns = false;
+            this.PlaylistView.AllowUserToResizeRows = false;
+            this.PlaylistView.AutoGenerateColumns = false;
+            this.PlaylistView.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.AllCells;
+            this.PlaylistView.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.PlaylistView.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
+            this.PlaylistView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
+            this.PlaylistView.ColumnHeadersVisible = false;
+            this.PlaylistView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.filePathDataGridViewTextBoxColumn,
             this.dataGridViewTextBoxColumn5});
-			this.PlaylistView.DataSource = this.MidiEntrySource;
-			this.PlaylistView.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.PlaylistView.EditMode = System.Windows.Forms.DataGridViewEditMode.EditProgrammatically;
-			this.PlaylistView.GridColor = System.Drawing.SystemColors.AppWorkspace;
-			this.PlaylistView.Location = new System.Drawing.Point(3, 25);
-			this.PlaylistView.Margin = new System.Windows.Forms.Padding(0);
-			this.PlaylistView.MultiSelect = false;
-			this.PlaylistView.Name = "PlaylistView";
-			this.PlaylistView.ReadOnly = true;
-			this.PlaylistView.RowHeadersVisible = false;
-			this.PlaylistView.RowHeadersWidth = 40;
-			this.PlaylistView.RowHeadersWidthSizeMode = System.Windows.Forms.DataGridViewRowHeadersWidthSizeMode.DisableResizing;
-			dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.AppWorkspace;
-			dataGridViewCellStyle1.ForeColor = System.Drawing.Color.Black;
-			dataGridViewCellStyle1.SelectionBackColor = System.Drawing.Color.Black;
-			dataGridViewCellStyle1.SelectionForeColor = System.Drawing.Color.White;
-			dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-			this.PlaylistView.RowsDefaultCellStyle = dataGridViewCellStyle1;
-			this.PlaylistView.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-			this.PlaylistView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-			this.PlaylistView.Size = new System.Drawing.Size(247, 182);
-			this.PlaylistView.TabIndex = 0;
-			this.PlaylistView.CellMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.PlaylistView_CellMouseDoubleClick);
-			this.PlaylistView.CellPainting += new System.Windows.Forms.DataGridViewCellPaintingEventHandler(this.PlaylistControl_CellPainting);
-			this.PlaylistView.DragDrop += new System.Windows.Forms.DragEventHandler(this.BmpMidiEntryList_DragDrop);
-			this.PlaylistView.DragOver += new System.Windows.Forms.DragEventHandler(this.BmpMidiEntryList_DragOver);
-			this.PlaylistView.MouseDown += new System.Windows.Forms.MouseEventHandler(this.BmpMidiEntryList_MouseDown);
-			this.PlaylistView.MouseMove += new System.Windows.Forms.MouseEventHandler(this.BmpMidiEntryList_MouseMove);
-			// 
-			// filePathDataGridViewTextBoxColumn
-			// 
-			this.filePathDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-			this.filePathDataGridViewTextBoxColumn.DataPropertyName = "FilePath";
-			this.filePathDataGridViewTextBoxColumn.HeaderText = "FilePath";
-			this.filePathDataGridViewTextBoxColumn.Name = "filePathDataGridViewTextBoxColumn";
-			this.filePathDataGridViewTextBoxColumn.ReadOnly = true;
-			this.filePathDataGridViewTextBoxColumn.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-			// 
-			// dataGridViewTextBoxColumn5
-			// 
-			this.dataGridViewTextBoxColumn5.DataPropertyName = "Track";
-			this.dataGridViewTextBoxColumn5.HeaderText = "Track";
-			this.dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
-			this.dataGridViewTextBoxColumn5.ReadOnly = true;
-			this.dataGridViewTextBoxColumn5.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-			this.dataGridViewTextBoxColumn5.Width = 5;
-			// 
-			// MidiEntrySource
-			// 
-			this.MidiEntrySource.DataSource = typeof(FFBardMusicCommon.BmpMidiEntry);
-			// 
-			// Playlist_Remove
-			// 
-			this.Playlist_Remove.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.Playlist_Remove.FlatAppearance.BorderSize = 0;
-			this.Playlist_Remove.FlatStyle = System.Windows.Forms.FlatStyle.System;
-			this.Playlist_Remove.Location = new System.Drawing.Point(207, 3);
-			this.Playlist_Remove.Name = "Playlist_Remove";
-			this.Playlist_Remove.Size = new System.Drawing.Size(22, 22);
-			this.Playlist_Remove.TabIndex = 8;
-			this.Playlist_Remove.Text = "-";
-			this.Playlist_Remove.UseVisualStyleBackColor = true;
-			this.Playlist_Remove.Click += new System.EventHandler(this.Playlist_Remove_Click);
-			// 
-			// Playlist_Add
-			// 
-			this.Playlist_Add.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.Playlist_Add.FlatAppearance.BorderSize = 0;
-			this.Playlist_Add.FlatStyle = System.Windows.Forms.FlatStyle.System;
-			this.Playlist_Add.Location = new System.Drawing.Point(228, 3);
-			this.Playlist_Add.Name = "Playlist_Add";
-			this.Playlist_Add.Size = new System.Drawing.Size(22, 22);
-			this.Playlist_Add.TabIndex = 3;
-			this.Playlist_Add.Text = "+";
-			this.Playlist_Add.UseVisualStyleBackColor = true;
-			this.Playlist_Add.Click += new System.EventHandler(this.Playlist_Add_Click);
-			// 
-			// dataGridViewTextBoxColumn1
-			// 
-			this.dataGridViewTextBoxColumn1.DataPropertyName = "Tag";
-			this.dataGridViewTextBoxColumn1.HeaderText = "Tag";
-			this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
-			// 
-			// Playlist_Export
-			// 
-			this.Playlist_Export.AutoSize = true;
-			this.Playlist_Export.Dock = System.Windows.Forms.DockStyle.Right;
-			this.Playlist_Export.FlatAppearance.BorderSize = 0;
-			this.Playlist_Export.Location = new System.Drawing.Point(227, 2);
-			this.Playlist_Export.Margin = new System.Windows.Forms.Padding(0);
-			this.Playlist_Export.Name = "Playlist_Export";
-			this.Playlist_Export.Size = new System.Drawing.Size(24, 22);
-			this.Playlist_Export.TabIndex = 8;
-			this.Playlist_Export.Text = "E";
-			this.Playlist_Export.UseVisualStyleBackColor = true;
-			this.Playlist_Export.Visible = false;
-			// 
-			// Playlist_Import
-			// 
-			this.Playlist_Import.AutoSize = true;
-			this.Playlist_Import.Dock = System.Windows.Forms.DockStyle.Right;
-			this.Playlist_Import.FlatAppearance.BorderSize = 0;
-			this.Playlist_Import.Location = new System.Drawing.Point(207, 2);
-			this.Playlist_Import.Margin = new System.Windows.Forms.Padding(0);
-			this.Playlist_Import.Name = "Playlist_Import";
-			this.Playlist_Import.Size = new System.Drawing.Size(20, 22);
-			this.Playlist_Import.TabIndex = 9;
-			this.Playlist_Import.Text = "I";
-			this.Playlist_Import.UseVisualStyleBackColor = true;
-			this.Playlist_Import.Visible = false;
-			// 
-			// ButtonPanel
-			// 
-			this.ButtonPanel.Controls.Add(this.AutoPlayToggle);
-			this.ButtonPanel.Controls.Add(this.Playlist_Random);
-			this.ButtonPanel.Controls.Add(this.Playlist_Loop);
-			this.ButtonPanel.Controls.Add(this.Playlist_Import);
-			this.ButtonPanel.Controls.Add(this.Playlist_Export);
-			this.ButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
-			this.ButtonPanel.Location = new System.Drawing.Point(0, 210);
-			this.ButtonPanel.Name = "ButtonPanel";
-			this.ButtonPanel.Padding = new System.Windows.Forms.Padding(2);
-			this.ButtonPanel.Size = new System.Drawing.Size(253, 26);
-			this.ButtonPanel.TabIndex = 10;
-			// 
-			// Playlist_Random
-			// 
-			this.Playlist_Random.Appearance = System.Windows.Forms.Appearance.Button;
-			this.Playlist_Random.AutoSize = true;
-			this.Playlist_Random.DataBindings.Add(new System.Windows.Forms.Binding("Checked", this.ButtonBindSource, "RandomMode", true));
-			this.Playlist_Random.Dock = System.Windows.Forms.DockStyle.Left;
-			this.Playlist_Random.Location = new System.Drawing.Point(46, 2);
-			this.Playlist_Random.Margin = new System.Windows.Forms.Padding(0);
-			this.Playlist_Random.Name = "Playlist_Random";
-			this.Playlist_Random.Size = new System.Drawing.Size(62, 22);
-			this.Playlist_Random.TabIndex = 7;
-			this.Playlist_Random.Text = "Random";
-			this.Playlist_Random.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.Playlist_Random.UseVisualStyleBackColor = true;
-			this.Playlist_Random.CheckedChanged += new System.EventHandler(this.Playlist_Random_CheckedChanged);
-			// 
-			// ButtonBindSource
-			// 
-			this.ButtonBindSource.DataSource = typeof(FFBardMusicPlayer.Controls.BmpPlaylist);
-			// 
-			// Playlist_Loop
-			// 
-			this.Playlist_Loop.Appearance = System.Windows.Forms.Appearance.Button;
-			this.Playlist_Loop.AutoSize = true;
-			this.Playlist_Loop.DataBindings.Add(new System.Windows.Forms.Binding("Checked", this.ButtonBindSource, "LoopMode", true, System.Windows.Forms.DataSourceUpdateMode.Never));
-			this.Playlist_Loop.Dock = System.Windows.Forms.DockStyle.Left;
-			this.Playlist_Loop.Location = new System.Drawing.Point(2, 2);
-			this.Playlist_Loop.Margin = new System.Windows.Forms.Padding(0);
-			this.Playlist_Loop.Name = "Playlist_Loop";
-			this.Playlist_Loop.Size = new System.Drawing.Size(44, 22);
-			this.Playlist_Loop.TabIndex = 6;
-			this.Playlist_Loop.Text = "Loop";
-			this.Playlist_Loop.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-			this.Playlist_Loop.UseVisualStyleBackColor = true;
-			this.Playlist_Loop.CheckedChanged += new System.EventHandler(this.Playlist_Loop_CheckedChanged);
-			// 
-			// dataGridViewTextBoxColumn3
-			// 
-			this.dataGridViewTextBoxColumn3.DataPropertyName = "FilePath";
-			this.dataGridViewTextBoxColumn3.HeaderText = "FilePath";
-			this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
-			this.dataGridViewTextBoxColumn3.ReadOnly = true;
-			this.dataGridViewTextBoxColumn3.Width = 5;
-			// 
-			// dataGridViewTextBoxColumn4
-			// 
-			this.dataGridViewTextBoxColumn4.DataPropertyName = "Track";
-			this.dataGridViewTextBoxColumn4.HeaderText = "Track";
-			this.dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
-			this.dataGridViewTextBoxColumn4.ReadOnly = true;
-			this.dataGridViewTextBoxColumn4.Width = 5;
-			// 
-			// dataGridViewTextBoxColumn2
-			// 
-			this.dataGridViewTextBoxColumn2.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-			this.dataGridViewTextBoxColumn2.DataPropertyName = "FilePath";
-			this.dataGridViewTextBoxColumn2.HeaderText = "FilePath";
-			this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
-			this.dataGridViewTextBoxColumn2.ReadOnly = true;
-			// 
-			// AutoPlayToggle
-			// 
-			this.AutoPlayToggle.AutoSize = true;
-			this.AutoPlayToggle.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.PlaylistAutoPlay;
-			this.AutoPlayToggle.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.AutoPlayToggle.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "PlaylistAutoPlay", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.AutoPlayToggle.Location = new System.Drawing.Point(111, 4);
-			this.AutoPlayToggle.Name = "AutoPlayToggle";
-			this.AutoPlayToggle.Size = new System.Drawing.Size(79, 19);
-			this.AutoPlayToggle.TabIndex = 10;
-			this.AutoPlayToggle.Text = "Auto-play";
-			this.AutoPlayToggle.UseVisualStyleBackColor = true;
-			// 
-			// BmpPlaylist
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.Controls.Add(this.ButtonPanel);
-			this.Controls.Add(this.Playlist);
-			this.Font = new System.Drawing.Font("Segoe UI", 9F);
-			this.Name = "BmpPlaylist";
-			this.Size = new System.Drawing.Size(253, 236);
-			this.Playlist.ResumeLayout(false);
-			((System.ComponentModel.ISupportInitialize)(this.PlaylistView)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.MidiEntrySource)).EndInit();
-			this.ButtonPanel.ResumeLayout(false);
-			this.ButtonPanel.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.ButtonBindSource)).EndInit();
-			this.ResumeLayout(false);
+            this.PlaylistView.DataSource = this.MidiEntrySource;
+            this.PlaylistView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.PlaylistView.EditMode = System.Windows.Forms.DataGridViewEditMode.EditProgrammatically;
+            this.PlaylistView.GridColor = System.Drawing.SystemColors.AppWorkspace;
+            this.PlaylistView.Location = new System.Drawing.Point(3, 25);
+            this.PlaylistView.Margin = new System.Windows.Forms.Padding(0);
+            this.PlaylistView.MultiSelect = false;
+            this.PlaylistView.Name = "PlaylistView";
+            this.PlaylistView.ReadOnly = true;
+            this.PlaylistView.RowHeadersVisible = false;
+            this.PlaylistView.RowHeadersWidth = 40;
+            this.PlaylistView.RowHeadersWidthSizeMode = System.Windows.Forms.DataGridViewRowHeadersWidthSizeMode.DisableResizing;
+            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.AppWorkspace;
+            dataGridViewCellStyle1.ForeColor = System.Drawing.Color.Black;
+            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.Color.Black;
+            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.Color.White;
+            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.PlaylistView.RowsDefaultCellStyle = dataGridViewCellStyle1;
+            this.PlaylistView.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+            this.PlaylistView.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.PlaylistView.Size = new System.Drawing.Size(247, 182);
+            this.PlaylistView.TabIndex = 0;
+            this.PlaylistView.CellMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.PlaylistView_CellMouseDoubleClick);
+            this.PlaylistView.CellMouseDown += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.BmpMidiEntryList_CellMouseDown);
+            this.PlaylistView.CellMouseMove += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.BmpMidiEntryList_CellMouseMove);
+            this.PlaylistView.CellMouseUp += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.BmpMidiEntryList_CellMouseUp);
+            this.PlaylistView.CellPainting += new System.Windows.Forms.DataGridViewCellPaintingEventHandler(this.PlaylistControl_CellPainting);
+            this.PlaylistView.DragDrop += new System.Windows.Forms.DragEventHandler(this.BmpMidiEntryList_DragDrop);
+            this.PlaylistView.DragOver += new System.Windows.Forms.DragEventHandler(this.BmpMidiEntryList_DragOver);
+            // 
+            // filePathDataGridViewTextBoxColumn
+            // 
+            this.filePathDataGridViewTextBoxColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.filePathDataGridViewTextBoxColumn.DataPropertyName = "FilePath";
+            this.filePathDataGridViewTextBoxColumn.HeaderText = "FilePath";
+            this.filePathDataGridViewTextBoxColumn.Name = "filePathDataGridViewTextBoxColumn";
+            this.filePathDataGridViewTextBoxColumn.ReadOnly = true;
+            this.filePathDataGridViewTextBoxColumn.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            // 
+            // dataGridViewTextBoxColumn5
+            // 
+            this.dataGridViewTextBoxColumn5.DataPropertyName = "Track";
+            this.dataGridViewTextBoxColumn5.HeaderText = "Track";
+            this.dataGridViewTextBoxColumn5.Name = "dataGridViewTextBoxColumn5";
+            this.dataGridViewTextBoxColumn5.ReadOnly = true;
+            this.dataGridViewTextBoxColumn5.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.dataGridViewTextBoxColumn5.Width = 5;
+            // 
+            // MidiEntrySource
+            // 
+            this.MidiEntrySource.DataSource = typeof(FFBardMusicCommon.BmpMidiEntry);
+            // 
+            // Playlist_Remove
+            // 
+            this.Playlist_Remove.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.Playlist_Remove.FlatAppearance.BorderSize = 0;
+            this.Playlist_Remove.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.Playlist_Remove.Location = new System.Drawing.Point(207, 3);
+            this.Playlist_Remove.Name = "Playlist_Remove";
+            this.Playlist_Remove.Size = new System.Drawing.Size(22, 22);
+            this.Playlist_Remove.TabIndex = 8;
+            this.Playlist_Remove.Text = "-";
+            this.Playlist_Remove.UseVisualStyleBackColor = true;
+            this.Playlist_Remove.Click += new System.EventHandler(this.Playlist_Remove_Click);
+            // 
+            // Playlist_Add
+            // 
+            this.Playlist_Add.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.Playlist_Add.FlatAppearance.BorderSize = 0;
+            this.Playlist_Add.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.Playlist_Add.Location = new System.Drawing.Point(228, 3);
+            this.Playlist_Add.Name = "Playlist_Add";
+            this.Playlist_Add.Size = new System.Drawing.Size(22, 22);
+            this.Playlist_Add.TabIndex = 3;
+            this.Playlist_Add.Text = "+";
+            this.Playlist_Add.UseVisualStyleBackColor = true;
+            this.Playlist_Add.Click += new System.EventHandler(this.Playlist_Add_Click);
+            // 
+            // dataGridViewTextBoxColumn1
+            // 
+            this.dataGridViewTextBoxColumn1.DataPropertyName = "Tag";
+            this.dataGridViewTextBoxColumn1.HeaderText = "Tag";
+            this.dataGridViewTextBoxColumn1.Name = "dataGridViewTextBoxColumn1";
+            // 
+            // Playlist_Export
+            // 
+            this.Playlist_Export.AutoSize = true;
+            this.Playlist_Export.Dock = System.Windows.Forms.DockStyle.Right;
+            this.Playlist_Export.FlatAppearance.BorderSize = 0;
+            this.Playlist_Export.Location = new System.Drawing.Point(227, 2);
+            this.Playlist_Export.Margin = new System.Windows.Forms.Padding(0);
+            this.Playlist_Export.Name = "Playlist_Export";
+            this.Playlist_Export.Size = new System.Drawing.Size(24, 22);
+            this.Playlist_Export.TabIndex = 8;
+            this.Playlist_Export.Text = "E";
+            this.Playlist_Export.UseVisualStyleBackColor = true;
+            this.Playlist_Export.Visible = false;
+            // 
+            // Playlist_Import
+            // 
+            this.Playlist_Import.AutoSize = true;
+            this.Playlist_Import.Dock = System.Windows.Forms.DockStyle.Right;
+            this.Playlist_Import.FlatAppearance.BorderSize = 0;
+            this.Playlist_Import.Location = new System.Drawing.Point(207, 2);
+            this.Playlist_Import.Margin = new System.Windows.Forms.Padding(0);
+            this.Playlist_Import.Name = "Playlist_Import";
+            this.Playlist_Import.Size = new System.Drawing.Size(20, 22);
+            this.Playlist_Import.TabIndex = 9;
+            this.Playlist_Import.Text = "I";
+            this.Playlist_Import.UseVisualStyleBackColor = true;
+            this.Playlist_Import.Visible = false;
+            // 
+            // ButtonPanel
+            // 
+            this.ButtonPanel.Controls.Add(this.AutoPlayToggle);
+            this.ButtonPanel.Controls.Add(this.Playlist_Random);
+            this.ButtonPanel.Controls.Add(this.Playlist_Loop);
+            this.ButtonPanel.Controls.Add(this.Playlist_Import);
+            this.ButtonPanel.Controls.Add(this.Playlist_Export);
+            this.ButtonPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.ButtonPanel.Location = new System.Drawing.Point(0, 210);
+            this.ButtonPanel.Name = "ButtonPanel";
+            this.ButtonPanel.Padding = new System.Windows.Forms.Padding(2);
+            this.ButtonPanel.Size = new System.Drawing.Size(253, 26);
+            this.ButtonPanel.TabIndex = 10;
+            // 
+            // AutoPlayToggle
+            // 
+            this.AutoPlayToggle.AutoSize = true;
+            this.AutoPlayToggle.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.PlaylistAutoPlay;
+            this.AutoPlayToggle.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.AutoPlayToggle.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "PlaylistAutoPlay", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.AutoPlayToggle.Location = new System.Drawing.Point(111, 4);
+            this.AutoPlayToggle.Name = "AutoPlayToggle";
+            this.AutoPlayToggle.Size = new System.Drawing.Size(79, 19);
+            this.AutoPlayToggle.TabIndex = 10;
+            this.AutoPlayToggle.Text = "Auto-play";
+            this.AutoPlayToggle.UseVisualStyleBackColor = true;
+            // 
+            // Playlist_Random
+            // 
+            this.Playlist_Random.Appearance = System.Windows.Forms.Appearance.Button;
+            this.Playlist_Random.AutoSize = true;
+            this.Playlist_Random.DataBindings.Add(new System.Windows.Forms.Binding("Checked", this.ButtonBindSource, "RandomMode", true));
+            this.Playlist_Random.Dock = System.Windows.Forms.DockStyle.Left;
+            this.Playlist_Random.Location = new System.Drawing.Point(46, 2);
+            this.Playlist_Random.Margin = new System.Windows.Forms.Padding(0);
+            this.Playlist_Random.Name = "Playlist_Random";
+            this.Playlist_Random.Size = new System.Drawing.Size(62, 22);
+            this.Playlist_Random.TabIndex = 7;
+            this.Playlist_Random.Text = "Random";
+            this.Playlist_Random.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.Playlist_Random.UseVisualStyleBackColor = true;
+            this.Playlist_Random.CheckedChanged += new System.EventHandler(this.Playlist_Random_CheckedChanged);
+            // 
+            // ButtonBindSource
+            // 
+            this.ButtonBindSource.DataSource = typeof(FFBardMusicPlayer.Controls.BmpPlaylist);
+            // 
+            // Playlist_Loop
+            // 
+            this.Playlist_Loop.Appearance = System.Windows.Forms.Appearance.Button;
+            this.Playlist_Loop.AutoSize = true;
+            this.Playlist_Loop.DataBindings.Add(new System.Windows.Forms.Binding("Checked", this.ButtonBindSource, "LoopMode", true, System.Windows.Forms.DataSourceUpdateMode.Never));
+            this.Playlist_Loop.Dock = System.Windows.Forms.DockStyle.Left;
+            this.Playlist_Loop.Location = new System.Drawing.Point(2, 2);
+            this.Playlist_Loop.Margin = new System.Windows.Forms.Padding(0);
+            this.Playlist_Loop.Name = "Playlist_Loop";
+            this.Playlist_Loop.Size = new System.Drawing.Size(44, 22);
+            this.Playlist_Loop.TabIndex = 6;
+            this.Playlist_Loop.Text = "Loop";
+            this.Playlist_Loop.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.Playlist_Loop.UseVisualStyleBackColor = true;
+            this.Playlist_Loop.CheckedChanged += new System.EventHandler(this.Playlist_Loop_CheckedChanged);
+            // 
+            // dataGridViewTextBoxColumn3
+            // 
+            this.dataGridViewTextBoxColumn3.DataPropertyName = "FilePath";
+            this.dataGridViewTextBoxColumn3.HeaderText = "FilePath";
+            this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
+            this.dataGridViewTextBoxColumn3.ReadOnly = true;
+            this.dataGridViewTextBoxColumn3.Width = 5;
+            // 
+            // dataGridViewTextBoxColumn4
+            // 
+            this.dataGridViewTextBoxColumn4.DataPropertyName = "Track";
+            this.dataGridViewTextBoxColumn4.HeaderText = "Track";
+            this.dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
+            this.dataGridViewTextBoxColumn4.ReadOnly = true;
+            this.dataGridViewTextBoxColumn4.Width = 5;
+            // 
+            // dataGridViewTextBoxColumn2
+            // 
+            this.dataGridViewTextBoxColumn2.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.dataGridViewTextBoxColumn2.DataPropertyName = "FilePath";
+            this.dataGridViewTextBoxColumn2.HeaderText = "FilePath";
+            this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
+            this.dataGridViewTextBoxColumn2.ReadOnly = true;
+            // 
+            // BmpPlaylist
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.ButtonPanel);
+            this.Controls.Add(this.Playlist);
+            this.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.Name = "BmpPlaylist";
+            this.Size = new System.Drawing.Size(253, 236);
+            this.Playlist.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.PlaylistView)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.MidiEntrySource)).EndInit();
+            this.ButtonPanel.ResumeLayout(false);
+            this.ButtonPanel.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.ButtonBindSource)).EndInit();
+            this.ResumeLayout(false);
 
 		}
 

--- a/FFBardMusicPlayer/Controls/BmpPlaylist.Designer.cs
+++ b/FFBardMusicPlayer/Controls/BmpPlaylist.Designer.cs
@@ -37,12 +37,13 @@
             this.Playlist_Import = new System.Windows.Forms.Button();
             this.ButtonPanel = new System.Windows.Forms.Panel();
             this.AutoPlayToggle = new System.Windows.Forms.CheckBox();
-            this.Playlist_Random = new FFBardMusicPlayer.Components.BmpCheckButton(this.components);
-            this.ButtonBindSource = new System.Windows.Forms.BindingSource(this.components);
-            this.Playlist_Loop = new FFBardMusicPlayer.Components.BmpCheckButton(this.components);
             this.dataGridViewTextBoxColumn3 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dataGridViewTextBoxColumn4 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.dataGridViewTextBoxColumn2 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Playlist_ClearAll = new System.Windows.Forms.Button();
+            this.Playlist_Random = new FFBardMusicPlayer.Components.BmpCheckButton(this.components);
+            this.ButtonBindSource = new System.Windows.Forms.BindingSource(this.components);
+            this.Playlist_Loop = new FFBardMusicPlayer.Components.BmpCheckButton(this.components);
             this.Playlist.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.PlaylistView)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.MidiEntrySource)).BeginInit();
@@ -55,6 +56,7 @@
             this.Playlist.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.Playlist.Controls.Add(this.Playlist_ClearAll);
             this.Playlist.Controls.Add(this.PlaylistView);
             this.Playlist.Controls.Add(this.Playlist_Remove);
             this.Playlist.Controls.Add(this.Playlist_Add);
@@ -140,11 +142,12 @@
             this.Playlist_Remove.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.Playlist_Remove.FlatAppearance.BorderSize = 0;
             this.Playlist_Remove.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.Playlist_Remove.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(1)), true);
             this.Playlist_Remove.Location = new System.Drawing.Point(207, 3);
             this.Playlist_Remove.Name = "Playlist_Remove";
             this.Playlist_Remove.Size = new System.Drawing.Size(22, 22);
             this.Playlist_Remove.TabIndex = 8;
-            this.Playlist_Remove.Text = "-";
+            this.Playlist_Remove.Text = "˗";
             this.Playlist_Remove.UseVisualStyleBackColor = true;
             this.Playlist_Remove.Click += new System.EventHandler(this.Playlist_Remove_Click);
             // 
@@ -153,6 +156,7 @@
             this.Playlist_Add.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.Playlist_Add.FlatAppearance.BorderSize = 0;
             this.Playlist_Add.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.Playlist_Add.Font = new System.Drawing.Font("Arial", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.Playlist_Add.Location = new System.Drawing.Point(228, 3);
             this.Playlist_Add.Name = "Playlist_Add";
             this.Playlist_Add.Size = new System.Drawing.Size(22, 22);
@@ -222,6 +226,45 @@
             this.AutoPlayToggle.Text = "Auto-play";
             this.AutoPlayToggle.UseVisualStyleBackColor = true;
             // 
+            // dataGridViewTextBoxColumn3
+            // 
+            this.dataGridViewTextBoxColumn3.DataPropertyName = "FilePath";
+            this.dataGridViewTextBoxColumn3.HeaderText = "FilePath";
+            this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
+            this.dataGridViewTextBoxColumn3.ReadOnly = true;
+            this.dataGridViewTextBoxColumn3.Width = 5;
+            // 
+            // dataGridViewTextBoxColumn4
+            // 
+            this.dataGridViewTextBoxColumn4.DataPropertyName = "Track";
+            this.dataGridViewTextBoxColumn4.HeaderText = "Track";
+            this.dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
+            this.dataGridViewTextBoxColumn4.ReadOnly = true;
+            this.dataGridViewTextBoxColumn4.Width = 5;
+            // 
+            // dataGridViewTextBoxColumn2
+            // 
+            this.dataGridViewTextBoxColumn2.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.dataGridViewTextBoxColumn2.DataPropertyName = "FilePath";
+            this.dataGridViewTextBoxColumn2.HeaderText = "FilePath";
+            this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
+            this.dataGridViewTextBoxColumn2.ReadOnly = true;
+            // 
+            // Playlist_ClearAll
+            // 
+            this.Playlist_ClearAll.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.Playlist_ClearAll.BackgroundImageLayout = System.Windows.Forms.ImageLayout.None;
+            this.Playlist_ClearAll.FlatAppearance.BorderSize = 0;
+            this.Playlist_ClearAll.FlatStyle = System.Windows.Forms.FlatStyle.System;
+            this.Playlist_ClearAll.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)), true);
+            this.Playlist_ClearAll.Location = new System.Drawing.Point(186, 3);
+            this.Playlist_ClearAll.Name = "Playlist_ClearAll";
+            this.Playlist_ClearAll.Size = new System.Drawing.Size(22, 22);
+            this.Playlist_ClearAll.TabIndex = 9;
+            this.Playlist_ClearAll.Text = "×";
+            this.Playlist_ClearAll.UseVisualStyleBackColor = true;
+            this.Playlist_ClearAll.Click += new System.EventHandler(this.Playlist_ClearAll_Click);
+            // 
             // Playlist_Random
             // 
             this.Playlist_Random.Appearance = System.Windows.Forms.Appearance.Button;
@@ -257,30 +300,6 @@
             this.Playlist_Loop.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.Playlist_Loop.UseVisualStyleBackColor = true;
             this.Playlist_Loop.CheckedChanged += new System.EventHandler(this.Playlist_Loop_CheckedChanged);
-            // 
-            // dataGridViewTextBoxColumn3
-            // 
-            this.dataGridViewTextBoxColumn3.DataPropertyName = "FilePath";
-            this.dataGridViewTextBoxColumn3.HeaderText = "FilePath";
-            this.dataGridViewTextBoxColumn3.Name = "dataGridViewTextBoxColumn3";
-            this.dataGridViewTextBoxColumn3.ReadOnly = true;
-            this.dataGridViewTextBoxColumn3.Width = 5;
-            // 
-            // dataGridViewTextBoxColumn4
-            // 
-            this.dataGridViewTextBoxColumn4.DataPropertyName = "Track";
-            this.dataGridViewTextBoxColumn4.HeaderText = "Track";
-            this.dataGridViewTextBoxColumn4.Name = "dataGridViewTextBoxColumn4";
-            this.dataGridViewTextBoxColumn4.ReadOnly = true;
-            this.dataGridViewTextBoxColumn4.Width = 5;
-            // 
-            // dataGridViewTextBoxColumn2
-            // 
-            this.dataGridViewTextBoxColumn2.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.dataGridViewTextBoxColumn2.DataPropertyName = "FilePath";
-            this.dataGridViewTextBoxColumn2.HeaderText = "FilePath";
-            this.dataGridViewTextBoxColumn2.Name = "dataGridViewTextBoxColumn2";
-            this.dataGridViewTextBoxColumn2.ReadOnly = true;
             // 
             // BmpPlaylist
             // 
@@ -322,5 +341,6 @@
 		private System.Windows.Forms.DataGridViewTextBoxColumn filePathDataGridViewTextBoxColumn;
 		private System.Windows.Forms.DataGridViewTextBoxColumn dataGridViewTextBoxColumn5;
 		private System.Windows.Forms.CheckBox AutoPlayToggle;
-	}
+        private System.Windows.Forms.Button Playlist_ClearAll;
+    }
 }

--- a/FFBardMusicPlayer/Controls/BmpPlaylist.cs
+++ b/FFBardMusicPlayer/Controls/BmpPlaylist.cs
@@ -191,10 +191,15 @@ namespace FFBardMusicPlayer.Controls {
 			int index = PlaylistView.SelectedRows[0].Index;
 			PlaylistView.ClearSelection();
 
-			if(RandomMode) {
+			if (RandomMode) {
 				Random rand = new Random();
-				index = rand.Next(0, PlaylistView.RowCount);
-			} else {
+                int newRandomIndex = rand.Next(0, PlaylistView.RowCount);
+                while (newRandomIndex == index)
+                {
+                    newRandomIndex = rand.Next(0, PlaylistView.RowCount);
+                }
+                index = newRandomIndex;
+            } else {
 				index++;
 				if(index == PlaylistView.RowCount) {
 					if(LoopMode) {

--- a/FFBardMusicPlayer/Controls/BmpPlaylist.cs
+++ b/FFBardMusicPlayer/Controls/BmpPlaylist.cs
@@ -375,5 +375,13 @@ namespace FFBardMusicPlayer.Controls {
                 }
             }
         }
+
+        private void Playlist_ClearAll_Click(object sender, EventArgs e)
+        {
+            while (PlaylistView.RowCount != 0)
+            {
+                RemovePlaylistEntry(0);
+            }
+        }
     }
 }

--- a/FFBardMusicPlayer/Controls/BmpSettings.Designer.cs
+++ b/FFBardMusicPlayer/Controls/BmpSettings.Designer.cs
@@ -23,434 +23,477 @@
 		/// the contents of this method with the code editor.
 		/// </summary>
 		private void InitializeComponent() {
-			this.components = new System.ComponentModel.Container();
-			this.GeneralSettings = new System.Windows.Forms.GroupBox();
-			this.KeyboardTest = new System.Windows.Forms.Button();
-			this.SettingsScrollPanel = new System.Windows.Forms.Panel();
-			this.verboseToggle = new System.Windows.Forms.CheckBox();
-			this.UnequipPause = new System.Windows.Forms.CheckBox();
-			this.ForceOpenToggle = new System.Windows.Forms.CheckBox();
-			this.SignatureFolder = new System.Windows.Forms.Button();
-			this.sigCheckbox = new System.Windows.Forms.CheckBox();
-			this.MidiInputLabel = new System.Windows.Forms.Label();
-			this.SettingMidiInput = new System.Windows.Forms.ComboBox();
-			this.SettingChatSave = new System.Windows.Forms.CheckBox();
-			this.SettingBringBmp = new System.Windows.Forms.CheckBox();
-			this.SettingBringGame = new System.Windows.Forms.CheckBox();
-			this.SettingsTable = new System.Windows.Forms.TableLayoutPanel();
-			this.ChatSettings = new System.Windows.Forms.GroupBox();
-			this.ListenChatList = new System.Windows.Forms.ComboBox();
-			this.ForceListenToggle = new System.Windows.Forms.CheckBox();
-			this.PlaybackSettings = new System.Windows.Forms.GroupBox();
-			this.TooFastChange = new System.Windows.Forms.NumericUpDown();
-			this.PlayHoldChange = new System.Windows.Forms.NumericUpDown();
-			this.SlowPlayToggle = new System.Windows.Forms.CheckBox();
-			this.ArpeggiateToggle = new System.Windows.Forms.CheckBox();
-			this.SettingHoldNotes = new System.Windows.Forms.CheckBox();
-			this.ChatSimToggle = new System.Windows.Forms.CheckBox();
-			this.HelpTip = new System.Windows.Forms.ToolTip(this.components);
-			this.GeneralSettings.SuspendLayout();
-			this.SettingsScrollPanel.SuspendLayout();
-			this.SettingsTable.SuspendLayout();
-			this.ChatSettings.SuspendLayout();
-			this.PlaybackSettings.SuspendLayout();
-			((System.ComponentModel.ISupportInitialize)(this.TooFastChange)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.PlayHoldChange)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// GeneralSettings
-			// 
-			this.GeneralSettings.AutoSize = true;
-			this.GeneralSettings.BackColor = System.Drawing.Color.Transparent;
-			this.GeneralSettings.Controls.Add(this.KeyboardTest);
-			this.GeneralSettings.Controls.Add(this.SettingsScrollPanel);
-			this.GeneralSettings.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.GeneralSettings.Location = new System.Drawing.Point(0, 0);
-			this.GeneralSettings.Margin = new System.Windows.Forms.Padding(0);
-			this.GeneralSettings.Name = "GeneralSettings";
-			this.GeneralSettings.Size = new System.Drawing.Size(355, 318);
-			this.GeneralSettings.TabIndex = 9;
-			this.GeneralSettings.TabStop = false;
-			this.GeneralSettings.Text = "Settings";
-			// 
-			// KeyboardTest
-			// 
-			this.KeyboardTest.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.KeyboardTest.Location = new System.Drawing.Point(253, 0);
-			this.KeyboardTest.Name = "KeyboardTest";
-			this.KeyboardTest.Size = new System.Drawing.Size(99, 23);
-			this.KeyboardTest.TabIndex = 0;
-			this.KeyboardTest.Text = "Test keyboard";
-			this.KeyboardTest.UseVisualStyleBackColor = true;
-			// 
-			// SettingsScrollPanel
-			// 
-			this.SettingsScrollPanel.AutoScroll = true;
-			this.SettingsScrollPanel.Controls.Add(this.verboseToggle);
-			this.SettingsScrollPanel.Controls.Add(this.UnequipPause);
-			this.SettingsScrollPanel.Controls.Add(this.ForceOpenToggle);
-			this.SettingsScrollPanel.Controls.Add(this.SignatureFolder);
-			this.SettingsScrollPanel.Controls.Add(this.sigCheckbox);
-			this.SettingsScrollPanel.Controls.Add(this.MidiInputLabel);
-			this.SettingsScrollPanel.Controls.Add(this.SettingMidiInput);
-			this.SettingsScrollPanel.Controls.Add(this.SettingChatSave);
-			this.SettingsScrollPanel.Controls.Add(this.SettingBringBmp);
-			this.SettingsScrollPanel.Controls.Add(this.SettingBringGame);
-			this.SettingsScrollPanel.Controls.Add(this.SettingsTable);
-			this.SettingsScrollPanel.Controls.Add(this.ChatSimToggle);
-			this.SettingsScrollPanel.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.SettingsScrollPanel.Location = new System.Drawing.Point(3, 18);
-			this.SettingsScrollPanel.Margin = new System.Windows.Forms.Padding(0);
-			this.SettingsScrollPanel.Name = "SettingsScrollPanel";
-			this.SettingsScrollPanel.Padding = new System.Windows.Forms.Padding(8);
-			this.SettingsScrollPanel.Size = new System.Drawing.Size(349, 297);
-			this.SettingsScrollPanel.TabIndex = 12;
-			// 
-			// verboseToggle
-			// 
-			this.verboseToggle.AutoSize = true;
-			this.verboseToggle.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.Verbose;
-			this.verboseToggle.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "Verbose", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.verboseToggle.Location = new System.Drawing.Point(13, 265);
-			this.verboseToggle.Name = "verboseToggle";
-			this.verboseToggle.Size = new System.Drawing.Size(136, 17);
-			this.verboseToggle.TabIndex = 20;
-			this.verboseToggle.Text = "Enable verbose mode";
-			this.HelpTip.SetToolTip(this.verboseToggle, "Print various kinds of information to the log window.");
-			this.verboseToggle.UseVisualStyleBackColor = true;
-			// 
-			// UnequipPause
-			// 
-			this.UnequipPause.AutoSize = true;
-			this.UnequipPause.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.UnequipPause;
-			this.UnequipPause.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.UnequipPause.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "UnequipPause", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.UnequipPause.Location = new System.Drawing.Point(13, 242);
-			this.UnequipPause.Name = "UnequipPause";
-			this.UnequipPause.Size = new System.Drawing.Size(196, 17);
-			this.UnequipPause.TabIndex = 19;
-			this.UnequipPause.Text = "Pause song when unequipping *";
-			this.HelpTip.SetToolTip(this.UnequipPause, "Pause the playing song when unequipping the instrument.\r\nUseful for resynchroniza" +
+            this.components = new System.ComponentModel.Container();
+            this.GeneralSettings = new System.Windows.Forms.GroupBox();
+            this.KeyboardTest = new System.Windows.Forms.Button();
+            this.SettingsScrollPanel = new System.Windows.Forms.Panel();
+            this.verboseToggle = new System.Windows.Forms.CheckBox();
+            this.UnequipPause = new System.Windows.Forms.CheckBox();
+            this.ForceOpenToggle = new System.Windows.Forms.CheckBox();
+            this.SignatureFolder = new System.Windows.Forms.Button();
+            this.sigCheckbox = new System.Windows.Forms.CheckBox();
+            this.MidiInputLabel = new System.Windows.Forms.Label();
+            this.SettingMidiInput = new System.Windows.Forms.ComboBox();
+            this.SettingChatSave = new System.Windows.Forms.CheckBox();
+            this.SettingBringBmp = new System.Windows.Forms.CheckBox();
+            this.SettingBringGame = new System.Windows.Forms.CheckBox();
+            this.SettingsTable = new System.Windows.Forms.TableLayoutPanel();
+            this.ChatSettings = new System.Windows.Forms.GroupBox();
+            this.ListenChatList = new System.Windows.Forms.ComboBox();
+            this.ForceListenToggle = new System.Windows.Forms.CheckBox();
+            this.PlaybackSettings = new System.Windows.Forms.GroupBox();
+            this.DelaySongsChange = new System.Windows.Forms.NumericUpDown();
+            this.WaitBetweenSongsToggle = new System.Windows.Forms.CheckBox();
+            this.TooFastChange = new System.Windows.Forms.NumericUpDown();
+            this.PlayHoldChange = new System.Windows.Forms.NumericUpDown();
+            this.SlowPlayToggle = new System.Windows.Forms.CheckBox();
+            this.ArpeggiateToggle = new System.Windows.Forms.CheckBox();
+            this.SettingHoldNotes = new System.Windows.Forms.CheckBox();
+            this.ChatSimToggle = new System.Windows.Forms.CheckBox();
+            this.HelpTip = new System.Windows.Forms.ToolTip(this.components);
+            this.GeneralSettings.SuspendLayout();
+            this.SettingsScrollPanel.SuspendLayout();
+            this.SettingsTable.SuspendLayout();
+            this.ChatSettings.SuspendLayout();
+            this.PlaybackSettings.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.DelaySongsChange)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.TooFastChange)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.PlayHoldChange)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // GeneralSettings
+            // 
+            this.GeneralSettings.AutoSize = true;
+            this.GeneralSettings.BackColor = System.Drawing.Color.Transparent;
+            this.GeneralSettings.Controls.Add(this.KeyboardTest);
+            this.GeneralSettings.Controls.Add(this.SettingsScrollPanel);
+            this.GeneralSettings.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.GeneralSettings.Location = new System.Drawing.Point(0, 0);
+            this.GeneralSettings.Margin = new System.Windows.Forms.Padding(0);
+            this.GeneralSettings.Name = "GeneralSettings";
+            this.GeneralSettings.Size = new System.Drawing.Size(568, 507);
+            this.GeneralSettings.TabIndex = 9;
+            this.GeneralSettings.TabStop = false;
+            this.GeneralSettings.Text = "Settings";
+            // 
+            // KeyboardTest
+            // 
+            this.KeyboardTest.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.KeyboardTest.Location = new System.Drawing.Point(466, 0);
+            this.KeyboardTest.Name = "KeyboardTest";
+            this.KeyboardTest.Size = new System.Drawing.Size(99, 23);
+            this.KeyboardTest.TabIndex = 0;
+            this.KeyboardTest.Text = "Test keyboard";
+            this.KeyboardTest.UseVisualStyleBackColor = true;
+            // 
+            // SettingsScrollPanel
+            // 
+            this.SettingsScrollPanel.AutoScroll = true;
+            this.SettingsScrollPanel.Controls.Add(this.verboseToggle);
+            this.SettingsScrollPanel.Controls.Add(this.UnequipPause);
+            this.SettingsScrollPanel.Controls.Add(this.ForceOpenToggle);
+            this.SettingsScrollPanel.Controls.Add(this.SignatureFolder);
+            this.SettingsScrollPanel.Controls.Add(this.sigCheckbox);
+            this.SettingsScrollPanel.Controls.Add(this.MidiInputLabel);
+            this.SettingsScrollPanel.Controls.Add(this.SettingMidiInput);
+            this.SettingsScrollPanel.Controls.Add(this.SettingChatSave);
+            this.SettingsScrollPanel.Controls.Add(this.SettingBringBmp);
+            this.SettingsScrollPanel.Controls.Add(this.SettingBringGame);
+            this.SettingsScrollPanel.Controls.Add(this.SettingsTable);
+            this.SettingsScrollPanel.Controls.Add(this.ChatSimToggle);
+            this.SettingsScrollPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.SettingsScrollPanel.Location = new System.Drawing.Point(3, 18);
+            this.SettingsScrollPanel.Margin = new System.Windows.Forms.Padding(0);
+            this.SettingsScrollPanel.Name = "SettingsScrollPanel";
+            this.SettingsScrollPanel.Padding = new System.Windows.Forms.Padding(8);
+            this.SettingsScrollPanel.Size = new System.Drawing.Size(562, 486);
+            this.SettingsScrollPanel.TabIndex = 12;
+            // 
+            // verboseToggle
+            // 
+            this.verboseToggle.AutoSize = true;
+            this.verboseToggle.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.Verbose;
+            this.verboseToggle.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "Verbose", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.verboseToggle.Location = new System.Drawing.Point(11, 345);
+            this.verboseToggle.Name = "verboseToggle";
+            this.verboseToggle.Size = new System.Drawing.Size(136, 17);
+            this.verboseToggle.TabIndex = 20;
+            this.verboseToggle.Text = "Enable verbose mode";
+            this.HelpTip.SetToolTip(this.verboseToggle, "Print various kinds of information to the log window.");
+            this.verboseToggle.UseVisualStyleBackColor = true;
+            // 
+            // UnequipPause
+            // 
+            this.UnequipPause.AutoSize = true;
+            this.UnequipPause.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.UnequipPause;
+            this.UnequipPause.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.UnequipPause.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "UnequipPause", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.UnequipPause.Location = new System.Drawing.Point(11, 290);
+            this.UnequipPause.Name = "UnequipPause";
+            this.UnequipPause.Size = new System.Drawing.Size(196, 17);
+            this.UnequipPause.TabIndex = 19;
+            this.UnequipPause.Text = "Pause song when unequipping *";
+            this.HelpTip.SetToolTip(this.UnequipPause, "Pause the playing song when unequipping the instrument.\r\nUseful for resynchroniza" +
         "tion or switching instrument mid-performance.");
-			this.UnequipPause.UseVisualStyleBackColor = true;
-			// 
-			// ForceOpenToggle
-			// 
-			this.ForceOpenToggle.AutoSize = true;
-			this.ForceOpenToggle.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.ForcedOpen;
-			this.ForceOpenToggle.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "ForcedOpen", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.ForceOpenToggle.Location = new System.Drawing.Point(13, 225);
-			this.ForceOpenToggle.Name = "ForceOpenToggle";
-			this.ForceOpenToggle.Size = new System.Drawing.Size(222, 17);
-			this.ForceOpenToggle.TabIndex = 16;
-			this.ForceOpenToggle.Text = "Force playback without performance *";
-			this.HelpTip.SetToolTip(this.ForceOpenToggle, "Ignores the current performance status and plays anyways.\r\n* Recommended to only " +
+            this.UnequipPause.UseVisualStyleBackColor = true;
+            // 
+            // ForceOpenToggle
+            // 
+            this.ForceOpenToggle.AutoSize = true;
+            this.ForceOpenToggle.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.ForcedOpen;
+            this.ForceOpenToggle.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "ForcedOpen", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.ForceOpenToggle.Location = new System.Drawing.Point(11, 265);
+            this.ForceOpenToggle.Name = "ForceOpenToggle";
+            this.ForceOpenToggle.Size = new System.Drawing.Size(222, 17);
+            this.ForceOpenToggle.TabIndex = 16;
+            this.ForceOpenToggle.Text = "Force playback without performance *";
+            this.HelpTip.SetToolTip(this.ForceOpenToggle, "Ignores the current performance status and plays anyways.\r\n* Recommended to only " +
         "be used when patches break playback.\r\n* Ignored when hooked to non-FFXIV applica" +
         "tions.");
-			this.ForceOpenToggle.UseVisualStyleBackColor = true;
-			this.ForceOpenToggle.CheckedChanged += new System.EventHandler(this.ForceOpenToggle_CheckedChanged);
-			// 
-			// SignatureFolder
-			// 
-			this.SignatureFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.SignatureFolder.Location = new System.Drawing.Point(236, 203);
-			this.SignatureFolder.Name = "SignatureFolder";
-			this.SignatureFolder.Size = new System.Drawing.Size(102, 23);
-			this.SignatureFolder.TabIndex = 13;
-			this.SignatureFolder.Text = "Open sig folder";
-			this.SignatureFolder.UseVisualStyleBackColor = true;
-			// 
-			// sigCheckbox
-			// 
-			this.sigCheckbox.AutoSize = true;
-			this.sigCheckbox.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.SigIgnore;
-			this.sigCheckbox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "SigIgnore", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.sigCheckbox.Location = new System.Drawing.Point(13, 207);
-			this.sigCheckbox.Name = "sigCheckbox";
-			this.sigCheckbox.Size = new System.Drawing.Size(152, 17);
-			this.sigCheckbox.TabIndex = 15;
-			this.sigCheckbox.Text = "Ignore signature update";
-			this.sigCheckbox.UseVisualStyleBackColor = true;
-			// 
-			// MidiInputLabel
-			// 
-			this.MidiInputLabel.Location = new System.Drawing.Point(11, 91);
-			this.MidiInputLabel.Name = "MidiInputLabel";
-			this.MidiInputLabel.Size = new System.Drawing.Size(104, 21);
-			this.MidiInputLabel.TabIndex = 14;
-			this.MidiInputLabel.Text = "MIDI Input device:";
-			this.MidiInputLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-			// 
-			// SettingMidiInput
-			// 
-			this.SettingMidiInput.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.ForceOpenToggle.UseVisualStyleBackColor = true;
+            this.ForceOpenToggle.CheckedChanged += new System.EventHandler(this.ForceOpenToggle_CheckedChanged);
+            // 
+            // SignatureFolder
+            // 
+            this.SignatureFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.SignatureFolder.Location = new System.Drawing.Point(449, 240);
+            this.SignatureFolder.Name = "SignatureFolder";
+            this.SignatureFolder.Size = new System.Drawing.Size(102, 23);
+            this.SignatureFolder.TabIndex = 13;
+            this.SignatureFolder.Text = "Open sig folder";
+            this.SignatureFolder.UseVisualStyleBackColor = true;
+            // 
+            // sigCheckbox
+            // 
+            this.sigCheckbox.AutoSize = true;
+            this.sigCheckbox.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.SigIgnore;
+            this.sigCheckbox.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "SigIgnore", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.sigCheckbox.Location = new System.Drawing.Point(11, 240);
+            this.sigCheckbox.Name = "sigCheckbox";
+            this.sigCheckbox.Size = new System.Drawing.Size(152, 17);
+            this.sigCheckbox.TabIndex = 15;
+            this.sigCheckbox.Text = "Ignore signature update";
+            this.sigCheckbox.UseVisualStyleBackColor = true;
+            // 
+            // MidiInputLabel
+            // 
+            this.MidiInputLabel.Location = new System.Drawing.Point(11, 91);
+            this.MidiInputLabel.Name = "MidiInputLabel";
+            this.MidiInputLabel.Size = new System.Drawing.Size(104, 21);
+            this.MidiInputLabel.TabIndex = 14;
+            this.MidiInputLabel.Text = "MIDI Input device:";
+            this.MidiInputLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // SettingMidiInput
+            // 
+            this.SettingMidiInput.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.SettingMidiInput.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.SettingMidiInput.FormattingEnabled = true;
-			this.SettingMidiInput.Items.AddRange(new object[] {
+            this.SettingMidiInput.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.SettingMidiInput.FormattingEnabled = true;
+            this.SettingMidiInput.Items.AddRange(new object[] {
             "None"});
-			this.SettingMidiInput.Location = new System.Drawing.Point(121, 92);
-			this.SettingMidiInput.Name = "SettingMidiInput";
-			this.SettingMidiInput.Size = new System.Drawing.Size(217, 21);
-			this.SettingMidiInput.TabIndex = 13;
-			// 
-			// SettingChatSave
-			// 
-			this.SettingChatSave.AutoSize = true;
-			this.SettingChatSave.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.SaveLog;
-			this.SettingChatSave.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "SaveLog", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.SettingChatSave.Location = new System.Drawing.Point(13, 66);
-			this.SettingChatSave.Name = "SettingChatSave";
-			this.SettingChatSave.Size = new System.Drawing.Size(185, 17);
-			this.SettingChatSave.TabIndex = 5;
-			this.SettingChatSave.Text = "Save chatlogs to \"logs\" folder *";
-			this.HelpTip.SetToolTip(this.SettingChatSave, "* requires program restart.");
-			this.SettingChatSave.UseVisualStyleBackColor = true;
-			// 
-			// SettingBringBmp
-			// 
-			this.SettingBringBmp.AutoSize = true;
-			this.SettingBringBmp.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.OpenBMP;
-			this.SettingBringBmp.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.SettingBringBmp.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "OpenBMP", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.SettingBringBmp.Location = new System.Drawing.Point(13, 23);
-			this.SettingBringBmp.Name = "SettingBringBmp";
-			this.SettingBringBmp.Size = new System.Drawing.Size(237, 17);
-			this.SettingBringBmp.TabIndex = 4;
-			this.SettingBringBmp.Text = "Bring BMP to front on Performance open";
-			this.SettingBringBmp.UseVisualStyleBackColor = true;
-			// 
-			// SettingBringGame
-			// 
-			this.SettingBringGame.AutoSize = true;
-			this.SettingBringGame.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.OpenFFXIV;
-			this.SettingBringGame.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.SettingBringGame.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "OpenFFXIV", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.SettingBringGame.Location = new System.Drawing.Point(13, 5);
-			this.SettingBringGame.Name = "SettingBringGame";
-			this.SettingBringGame.Size = new System.Drawing.Size(168, 17);
-			this.SettingBringGame.TabIndex = 3;
-			this.SettingBringGame.Text = "Bring FFXIV to front on Play";
-			this.SettingBringGame.UseVisualStyleBackColor = true;
-			// 
-			// SettingsTable
-			// 
-			this.SettingsTable.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.SettingMidiInput.Location = new System.Drawing.Point(121, 92);
+            this.SettingMidiInput.Name = "SettingMidiInput";
+            this.SettingMidiInput.Size = new System.Drawing.Size(430, 21);
+            this.SettingMidiInput.TabIndex = 13;
+            // 
+            // SettingChatSave
+            // 
+            this.SettingChatSave.AutoSize = true;
+            this.SettingChatSave.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.SaveLog;
+            this.SettingChatSave.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "SaveLog", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.SettingChatSave.Location = new System.Drawing.Point(13, 66);
+            this.SettingChatSave.Name = "SettingChatSave";
+            this.SettingChatSave.Size = new System.Drawing.Size(185, 17);
+            this.SettingChatSave.TabIndex = 5;
+            this.SettingChatSave.Text = "Save chatlogs to \"logs\" folder *";
+            this.HelpTip.SetToolTip(this.SettingChatSave, "* requires program restart.");
+            this.SettingChatSave.UseVisualStyleBackColor = true;
+            // 
+            // SettingBringBmp
+            // 
+            this.SettingBringBmp.AutoSize = true;
+            this.SettingBringBmp.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.OpenBMP;
+            this.SettingBringBmp.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.SettingBringBmp.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "OpenBMP", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.SettingBringBmp.Location = new System.Drawing.Point(13, 23);
+            this.SettingBringBmp.Name = "SettingBringBmp";
+            this.SettingBringBmp.Size = new System.Drawing.Size(235, 17);
+            this.SettingBringBmp.TabIndex = 4;
+            this.SettingBringBmp.Text = "Bring BMP to front on Performance open";
+            this.SettingBringBmp.UseVisualStyleBackColor = true;
+            // 
+            // SettingBringGame
+            // 
+            this.SettingBringGame.AutoSize = true;
+            this.SettingBringGame.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.OpenFFXIV;
+            this.SettingBringGame.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.SettingBringGame.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "OpenFFXIV", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.SettingBringGame.Location = new System.Drawing.Point(13, 5);
+            this.SettingBringGame.Name = "SettingBringGame";
+            this.SettingBringGame.Size = new System.Drawing.Size(167, 17);
+            this.SettingBringGame.TabIndex = 3;
+            this.SettingBringGame.Text = "Bring FFXIV to front on Play";
+            this.SettingBringGame.UseVisualStyleBackColor = true;
+            // 
+            // SettingsTable
+            // 
+            this.SettingsTable.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.SettingsTable.ColumnCount = 2;
-			this.SettingsTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-			this.SettingsTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-			this.SettingsTable.Controls.Add(this.ChatSettings, 0, 0);
-			this.SettingsTable.Controls.Add(this.PlaybackSettings, 1, 0);
-			this.SettingsTable.Location = new System.Drawing.Point(11, 119);
-			this.SettingsTable.Name = "SettingsTable";
-			this.SettingsTable.RowCount = 1;
-			this.SettingsTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-			this.SettingsTable.Size = new System.Drawing.Size(327, 82);
-			this.SettingsTable.TabIndex = 18;
-			// 
-			// ChatSettings
-			// 
-			this.ChatSettings.Controls.Add(this.ListenChatList);
-			this.ChatSettings.Controls.Add(this.ForceListenToggle);
-			this.ChatSettings.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.ChatSettings.Location = new System.Drawing.Point(0, 0);
-			this.ChatSettings.Margin = new System.Windows.Forms.Padding(0, 0, 1, 0);
-			this.ChatSettings.Name = "ChatSettings";
-			this.ChatSettings.Padding = new System.Windows.Forms.Padding(0);
-			this.ChatSettings.Size = new System.Drawing.Size(162, 82);
-			this.ChatSettings.TabIndex = 11;
-			this.ChatSettings.TabStop = false;
-			this.ChatSettings.Text = "Chat listen channel";
-			// 
-			// ListenChatList
-			// 
-			this.ListenChatList.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.SettingsTable.ColumnCount = 2;
+            this.SettingsTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.SettingsTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.SettingsTable.Controls.Add(this.ChatSettings, 0, 0);
+            this.SettingsTable.Controls.Add(this.PlaybackSettings, 1, 0);
+            this.SettingsTable.Location = new System.Drawing.Point(11, 119);
+            this.SettingsTable.Name = "SettingsTable";
+            this.SettingsTable.RowCount = 1;
+            this.SettingsTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.SettingsTable.Size = new System.Drawing.Size(540, 118);
+            this.SettingsTable.TabIndex = 18;
+            // 
+            // ChatSettings
+            // 
+            this.ChatSettings.Controls.Add(this.ListenChatList);
+            this.ChatSettings.Controls.Add(this.ForceListenToggle);
+            this.ChatSettings.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ChatSettings.Location = new System.Drawing.Point(0, 0);
+            this.ChatSettings.Margin = new System.Windows.Forms.Padding(0, 0, 1, 0);
+            this.ChatSettings.Name = "ChatSettings";
+            this.ChatSettings.Padding = new System.Windows.Forms.Padding(0);
+            this.ChatSettings.Size = new System.Drawing.Size(269, 118);
+            this.ChatSettings.TabIndex = 11;
+            this.ChatSettings.TabStop = false;
+            this.ChatSettings.Text = "Chat listen channel";
+            // 
+            // ListenChatList
+            // 
+            this.ListenChatList.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.ListenChatList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.ListenChatList.FormattingEnabled = true;
-			this.ListenChatList.Location = new System.Drawing.Point(8, 18);
-			this.ListenChatList.Name = "ListenChatList";
-			this.ListenChatList.Size = new System.Drawing.Size(142, 21);
-			this.ListenChatList.TabIndex = 7;
-			this.HelpTip.SetToolTip(this.ListenChatList, "Use the selected channel as the main channel. (b.conduct)");
-			// 
-			// ForceListenToggle
-			// 
-			this.ForceListenToggle.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.ForceListen;
-			this.ForceListenToggle.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "ForceListen", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.ForceListenToggle.Location = new System.Drawing.Point(8, 41);
-			this.ForceListenToggle.Margin = new System.Windows.Forms.Padding(0);
-			this.ForceListenToggle.Name = "ForceListenToggle";
-			this.ForceListenToggle.Size = new System.Drawing.Size(88, 16);
-			this.ForceListenToggle.TabIndex = 6;
-			this.ForceListenToggle.Text = "Force listen";
-			this.HelpTip.SetToolTip(this.ForceListenToggle, "Forces commands to work from everyone in the selected chat channel.");
-			this.ForceListenToggle.UseVisualStyleBackColor = true;
-			// 
-			// PlaybackSettings
-			// 
-			this.PlaybackSettings.Controls.Add(this.TooFastChange);
-			this.PlaybackSettings.Controls.Add(this.PlayHoldChange);
-			this.PlaybackSettings.Controls.Add(this.SlowPlayToggle);
-			this.PlaybackSettings.Controls.Add(this.ArpeggiateToggle);
-			this.PlaybackSettings.Controls.Add(this.SettingHoldNotes);
-			this.PlaybackSettings.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.PlaybackSettings.Location = new System.Drawing.Point(164, 0);
-			this.PlaybackSettings.Margin = new System.Windows.Forms.Padding(1, 0, 0, 0);
-			this.PlaybackSettings.Name = "PlaybackSettings";
-			this.PlaybackSettings.Padding = new System.Windows.Forms.Padding(0);
-			this.PlaybackSettings.Size = new System.Drawing.Size(163, 82);
-			this.PlaybackSettings.TabIndex = 12;
-			this.PlaybackSettings.TabStop = false;
-			this.PlaybackSettings.Text = "Playback";
-			// 
-			// TooFastChange
-			// 
-			this.TooFastChange.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.TooFastChange.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::FFBardMusicPlayer.Properties.Settings.Default, "TooFastDelay", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.TooFastChange.Font = new System.Drawing.Font("Segoe UI", 8F);
-			this.TooFastChange.Increment = new decimal(new int[] {
-            5,
+            this.ListenChatList.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.ListenChatList.FormattingEnabled = true;
+            this.ListenChatList.Location = new System.Drawing.Point(8, 18);
+            this.ListenChatList.Name = "ListenChatList";
+            this.ListenChatList.Size = new System.Drawing.Size(249, 21);
+            this.ListenChatList.TabIndex = 7;
+            this.HelpTip.SetToolTip(this.ListenChatList, "Use the selected channel as the main channel. (b.conduct)");
+            // 
+            // ForceListenToggle
+            // 
+            this.ForceListenToggle.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.ForceListen;
+            this.ForceListenToggle.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "ForceListen", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.ForceListenToggle.Location = new System.Drawing.Point(8, 44);
+            this.ForceListenToggle.Margin = new System.Windows.Forms.Padding(0);
+            this.ForceListenToggle.Name = "ForceListenToggle";
+            this.ForceListenToggle.Size = new System.Drawing.Size(88, 16);
+            this.ForceListenToggle.TabIndex = 6;
+            this.ForceListenToggle.Text = "Force listen";
+            this.HelpTip.SetToolTip(this.ForceListenToggle, "Forces commands to work from everyone in the selected chat channel.");
+            this.ForceListenToggle.UseVisualStyleBackColor = true;
+            // 
+            // PlaybackSettings
+            // 
+            this.PlaybackSettings.Controls.Add(this.DelaySongsChange);
+            this.PlaybackSettings.Controls.Add(this.WaitBetweenSongsToggle);
+            this.PlaybackSettings.Controls.Add(this.TooFastChange);
+            this.PlaybackSettings.Controls.Add(this.PlayHoldChange);
+            this.PlaybackSettings.Controls.Add(this.SlowPlayToggle);
+            this.PlaybackSettings.Controls.Add(this.ArpeggiateToggle);
+            this.PlaybackSettings.Controls.Add(this.SettingHoldNotes);
+            this.PlaybackSettings.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.PlaybackSettings.Location = new System.Drawing.Point(271, 0);
+            this.PlaybackSettings.Margin = new System.Windows.Forms.Padding(1, 0, 0, 0);
+            this.PlaybackSettings.Name = "PlaybackSettings";
+            this.PlaybackSettings.Padding = new System.Windows.Forms.Padding(0);
+            this.PlaybackSettings.Size = new System.Drawing.Size(269, 118);
+            this.PlaybackSettings.TabIndex = 12;
+            this.PlaybackSettings.TabStop = false;
+            this.PlaybackSettings.Text = "Playback";
+            // 
+            // DelaySongsChange
+            // 
+            this.DelaySongsChange.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.DelaySongsChange.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::FFBardMusicPlayer.Properties.Settings.Default, "DelayBetweenSongs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.DelaySongsChange.Location = new System.Drawing.Point(226, 85);
+            this.DelaySongsChange.Margin = new System.Windows.Forms.Padding(0);
+            this.DelaySongsChange.Maximum = new decimal(new int[] {
+            60,
             0,
             0,
             0});
-			this.TooFastChange.Location = new System.Drawing.Point(122, 12);
-			this.TooFastChange.Margin = new System.Windows.Forms.Padding(0);
-			this.TooFastChange.Maximum = new decimal(new int[] {
-            200,
-            0,
-            0,
-            0});
-			this.TooFastChange.Minimum = new decimal(new int[] {
+            this.DelaySongsChange.Minimum = new decimal(new int[] {
             1,
             0,
             0,
             0});
-			this.TooFastChange.Name = "TooFastChange";
-			this.TooFastChange.Size = new System.Drawing.Size(41, 22);
-			this.TooFastChange.TabIndex = 5;
-			this.TooFastChange.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-			this.HelpTip.SetToolTip(this.TooFastChange, "How many milliseconds for detecting chords?");
-			this.TooFastChange.Value = global::FFBardMusicPlayer.Properties.Settings.Default.TooFastDelay;
-			// 
-			// PlayHoldChange
-			// 
-			this.PlayHoldChange.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.PlayHoldChange.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::FFBardMusicPlayer.Properties.Settings.Default, "PlayHold", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.PlayHoldChange.DataBindings.Add(new System.Windows.Forms.Binding("Visible", global::FFBardMusicPlayer.Properties.Settings.Default, "SlowPlay", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.PlayHoldChange.Font = new System.Drawing.Font("Segoe UI", 8F);
-			this.PlayHoldChange.Increment = new decimal(new int[] {
-            10,
+            this.DelaySongsChange.Name = "DelaySongsChange";
+            this.DelaySongsChange.Size = new System.Drawing.Size(41, 22);
+            this.DelaySongsChange.TabIndex = 7;
+            this.DelaySongsChange.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.HelpTip.SetToolTip(this.DelaySongsChange, "How many seconds to wait between songs?");
+            this.DelaySongsChange.Value = global::FFBardMusicPlayer.Properties.Settings.Default.DelayBetweenSongs;
+            // 
+            // WaitBetweenSongsToggle
+            // 
+            this.WaitBetweenSongsToggle.AutoSize = true;
+            this.WaitBetweenSongsToggle.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.WaitBetweenSongs;
+            this.WaitBetweenSongsToggle.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "WaitBetweenSongs", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.WaitBetweenSongsToggle.Location = new System.Drawing.Point(6, 90);
+            this.WaitBetweenSongsToggle.Name = "WaitBetweenSongsToggle";
+            this.WaitBetweenSongsToggle.Size = new System.Drawing.Size(136, 17);
+            this.WaitBetweenSongsToggle.TabIndex = 6;
+            this.WaitBetweenSongsToggle.Text = "Delay between songs";
+            this.HelpTip.SetToolTip(this.WaitBetweenSongsToggle, "Adds a delay between playing the next song in the playlist.");
+            this.WaitBetweenSongsToggle.UseVisualStyleBackColor = true;
+            this.WaitBetweenSongsToggle.CheckedChanged += new System.EventHandler(this.WaitBetweenSongs_CheckedChanged);
+            // 
+            // TooFastChange
+            // 
+            this.TooFastChange.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.TooFastChange.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::FFBardMusicPlayer.Properties.Settings.Default, "TooFastDelay", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.TooFastChange.Font = new System.Drawing.Font("Segoe UI", 8F);
+            this.TooFastChange.Increment = new decimal(new int[] {
+            5,
             0,
             0,
             0});
-			this.PlayHoldChange.Location = new System.Drawing.Point(122, 52);
-			this.PlayHoldChange.Margin = new System.Windows.Forms.Padding(0);
-			this.PlayHoldChange.Maximum = new decimal(new int[] {
+            this.TooFastChange.Location = new System.Drawing.Point(226, 10);
+            this.TooFastChange.Margin = new System.Windows.Forms.Padding(0);
+            this.TooFastChange.Maximum = new decimal(new int[] {
             200,
             0,
             0,
             0});
-			this.PlayHoldChange.Minimum = new decimal(new int[] {
+            this.TooFastChange.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.TooFastChange.Name = "TooFastChange";
+            this.TooFastChange.Size = new System.Drawing.Size(41, 22);
+            this.TooFastChange.TabIndex = 5;
+            this.TooFastChange.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.HelpTip.SetToolTip(this.TooFastChange, "How many milliseconds for detecting chords?");
+            this.TooFastChange.Value = global::FFBardMusicPlayer.Properties.Settings.Default.TooFastDelay;
+            // 
+            // PlayHoldChange
+            // 
+            this.PlayHoldChange.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.PlayHoldChange.DataBindings.Add(new System.Windows.Forms.Binding("Value", global::FFBardMusicPlayer.Properties.Settings.Default, "PlayHold", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.PlayHoldChange.DataBindings.Add(new System.Windows.Forms.Binding("Visible", global::FFBardMusicPlayer.Properties.Settings.Default, "SlowPlay", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.PlayHoldChange.Font = new System.Drawing.Font("Segoe UI", 8F);
+            this.PlayHoldChange.Increment = new decimal(new int[] {
             10,
             0,
             0,
             0});
-			this.PlayHoldChange.Name = "PlayHoldChange";
-			this.PlayHoldChange.Size = new System.Drawing.Size(41, 22);
-			this.PlayHoldChange.TabIndex = 4;
-			this.PlayHoldChange.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
-			this.HelpTip.SetToolTip(this.PlayHoldChange, "For how long should the notes be held?");
-			this.PlayHoldChange.Value = global::FFBardMusicPlayer.Properties.Settings.Default.PlayHold;
-			this.PlayHoldChange.Visible = global::FFBardMusicPlayer.Properties.Settings.Default.SlowPlay;
-			// 
-			// SlowPlayToggle
-			// 
-			this.SlowPlayToggle.AutoSize = true;
-			this.SlowPlayToggle.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.SlowPlay;
-			this.SlowPlayToggle.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "SlowPlay", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.SlowPlayToggle.Location = new System.Drawing.Point(6, 53);
-			this.SlowPlayToggle.Name = "SlowPlayToggle";
-			this.SlowPlayToggle.Size = new System.Drawing.Size(93, 17);
-			this.SlowPlayToggle.TabIndex = 3;
-			this.SlowPlayToggle.Text = "Play all notes";
-			this.HelpTip.SetToolTip(this.SlowPlayToggle, "Plays all notes in the song in exchange for speed accuracy.\r\nDo not use in orches" +
+            this.PlayHoldChange.Location = new System.Drawing.Point(226, 60);
+            this.PlayHoldChange.Margin = new System.Windows.Forms.Padding(0);
+            this.PlayHoldChange.Maximum = new decimal(new int[] {
+            200,
+            0,
+            0,
+            0});
+            this.PlayHoldChange.Minimum = new decimal(new int[] {
+            10,
+            0,
+            0,
+            0});
+            this.PlayHoldChange.Name = "PlayHoldChange";
+            this.PlayHoldChange.Size = new System.Drawing.Size(41, 22);
+            this.PlayHoldChange.TabIndex = 4;
+            this.PlayHoldChange.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            this.HelpTip.SetToolTip(this.PlayHoldChange, "For how long should the notes be held?");
+            this.PlayHoldChange.Value = global::FFBardMusicPlayer.Properties.Settings.Default.PlayHold;
+            this.PlayHoldChange.Visible = global::FFBardMusicPlayer.Properties.Settings.Default.SlowPlay;
+            // 
+            // SlowPlayToggle
+            // 
+            this.SlowPlayToggle.AutoSize = true;
+            this.SlowPlayToggle.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.SlowPlay;
+            this.SlowPlayToggle.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "SlowPlay", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.SlowPlayToggle.Location = new System.Drawing.Point(6, 65);
+            this.SlowPlayToggle.Name = "SlowPlayToggle";
+            this.SlowPlayToggle.Size = new System.Drawing.Size(93, 17);
+            this.SlowPlayToggle.TabIndex = 3;
+            this.SlowPlayToggle.Text = "Play all notes";
+            this.HelpTip.SetToolTip(this.SlowPlayToggle, "Plays all notes in the song in exchange for speed accuracy.\r\nDo not use in orches" +
         "tra mode!");
-			this.SlowPlayToggle.UseVisualStyleBackColor = true;
-			this.SlowPlayToggle.CheckedChanged += new System.EventHandler(this.SlowPlayToggle_CheckedChanged);
-			// 
-			// ArpeggiateToggle
-			// 
-			this.ArpeggiateToggle.AutoSize = true;
-			this.ArpeggiateToggle.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.AutoArpeggiate;
-			this.ArpeggiateToggle.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.ArpeggiateToggle.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "AutoArpeggiate", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.ArpeggiateToggle.Location = new System.Drawing.Point(6, 15);
-			this.ArpeggiateToggle.Name = "ArpeggiateToggle";
-			this.ArpeggiateToggle.Size = new System.Drawing.Size(108, 17);
-			this.ArpeggiateToggle.TabIndex = 2;
-			this.ArpeggiateToggle.Text = "Simulate chords";
-			this.HelpTip.SetToolTip(this.ArpeggiateToggle, "Detect and simulate chords.");
-			this.ArpeggiateToggle.UseVisualStyleBackColor = true;
-			// 
-			// SettingHoldNotes
-			// 
-			this.SettingHoldNotes.AutoSize = true;
-			this.SettingHoldNotes.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.HoldNotes;
-			this.SettingHoldNotes.CheckState = System.Windows.Forms.CheckState.Checked;
-			this.SettingHoldNotes.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "HoldNotes", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.SettingHoldNotes.Location = new System.Drawing.Point(6, 34);
-			this.SettingHoldNotes.Name = "SettingHoldNotes";
-			this.SettingHoldNotes.Size = new System.Drawing.Size(83, 17);
-			this.SettingHoldNotes.TabIndex = 1;
-			this.SettingHoldNotes.Text = "Hold notes";
-			this.HelpTip.SetToolTip(this.SettingHoldNotes, "Enables held notes.");
-			this.SettingHoldNotes.UseVisualStyleBackColor = true;
-			// 
-			// ChatSimToggle
-			// 
-			this.ChatSimToggle.AutoSize = true;
-			this.ChatSimToggle.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.PlayLyrics;
-			this.ChatSimToggle.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "PlayLyrics", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-			this.ChatSimToggle.Location = new System.Drawing.Point(13, 48);
-			this.ChatSimToggle.Name = "ChatSimToggle";
-			this.ChatSimToggle.Size = new System.Drawing.Size(169, 17);
-			this.ChatSimToggle.TabIndex = 6;
-			this.ChatSimToggle.Text = "Allow in-game chat typing *";
-			this.HelpTip.SetToolTip(this.ChatSimToggle, "Allows program to type in the in-game chat.\r\nAffects MIDI lyrics and <b.cmd> comm" +
+            this.SlowPlayToggle.UseVisualStyleBackColor = true;
+            this.SlowPlayToggle.CheckedChanged += new System.EventHandler(this.SlowPlayToggle_CheckedChanged);
+            // 
+            // ArpeggiateToggle
+            // 
+            this.ArpeggiateToggle.AutoSize = true;
+            this.ArpeggiateToggle.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.AutoArpeggiate;
+            this.ArpeggiateToggle.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.ArpeggiateToggle.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "AutoArpeggiate", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.ArpeggiateToggle.Location = new System.Drawing.Point(6, 15);
+            this.ArpeggiateToggle.Name = "ArpeggiateToggle";
+            this.ArpeggiateToggle.Size = new System.Drawing.Size(108, 17);
+            this.ArpeggiateToggle.TabIndex = 2;
+            this.ArpeggiateToggle.Text = "Simulate chords";
+            this.HelpTip.SetToolTip(this.ArpeggiateToggle, "Detect and simulate chords.");
+            this.ArpeggiateToggle.UseVisualStyleBackColor = true;
+            // 
+            // SettingHoldNotes
+            // 
+            this.SettingHoldNotes.AutoSize = true;
+            this.SettingHoldNotes.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.HoldNotes;
+            this.SettingHoldNotes.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.SettingHoldNotes.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "HoldNotes", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.SettingHoldNotes.Location = new System.Drawing.Point(6, 40);
+            this.SettingHoldNotes.Name = "SettingHoldNotes";
+            this.SettingHoldNotes.Size = new System.Drawing.Size(83, 17);
+            this.SettingHoldNotes.TabIndex = 1;
+            this.SettingHoldNotes.Text = "Hold notes";
+            this.HelpTip.SetToolTip(this.SettingHoldNotes, "Enables held notes.");
+            this.SettingHoldNotes.UseVisualStyleBackColor = true;
+            // 
+            // ChatSimToggle
+            // 
+            this.ChatSimToggle.AutoSize = true;
+            this.ChatSimToggle.Checked = global::FFBardMusicPlayer.Properties.Settings.Default.PlayLyrics;
+            this.ChatSimToggle.DataBindings.Add(new System.Windows.Forms.Binding("Checked", global::FFBardMusicPlayer.Properties.Settings.Default, "PlayLyrics", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.ChatSimToggle.Location = new System.Drawing.Point(13, 48);
+            this.ChatSimToggle.Name = "ChatSimToggle";
+            this.ChatSimToggle.Size = new System.Drawing.Size(169, 17);
+            this.ChatSimToggle.TabIndex = 6;
+            this.ChatSimToggle.Text = "Allow in-game chat typing *";
+            this.HelpTip.SetToolTip(this.ChatSimToggle, "Allows program to type in the in-game chat.\r\nAffects MIDI lyrics and <b.cmd> comm" +
         "and.");
-			this.ChatSimToggle.UseVisualStyleBackColor = true;
-			// 
-			// HelpTip
-			// 
-			this.HelpTip.AutoPopDelay = 5000;
-			this.HelpTip.BackColor = System.Drawing.Color.White;
-			this.HelpTip.ForeColor = System.Drawing.Color.Black;
-			this.HelpTip.InitialDelay = 100;
-			this.HelpTip.ReshowDelay = 100;
-			this.HelpTip.UseAnimation = false;
-			this.HelpTip.UseFading = false;
-			// 
-			// BmpSettings
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.Controls.Add(this.GeneralSettings);
-			this.Font = new System.Drawing.Font("Segoe UI", 8F);
-			this.Name = "BmpSettings";
-			this.Size = new System.Drawing.Size(355, 318);
-			this.GeneralSettings.ResumeLayout(false);
-			this.SettingsScrollPanel.ResumeLayout(false);
-			this.SettingsScrollPanel.PerformLayout();
-			this.SettingsTable.ResumeLayout(false);
-			this.ChatSettings.ResumeLayout(false);
-			this.PlaybackSettings.ResumeLayout(false);
-			this.PlaybackSettings.PerformLayout();
-			((System.ComponentModel.ISupportInitialize)(this.TooFastChange)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.PlayHoldChange)).EndInit();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.ChatSimToggle.UseVisualStyleBackColor = true;
+            // 
+            // HelpTip
+            // 
+            this.HelpTip.AutoPopDelay = 5000;
+            this.HelpTip.BackColor = System.Drawing.Color.White;
+            this.HelpTip.ForeColor = System.Drawing.Color.Black;
+            this.HelpTip.InitialDelay = 100;
+            this.HelpTip.ReshowDelay = 100;
+            this.HelpTip.UseAnimation = false;
+            this.HelpTip.UseFading = false;
+            // 
+            // BmpSettings
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.GeneralSettings);
+            this.Font = new System.Drawing.Font("Segoe UI", 8F);
+            this.Name = "BmpSettings";
+            this.Size = new System.Drawing.Size(568, 507);
+            this.GeneralSettings.ResumeLayout(false);
+            this.SettingsScrollPanel.ResumeLayout(false);
+            this.SettingsScrollPanel.PerformLayout();
+            this.SettingsTable.ResumeLayout(false);
+            this.ChatSettings.ResumeLayout(false);
+            this.PlaybackSettings.ResumeLayout(false);
+            this.PlaybackSettings.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.DelaySongsChange)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.TooFastChange)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.PlayHoldChange)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -480,5 +523,7 @@
 		private System.Windows.Forms.TableLayoutPanel SettingsTable;
 		private System.Windows.Forms.CheckBox UnequipPause;
 		private System.Windows.Forms.CheckBox verboseToggle;
-	}
+        private System.Windows.Forms.NumericUpDown DelaySongsChange;
+        private System.Windows.Forms.CheckBox WaitBetweenSongsToggle;
+    }
 }

--- a/FFBardMusicPlayer/Controls/BmpSettings.cs
+++ b/FFBardMusicPlayer/Controls/BmpSettings.cs
@@ -185,9 +185,16 @@ namespace FFBardMusicPlayer.Controls {
 			BmpAbout about = new BmpAbout();
 			about.ShowDialog(this);
 		}
-	}
 
-	public class MidiInput {
+        private void WaitBetweenSongs_CheckedChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.WaitBetweenSongs = WaitBetweenSongsToggle.Checked;
+            Properties.Settings.Default.DelayBetweenSongs = ((int)DelaySongsChange.Value);
+            Properties.Settings.Default.Save();
+        }
+    }
+
+    public class MidiInput {
 		public string name = string.Empty;
 		public int id = 0;
 		public MidiInput(string n, int i) {

--- a/FFBardMusicPlayer/Forms/BmpMain.cs
+++ b/FFBardMusicPlayer/Forms/BmpMain.cs
@@ -539,20 +539,54 @@ namespace FFBardMusicPlayer.Forms {
             }
         }
 		///
+        private bool WantsDelay
+        {
+            get
+            {
+                return Properties.Settings.Default.WaitBetweenSongs;
+            }
+        }
 
+        private int DelayAmount
+        {
+            get
+            {
+                return ((int)Properties.Settings.Default.DelayBetweenSongs);
+            }
+        }
 
-		private void NextSong() {
-			if(Playlist.AdvanceNext(out string filename, out int track)) {
+		private void NextSong()
+        {
+			if (Playlist.AdvanceNext(out string filename, out int track))
+            {
 				Timer playlistTimer = new Timer();
-				playlistTimer.Interval = 100;
-				playlistTimer.Elapsed += delegate (object o, ElapsedEventArgs e) {
-					this.Invoke(t => t.Playlist.PlaySelectedMidi());
+
+                // if user has requested a delay in-between songs, who are we to want to stop them?
+                if (WantsDelay)
+                {
+                    // internal is in ms, delay amount is in s
+                    playlistTimer.Interval = 1000 * DelayAmount;
+                    Log(string.Format("Waiting {0}s before playing next song.", DelayAmount));
+                }
+                else
+                {
+                    // gotta go fast
+                    playlistTimer.Interval = 100;
+                }
+
+				playlistTimer.Elapsed += delegate (object o, ElapsedEventArgs e)
+                {
+                    Log("Playing the next song in the playlist!");
+                    this.Invoke(t => t.Playlist.PlaySelectedMidi());
 					playlistTimer.Dispose();
 				};
 				playlistTimer.Start();
-			} else {
+			}
+            else
+            {
 				// If failed playlist when you wanted to, just stop
-				if(proceedPlaylistMidi) {
+				if (proceedPlaylistMidi)
+                {
 					Player.Player.Stop();
 				}
 			}

--- a/FFBardMusicPlayer/Forms/BmpMain.cs
+++ b/FFBardMusicPlayer/Forms/BmpMain.cs
@@ -231,6 +231,7 @@ namespace FFBardMusicPlayer.Forms {
 
 			Playlist.OnMidiSelect += Playlist_OnMidiSelect;
 			Playlist.OnPlaylistRequestAdd += Playlist_OnPlaylistRequestAdd;
+            Playlist.OnPlaylistManualRequestAdd += Playlist_OnPlaylistManualRequestAdd;
 
 			this.ResizeBegin += (s, e) => {
 				LocalOrchestra.SuspendLayout();
@@ -511,7 +512,7 @@ namespace FFBardMusicPlayer.Forms {
 				Explorer.Invoke(t => t.SelectTrack(entry.Track.Track));
 				Explorer.EnterFile();
 			}
-			Playlist.Select(entry.FilePath.FilePath);
+			//Playlist.Select(entry.FilePath.FilePath);
 			if(proceedPlaylistMidi && Playlist.AutoPlay) {
 				Player.Player.Play();
 				proceedPlaylistMidi = false;
@@ -526,6 +527,17 @@ namespace FFBardMusicPlayer.Forms {
 				Playlist.AddPlaylistEntry(filename, track);
 			}
 		}
+        private void Playlist_OnPlaylistManualRequestAdd(object o, BmpPlaylist.BmpPlaylistRequestAddEvent args)
+        {
+            if (!string.IsNullOrEmpty(args.filePath))
+            {
+                // ensure the midi is in our directory before we accept it and add it to the playlist
+                if (Explorer.SelectFile(args.filePath))
+                {
+                    Playlist.AddPlaylistEntry(args.filePath, args.track, args.dropIndex);
+                }
+            }
+        }
 		///
 
 

--- a/FFBardMusicPlayer/Forms/BmpMain.cs
+++ b/FFBardMusicPlayer/Forms/BmpMain.cs
@@ -512,7 +512,7 @@ namespace FFBardMusicPlayer.Forms {
 				Explorer.Invoke(t => t.SelectTrack(entry.Track.Track));
 				Explorer.EnterFile();
 			}
-			//Playlist.Select(entry.FilePath.FilePath);
+			Playlist.Select(entry.FilePath.FilePath);
 			if(proceedPlaylistMidi && Playlist.AutoPlay) {
 				Player.Player.Play();
 				proceedPlaylistMidi = false;

--- a/FFBardMusicPlayer/Properties/Settings.Designer.cs
+++ b/FFBardMusicPlayer/Properties/Settings.Designer.cs
@@ -381,5 +381,29 @@ namespace FFBardMusicPlayer.Properties {
                 this["PlayAllTracks"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool WaitBetweenSongs {
+            get {
+                return ((bool)(this["WaitBetweenSongs"]));
+            }
+            set {
+                this["WaitBetweenSongs"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("3")]
+        public decimal DelayBetweenSongs {
+            get {
+                return ((decimal)(this["DelayBetweenSongs"]));
+            }
+            set {
+                this["DelayBetweenSongs"] = value;
+            }
+        }
     }
 }

--- a/FFBardMusicPlayer/Properties/Settings.settings
+++ b/FFBardMusicPlayer/Properties/Settings.settings
@@ -92,5 +92,11 @@
     <Setting Name="PlayAllTracks" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="WaitBetweenSongs" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
+    <Setting Name="DelayBetweenSongs" Type="System.Decimal" Scope="User">
+      <Value Profile="(Default)">3</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/FFBardMusicPlayer/app.config
+++ b/FFBardMusicPlayer/app.config
@@ -94,6 +94,12 @@
             <setting name="PlayAllTracks" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="WaitBetweenSongs" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="DelayBetweenSongs" serializeAs="String">
+                <value>3</value>
+            </setting>
         </FFBardMusicPlayer.Properties.Settings>
     </userSettings>
 </configuration>


### PR DESCRIPTION
Features:
- Allows files from Windows Explorer to be drag-and-dropped into the playlist. Requires the midis are in the songs directory.
- Songs within playlists can now be drag-and-moved to different positions.
- Right-clicking on midis in the playlist will remove them from the playlist.
- Added a "clear all songs" from playlist button.
- Users can enable and set a delay time between the current song ending and the next song in the playlist starting.

Other fixes:
- Seems to have solved the crash that happened when auto-play was enabled. _(no longer able to repro. 60min constant auto-play + loop)_
- Fixed a FormatException when attempting to provide NumericUpDown Text fields custom, non-numerical strings.
- Fixed an issue where RandomMode would sometimes allow for the same song to be played N times in a row.

Known issues:
- When DnD is used, it places a single midi file above the hovered midi in the current playlist. However, when you drag and drop multiple midi files, it will insert them in reverse order.

TODO:
- Import/export of playlists.
- Track selection on loaded songs.