### PR TITLE
change type 0 support to not supported at all.

### DIFF
--- a/FFBardMusicPlayer/DryWetUtil.cs
+++ b/FFBardMusicPlayer/DryWetUtil.cs
@@ -68,10 +68,6 @@ namespace FFBardMusicPlayer
                         {
                             throw new NotSupportedException();
                         }
-                        else if (fileFormat == MidiFileFormat.SingleTrack)
-                        {
-                            throw new NotSupportedException();
-                        }
                     }
                     catch (Exception exception) when (exception is UnknownFileFormatException || exception is InvalidOperationException)
                     {

--- a/FFBardMusicPlayer/DryWetUtil.cs
+++ b/FFBardMusicPlayer/DryWetUtil.cs
@@ -50,8 +50,6 @@ namespace FFBardMusicPlayer
                     }
                 });
 
-                bool explode = false;
-
                 #region Require
 
                 if (midiFile == null)
@@ -72,7 +70,7 @@ namespace FFBardMusicPlayer
                         }
                         else if (fileFormat == MidiFileFormat.SingleTrack)
                         {
-                            explode = true;
+                            throw new NotSupportedException();
                         }
                     }
                     catch (Exception exception) when (exception is UnknownFileFormatException || exception is InvalidOperationException)
@@ -85,8 +83,7 @@ namespace FFBardMusicPlayer
                 Console.WriteLine("Scrubbing " + filePath);
                 var loaderWatch = Stopwatch.StartNew();
 
-                if (explode || midiFile.Chunks.Count == 1) originalTrackChunks = midiFile.GetTrackChunks().First().Explode();
-                else originalTrackChunks = midiFile.GetTrackChunks();
+                originalTrackChunks = midiFile.GetTrackChunks();
 
                 tempoMap = midiFile.GetTempoMap();
                 newTrackChunks = new ConcurrentDictionary<int, TrackChunk>();


### PR DESCRIPTION
exploding type 0 wasn't supported in bmp before, and is breaking some type 1 midi files.