### PR TITLE
Fixed exception while loading a song twice

### DIFF
--- a/BardMusicPlayer.Coffer/BmpCoffer.cs
+++ b/BardMusicPlayer.Coffer/BmpCoffer.cs
@@ -312,6 +312,13 @@ namespace BardMusicPlayer.Coffer
                 if (song.Id == null)
                 {
                     song.Id = ObjectId.NewObjectId();
+                    //If the song title is already in the database, just update the song
+                    var results = songCol.Find(x => x.Title.Equals(song.Title));
+                    if (results.Count() > 0)
+                    {
+                        songCol.Update(song);
+                        return;
+                    }
                     songCol.Insert(song);
                 }
                 else


### PR DESCRIPTION
If the song title is already in the database, just update the song.