### PR TITLE
Add method for removing a BmpSong

### DIFF
--- a/BardMusicPlayer.Coffer.Tests/BmpPlaylistDecoratorTest.cs
+++ b/BardMusicPlayer.Coffer.Tests/BmpPlaylistDecoratorTest.cs
@@ -120,7 +120,7 @@ namespace BardMusicPlayer.Coffer.Tests
         }
 
         [TestMethod]
-        public void TestRemove()
+        public void TestRemoveIndex()
         {
             BmpSong songA = new BmpSong()
             {
@@ -151,6 +151,43 @@ namespace BardMusicPlayer.Coffer.Tests
             Assert.AreSame(songC, objRef.Songs[2]);
 
             ((IPlaylist)test).Remove(1);
+            Assert.AreEqual(2, objRef.Songs.Count);
+            Assert.AreSame(songA, objRef.Songs[0]);
+            Assert.AreSame(songC, objRef.Songs[1]);
+        }
+
+        [TestMethod]
+        public void TestRemoveSong()
+        {
+            BmpSong songA = new BmpSong()
+            {
+                Id = ObjectId.NewObjectId()
+            };
+
+            BmpSong songB = new BmpSong()
+            {
+                Id = ObjectId.NewObjectId()
+            };
+
+            BmpSong songC = new BmpSong()
+            {
+                Id = ObjectId.NewObjectId()
+            };
+
+            BmpPlaylistDecorator test = CreateTestPlaylist();
+
+            var objRef = test.GetBmpPlaylist();
+
+            ((IPlaylist)test).Add(songA);
+            ((IPlaylist)test).Add(songB);
+            ((IPlaylist)test).Add(songC);
+
+            Assert.AreEqual(3, objRef.Songs.Count);
+            Assert.AreSame(songA, objRef.Songs[0]);
+            Assert.AreSame(songB, objRef.Songs[1]);
+            Assert.AreSame(songC, objRef.Songs[2]);
+
+            ((IPlaylist)test).Remove(songB);
             Assert.AreEqual(2, objRef.Songs.Count);
             Assert.AreSame(songA, objRef.Songs[0]);
             Assert.AreSame(songC, objRef.Songs[1]);

--- a/BardMusicPlayer.Coffer/BmpPlaylistDecorator.cs
+++ b/BardMusicPlayer.Coffer/BmpPlaylistDecorator.cs
@@ -65,6 +65,12 @@ namespace BardMusicPlayer.Coffer
             this.target.Songs.RemoveAt(idx);
         }
 
+        /// <inheritdoc />
+        void IPlaylist.Remove(BmpSong song)
+        {
+            this.target.Songs.Remove(song);
+        }
+
         ///<inheritdoc/>
         void IPlaylist.SetName(string name)
         {

--- a/BardMusicPlayer.Coffer/IPlaylist.cs
+++ b/BardMusicPlayer.Coffer/IPlaylist.cs
@@ -37,6 +37,12 @@ namespace BardMusicPlayer.Coffer
         void Remove(int idx);
 
         /// <summary>
+        /// This removes the specified <see cref="BmpSong"/>.
+        /// </summary>
+        /// <param name="song">The song the remove</param>
+        void Remove(BmpSong song);
+
+        /// <summary>
         /// Returns the name of the playlist.
         /// </summary>
         /// <returns></returns>


### PR DESCRIPTION
This lets you remove a `BmpSong` without needing its index.