### PR TITLE
Chip/1.27 fixes

### DIFF
--- a/FFBardMusicPlayer/Components/BmpBrowser.cs
+++ b/FFBardMusicPlayer/Components/BmpBrowser.cs
@@ -238,6 +238,11 @@ namespace FFBardMusicPlayer.Components {
 			MidiFile singleEntry = null;
 			MidiFile focusEntry = null;
 
+	    // this function is called so many times. since we're clearing the list each time,
+	    // the UI element is resetting it's selected index and forcing the selected item to always be 0
+	    // storing the previously selected index should be sufficient, for now
+	    int previouslySelectedIndex = this.SelectedIndex;
+
 			if(!string.IsNullOrEmpty(filenameFilter)) {
 				if(!IsFilenameValid(FilenameFilter)) {
 					midis.Clear();
@@ -304,7 +309,8 @@ namespace FFBardMusicPlayer.Components {
 			} else {
 				if(this.SelectedIndex == -1) {
 					if(this.Items.Count > 0) {
-						this.SelectedIndex = 0;
+			// don't allow this to pass the current index limits. this could change, say, when the user is using the search feature
+						this.SelectedIndex = previouslySelectedIndex < this.Items.Count ? previouslySelectedIndex : this.Items.Count - 1;
 					}
 				}
 			}

--- a/FFBardMusicPlayer/Components/BmpSearcher.cs
+++ b/FFBardMusicPlayer/Components/BmpSearcher.cs
@@ -24,21 +24,19 @@ namespace FFBardMusicPlayer.Controls {
 			// OnTextChange?.Invoke(this, this.Text);
 		}
 
-        protected override void OnKeyPress(KeyPressEventArgs e)
+        protected override void OnKeyUp(KeyEventArgs e)
         {
-            base.OnKeyPress(e);
+	    // here, we can check if the input character in the search bar is either a
+	    // letter or a number, and invoke the text change
+	    // since backspace and delete are special, we'll want to listen for those as well
+	    if (char.IsLetterOrDigit((char)e.KeyCode) ||
+		e.KeyCode == Keys.Delete  ||
+		e.KeyCode == Keys.Back)
+            {
+		OnTextChange?.Invoke(this, this.Text);
+            }
 
-			// here, we can check if the input character in the search bar is either a
-			// letter or a number, and invoke the text change
-			if (char.IsLetterOrDigit(e.KeyChar))
-            {
-				OnTextChange?.Invoke(this, this.Text);
-			}
-			// since backspace and delete are special, we'll want to listen for those as well
-			else if (e.KeyChar == (char)Keys.Delete || e.KeyChar == (char)Keys.Back)
-            {
-				OnTextChange?.Invoke(this, this.Text);
-			}
+	    base.OnKeyUp(e);
         }
 
         protected override void OnKeyDown(KeyEventArgs e) {

--- a/FFBardMusicPlayer/Forms/BmpMain.cs
+++ b/FFBardMusicPlayer/Forms/BmpMain.cs
@@ -641,13 +641,13 @@ namespace FFBardMusicPlayer.Forms {
 						System.Threading.Thread.Sleep(100);
 					}
 				}
-				//if(key == Keys.Space) {
-				//	if(Player.Player.IsPlaying) {
-				//		Player.Player.Pause();
-				//	} else {
-				//		Player.Player.Play();
-				//	}
-				//}
+				if(key == Keys.Space) {
+					if(Player.Player.IsPlaying) {
+						Player.Player.Pause();
+					} else {
+						Player.Player.Play();
+					}
+				}
 				if(key == Keys.Right) {
 					if(Player.Player.IsPlaying) {
 						Player.Player.Seek(1000);


### PR DESCRIPTION
- Add back spacebar support, previously removed.
- Fix an issue with track switching causing BMP to load the first song in the explorer.
- Fix song search functionality not registering on each key event.