### PR TITLE
Workaround fixes for issue #22 / #23

### DIFF
--- a/FFBardMusicPlayer/Controls/BmpLocalPerformer.cs
+++ b/FFBardMusicPlayer/Controls/BmpLocalPerformer.cs
@@ -232,7 +232,7 @@ namespace FFBardMusicPlayer.Controls {
 
 			Keyboard.UpdateFrequency(new List<int>());
 			if((tn >= 0 && tn < seq.Count) && seq[tn] is Track track) {
-				int po = OctaveNum + bmpSeq.GetTrackPreferredOctaveShift(track);
+				int po = bmpSeq.GetTrackPreferredOctaveShift(track);
 				Console.WriteLine(String.Format("Track {0} {1} po {2}", tn, bmpSeq.MaxTrack, po));
 				List<int> notes = new List<int>();
 				foreach(MidiEvent ev in track.Iterator()) {

--- a/FFBardMusicPlayer/Controls/BmpLocalPerformer.cs
+++ b/FFBardMusicPlayer/Controls/BmpLocalPerformer.cs
@@ -366,8 +366,10 @@ namespace FFBardMusicPlayer.Controls {
 		}
 
 		private void TrackShift_ValueChanged(object sender, EventArgs e) {
+            // reset the applied octave shift if switching tracks
             OctaveShift.Value = 0;
-            this.Invoke(t => t.Update(sequencer));		}
+            this.Invoke(t => t.Update(sequencer));
+		}
 
 		private void OctaveShift_ValueChanged(object sender, EventArgs e) {
             decimal octave = (sender as NumericUpDown).Value;

--- a/FFBardMusicPlayer/Controls/BmpLocalPerformer.cs
+++ b/FFBardMusicPlayer/Controls/BmpLocalPerformer.cs
@@ -366,16 +366,8 @@ namespace FFBardMusicPlayer.Controls {
 		}
 
 		private void TrackShift_ValueChanged(object sender, EventArgs e) {
-            if (sequencer != null)
-            {
-                var seq = sequencer.Sequence;
-                int newTn = decimal.ToInt32((sender as NumericUpDown).Value);
-                int newOs = ((newTn >= 0 && newTn < seq.Count) ? sequencer.GetTrackPreferredOctaveShift(seq[newTn]) : 0);
-                this.OctaveShift.Value = newOs;
-            }
-
-            this.Invoke(t => t.Update(sequencer));
-		}
+            OctaveShift.Value = 0;
+            this.Invoke(t => t.Update(sequencer));		}
 
 		private void OctaveShift_ValueChanged(object sender, EventArgs e) {
             decimal octave = (sender as NumericUpDown).Value;

--- a/FFBardMusicPlayer/Controls/BmpPlayer.cs
+++ b/FFBardMusicPlayer/Controls/BmpPlayer.cs
@@ -223,8 +223,7 @@ namespace FFBardMusicPlayer.Controls {
 		private void OnPlayerMidiLoad(Object o, EventArgs e) {
 			OnMidiTrackLoad?.Invoke(o, player.LoadedTrack);
 
-            // this will also update the keyboard
-            OctaveShift = player.GetTrackPreferredOctaveShift(player.LoadedTrack);
+			UpdateKeyboard(player.LoadedTrack);
 
 			TotalProgressInfo.Invoke(t => t.Text = player.MaxTime);
 


### PR DESCRIPTION
Requested by @MoogleTroupe, assumed for ease of testing.

Fixes for issue #22 / #23 
* Resolves issue with octaves double shifting on initial load for Solo when loading midis with track names that have a shift specified.
* Resolves issue with octaves double shifting on track change for Local Orchestra when track names have a shift specified by temporarily reverting logic back to reset octave box count on track change.
* Resolves issue with octaves visually double shifting when touching octave box in Local Orchestra.

See https://github.com/parulina/bardmusicplayer/issues/23#issuecomment-706851411 for more info.