### PR TITLE
Dat file reader modifications

### DIFF
--- a/BardMusicPlayer.Seer/Reader/Backend/DatFile/BarInfo.cs
+++ b/BardMusicPlayer.Seer/Reader/Backend/DatFile/BarInfo.cs
@@ -1,0 +1,13 @@
+﻿/*
+ * Copyright(c) 2021 MoogleTroupe, 2018-2020 parulina
+ * Licensed under the GPL v3 license. See https://github.com/BardMusicPlayer/BardMusicPlayer/blob/develop/LICENSE for full license information.
+ */
+
+namespace BardMusicPlayer.Seer.Reader.Backend.DatFile
+{
+    internal class BarInfo
+    {
+        public int HotbarNumber { get; set; }
+        public bool IsShared { get; set; }
+    }
+}

--- a/BardMusicPlayer.Seer/Reader/Backend/DatFile/BarInfo.cs
+++ b/BardMusicPlayer.Seer/Reader/Backend/DatFile/BarInfo.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2021 MoogleTroupe, 2018-2020 parulina
+ * Copyright(c) 2021 MoogleTroupe, sammhill
  * Licensed under the GPL v3 license. See https://github.com/BardMusicPlayer/BardMusicPlayer/blob/develop/LICENSE for full license information.
  */
 

--- a/BardMusicPlayer.Seer/Reader/Backend/DatFile/CommonDatFile.cs
+++ b/BardMusicPlayer.Seer/Reader/Backend/DatFile/CommonDatFile.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2021 MoogleTroupe, 2018-2020 parulina
+ * Copyright(c) 2021 MoogleTroupe, sammhill
  * Licensed under the GPL v3 license. See https://github.com/BardMusicPlayer/BardMusicPlayer/blob/develop/LICENSE for full license information.
  */
 

--- a/BardMusicPlayer.Seer/Reader/Backend/DatFile/CommonDatFile.cs
+++ b/BardMusicPlayer.Seer/Reader/Backend/DatFile/CommonDatFile.cs
@@ -1,0 +1,73 @@
+﻿/*
+ * Copyright(c) 2021 MoogleTroupe, 2018-2020 parulina
+ * Licensed under the GPL v3 license. See https://github.com/BardMusicPlayer/BardMusicPlayer/blob/develop/LICENSE for full license information.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BardMusicPlayer.Quotidian.Structs;
+using BardMusicPlayer.Seer.Reader.Backend.DatFile.Objects;
+using BardMusicPlayer.Seer.Reader.Backend.DatFile.Utilities;
+
+namespace BardMusicPlayer.Seer.Reader.Backend.DatFile {
+    internal class CommonDatFile : IDisposable {
+
+        internal bool Fresh = true;
+        private string _filePath;
+        private int startingByte = 1360; // Shared hotbar information starts here
+
+        private List<BarInfo> _hotbarBarInformation = new List<BarInfo>();
+
+        internal CommonDatFile(string filePath)
+        {
+            _filePath = filePath;
+        }
+
+        public bool Load()
+        {
+            if (string.IsNullOrEmpty(_filePath)) throw new FileFormatException("No path to COMMON.DAT file provided.");
+            if (!File.Exists(_filePath)) throw new FileFormatException("Missing COMMON.DAT file.");
+
+            using var fileStream = File.Open(_filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var memStream = new MemoryStream();
+            if (fileStream.CanRead && fileStream.CanSeek)
+            {
+                fileStream.CopyTo(memStream);
+            }
+
+            fileStream.Dispose();
+            if (memStream.Length == 0)
+            {
+                memStream.Dispose();
+                return false;
+            }
+
+            using var reader = new BinaryReader(memStream);
+
+            reader.BaseStream.Seek(startingByte, SeekOrigin.Begin);
+
+            for (int i = 1; i < 11; i++) // 10 hotbars, indexed at 1 to match data file and game
+            {
+                var currentBarBytes = reader.ReadBytes(0x12); // Hotbar information is in blocks of 18 bytes
+                _hotbarBarInformation.Add(new BarInfo()
+                {
+                    HotbarNumber = i,
+                    IsShared = currentBarBytes[16] == 0x31
+                });
+            }
+
+            return true;
+        }
+
+        public List<BarInfo> GetBars() => _hotbarBarInformation.ToList();
+        public List<BarInfo> GetSharedBars() => _hotbarBarInformation.Where(x => x.IsShared).ToList();
+        public List<BarInfo> GetJobBars() => _hotbarBarInformation.Where(x => !x.IsShared).ToList();
+
+        public void Dispose()
+        {
+            _hotbarBarInformation.Clear();
+        }
+    }
+}

--- a/BardMusicPlayer.Seer/Reader/Backend/DatFile/DatFileReaderBackend.cs
+++ b/BardMusicPlayer.Seer/Reader/Backend/DatFile/DatFileReaderBackend.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2021 MoogleTroupe, 2018-2020 parulina
+ * Copyright(c) 2021 MoogleTroupe, sammhill, 2018-2020 parulina
  * Licensed under the GPL v3 license. See https://github.com/BardMusicPlayer/BardMusicPlayer/blob/develop/LICENSE for full license information.
  */
 

--- a/BardMusicPlayer.Seer/Reader/Backend/DatFile/HotbarDatFile.cs
+++ b/BardMusicPlayer.Seer/Reader/Backend/DatFile/HotbarDatFile.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright(c) 2021 MoogleTroupe, 2018-2020 parulina
+ * Copyright(c) 2021 MoogleTroupe, sammhill, 2018-2020 parulina
  * Licensed under the GPL v3 license. See https://github.com/BardMusicPlayer/BardMusicPlayer/blob/develop/LICENSE for full license information.
  */
 

--- a/BardMusicPlayer.Seer/Reader/Backend/DatFile/HotbarDatFile.cs
+++ b/BardMusicPlayer.Seer/Reader/Backend/DatFile/HotbarDatFile.cs
@@ -68,7 +68,6 @@ namespace BardMusicPlayer.Seer.Reader.Backend.DatFile {
                         if (ac.Type == 0x1D)
                         {
                             _hotbarData[ac.Hotbar][ac.Slot][ac.Job] = ac;
-                            //Console.WriteLine(string.Format("{0} ({1}): {2} {3}", ac.ToString(), ac.job, ac.action, ac.type));
                         }
                     }
                 }
@@ -87,17 +86,21 @@ namespace BardMusicPlayer.Seer.Reader.Backend.DatFile {
 
         private readonly HotbarData _hotbarData = new();
 
-		public List<HotbarSlot> GetSlotsFromType(SlotType type) => GetSlotsFromType((int) type);
-		public List<HotbarSlot> GetSlotsFromType(int type) => (from row in _hotbarData.Rows.Values from jobSlot in row.Slots.Values from slot in jobSlot.JobSlots.Values where slot.Type == type select slot).ToList();
+        public List<HotbarSlot> GetSlotsFromType(SlotType type) => GetSlotsFromType((int)type);
+        public List<HotbarSlot> GetSlotsFromType(int type) => (from row in _hotbarData.Rows.Values from jobSlot in row.Slots.Values from slot in jobSlot.JobSlots.Values where slot.Type == type select slot).ToList();
+
+        public List<HotbarSlot> GetBRDSlots() => (from row in _hotbarData.Rows.Values from jobSlot in row.Slots.Values from slot in jobSlot.JobSlots.Values where slot.Job == 0x17 select slot).ToList();
+        public List<HotbarSlot> GetGlobalSlots() => (from row in _hotbarData.Rows.Values from jobSlot in row.Slots.Values from slot in jobSlot.JobSlots.Values where slot.Job == 0 select slot).ToList();
 
         internal enum SlotType
         {
-			Unknown,
-			Instrument = 0x1D,
-            InstrumentTone = 0x1D
+            Unknown,
+            Instrument = 0x1D,
+            InstrumentTone = Unknown // Leaving this as unknown as we can just use 'Instrument' for now, they have the same id in hex.
         }
 
-        public string GetInstrumentToneKeyMap(InstrumentTone instrumentTone) {
+        public string GetInstrumentToneKeyMap(InstrumentTone instrumentTone)
+        {
             var slots = GetSlotsFromType(SlotType.InstrumentTone);
             foreach (var slot in slots.Where(slot => slot.Action == instrumentTone))
             {
@@ -106,29 +109,32 @@ namespace BardMusicPlayer.Seer.Reader.Backend.DatFile {
             return string.Empty;
         }
 
-		public string GetInstrumentKeyMap(Instrument instrument) {
+        public string GetInstrumentKeyMap(Instrument instrument)
+        {
             var slots = GetSlotsFromType(SlotType.Instrument);
-			foreach (var slot in slots.Where(slot => slot.Action == instrument))
+            foreach (var slot in slots.Where(slot => slot.Action == instrument))
             {
                 return slot.ToString();
             }
-			return string.Empty;
-		}
+            return string.Empty;
+        }
 
-		private static HotbarSlot ParseSection(BinaryReader stream) {
-			const byte xor = 0x31;
-			var ac = new HotbarSlot {
-				Action = XorTools.ReadXorByte(stream, xor),
-				Flag = XorTools.ReadXorByte(stream, xor),
-				Unk1 = XorTools.ReadXorByte(stream, xor),
-				Unk2 = XorTools.ReadXorByte(stream, xor),
-				Job = XorTools.ReadXorByte(stream, xor),
-				Hotbar = XorTools.ReadXorByte(stream, xor),
-				Slot = XorTools.ReadXorByte(stream, xor),
-				Type = XorTools.ReadXorByte(stream, xor),
-			};
-			return ac;
-		}
+        private static HotbarSlot ParseSection(BinaryReader stream)
+        {
+            const byte xor = 0x31;
+            var ac = new HotbarSlot
+            {
+                Action = XorTools.ReadXorByte(stream, xor),
+                Flag = XorTools.ReadXorByte(stream, xor),
+                Unk1 = XorTools.ReadXorByte(stream, xor),
+                Unk2 = XorTools.ReadXorByte(stream, xor),
+                Job = XorTools.ReadXorByte(stream, xor),
+                Hotbar = XorTools.ReadXorByte(stream, xor),
+                Slot = XorTools.ReadXorByte(stream, xor),
+                Type = XorTools.ReadXorByte(stream, xor),
+            };
+            return ac;
+        }
         ~HotbarDatFile() => Dispose();
         public void Dispose()
         {

--- a/BardMusicPlayer.Seer/Reader/Backend/DatFile/HotbarDatFile.cs
+++ b/BardMusicPlayer.Seer/Reader/Backend/DatFile/HotbarDatFile.cs
@@ -63,13 +63,13 @@ namespace BardMusicPlayer.Seer.Reader.Backend.DatFile {
                 while (reader.BaseStream.Position < dataSize)
                 {
                     var ac = ParseSection(reader);
-                    if (ac.Job <= 0x23)
+                    if (ac.Job == 0x17 || ac.Job == 0)
                     {
                         if (ac.Type == 0x1D)
                         {
+                            _hotbarData[ac.Hotbar][ac.Slot][ac.Job] = ac;
                             //Console.WriteLine(string.Format("{0} ({1}): {2} {3}", ac.ToString(), ac.job, ac.action, ac.type));
                         }
-                        _hotbarData[ac.Hotbar][ac.Slot][ac.Job] = ac;
                     }
                 }
             }
@@ -94,7 +94,7 @@ namespace BardMusicPlayer.Seer.Reader.Backend.DatFile {
         {
 			Unknown,
 			Instrument = 0x1D,
-            InstrumentTone = Unknown
+            InstrumentTone = 0x1D
         }
 
         public string GetInstrumentToneKeyMap(InstrumentTone instrumentTone) {

--- a/BardMusicPlayer.Seer/Reader/Backend/DatFile/Objects/HotbarSlot.cs
+++ b/BardMusicPlayer.Seer/Reader/Backend/DatFile/Objects/HotbarSlot.cs
@@ -33,6 +33,8 @@ namespace BardMusicPlayer.Seer.Reader.Backend.DatFile.Objects
         public byte Job { get; set; } = 0;
         public byte Type { get; set; } = 0;
 
+        public bool IsBard => Job == 0x17;
+
         public override string ToString() => string.Format("HOTBAR_{0}_{1:X}", Hotbar, Slot);
 
         ~HotbarSlot() => Dispose();


### PR DESCRIPTION
Updated hotbar dat file reader to now only include hotbar slots for instruments. whether shared bars or BRD specifically.
added common.dat reader, returning information on all hotbars and whether they are currently shared or not