### PR TITLE
Add Note cooldown for live-playing

### DIFF
--- a/FFBardMusicPlayer/Controls/BmpSettings.Designer.cs
+++ b/FFBardMusicPlayer/Controls/BmpSettings.Designer.cs
@@ -29,27 +29,35 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components          = new System.ComponentModel.Container();
-            this.GeneralSettings     = new System.Windows.Forms.GroupBox();
-            this.KeyboardTest        = new System.Windows.Forms.Button();
-            this.SignatureFolder     = new System.Windows.Forms.Button();
+            this.components = new System.ComponentModel.Container();
+            this.GeneralSettings = new System.Windows.Forms.GroupBox();
+            this.KeyboardTest = new System.Windows.Forms.Button();
+            this.SignatureFolder = new System.Windows.Forms.Button();
             this.SettingsScrollPanel = new System.Windows.Forms.Panel();
-            this.verboseToggle       = new System.Windows.Forms.CheckBox();
-            this.sigCheckbox         = new System.Windows.Forms.CheckBox();
-            this.SettingChatSave     = new System.Windows.Forms.CheckBox();
-            this.SettingsTable       = new System.Windows.Forms.TableLayoutPanel();
-            this.ChatSettings        = new System.Windows.Forms.GroupBox();
-            this.SettingBringGame    = new System.Windows.Forms.CheckBox();
-            this.UnequipPause        = new System.Windows.Forms.CheckBox();
-            this.SettingBringBmp     = new System.Windows.Forms.CheckBox();
-            this.PlaybackSettings    = new System.Windows.Forms.GroupBox();
-            this.SettingHoldNotes    = new System.Windows.Forms.CheckBox();
-            this.ForceOpenToggle     = new System.Windows.Forms.CheckBox();
-            this.MidiInputLabel      = new System.Windows.Forms.Label();
-            this.SettingMidiInput    = new System.Windows.Forms.ComboBox();
-            this.HelpTip             = new System.Windows.Forms.ToolTip(this.components);
+            this.panel2 = new System.Windows.Forms.Panel();
+            this.noteCooldownLabel = new System.Windows.Forms.Label();
+            this.noteCooldownLength = new System.Windows.Forms.NumericUpDown();
+            this.noteCooldownLabelMs = new System.Windows.Forms.Label();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.verboseToggle = new System.Windows.Forms.CheckBox();
+            this.sigCheckbox = new System.Windows.Forms.CheckBox();
+            this.SettingChatSave = new System.Windows.Forms.CheckBox();
+            this.SettingsTable = new System.Windows.Forms.TableLayoutPanel();
+            this.ChatSettings = new System.Windows.Forms.GroupBox();
+            this.SettingBringGame = new System.Windows.Forms.CheckBox();
+            this.UnequipPause = new System.Windows.Forms.CheckBox();
+            this.SettingBringBmp = new System.Windows.Forms.CheckBox();
+            this.PlaybackSettings = new System.Windows.Forms.GroupBox();
+            this.SettingHoldNotes = new System.Windows.Forms.CheckBox();
+            this.ForceOpenToggle = new System.Windows.Forms.CheckBox();
+            this.MidiInputLabel = new System.Windows.Forms.Label();
+            this.SettingMidiInput = new System.Windows.Forms.ComboBox();
+            this.HelpTip = new System.Windows.Forms.ToolTip(this.components);
             this.GeneralSettings.SuspendLayout();
             this.SettingsScrollPanel.SuspendLayout();
+            this.panel2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.noteCooldownLength)).BeginInit();
+            this.panel1.SuspendLayout();
             this.SettingsTable.SuspendLayout();
             this.ChatSettings.SuspendLayout();
             this.PlaybackSettings.SuspendLayout();
@@ -57,113 +65,156 @@
             // 
             // GeneralSettings
             // 
-            this.GeneralSettings.AutoSize  = true;
+            this.GeneralSettings.AutoSize = true;
             this.GeneralSettings.BackColor = System.Drawing.Color.Transparent;
             this.GeneralSettings.Controls.Add(this.KeyboardTest);
             this.GeneralSettings.Controls.Add(this.SignatureFolder);
             this.GeneralSettings.Controls.Add(this.SettingsScrollPanel);
-            this.GeneralSettings.Dock     = System.Windows.Forms.DockStyle.Fill;
+            this.GeneralSettings.Dock = System.Windows.Forms.DockStyle.Fill;
             this.GeneralSettings.Location = new System.Drawing.Point(0, 0);
-            this.GeneralSettings.Margin   = new System.Windows.Forms.Padding(0);
-            this.GeneralSettings.Name     = "GeneralSettings";
-            this.GeneralSettings.Size     = new System.Drawing.Size(546, 325);
+            this.GeneralSettings.Margin = new System.Windows.Forms.Padding(0);
+            this.GeneralSettings.Name = "GeneralSettings";
+            this.GeneralSettings.Size = new System.Drawing.Size(546, 325);
             this.GeneralSettings.TabIndex = 9;
-            this.GeneralSettings.TabStop  = false;
-            this.GeneralSettings.Text     = "Settings";
+            this.GeneralSettings.TabStop = false;
+            this.GeneralSettings.Text = "Settings";
             // 
             // KeyboardTest
             // 
-            this.KeyboardTest.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
-            this.KeyboardTest.Location                = new System.Drawing.Point(313, 3);
-            this.KeyboardTest.Name                    = "KeyboardTest";
-            this.KeyboardTest.Size                    = new System.Drawing.Size(97, 23);
-            this.KeyboardTest.TabIndex                = 0;
-            this.KeyboardTest.Text                    = "Test keyboard";
+            this.KeyboardTest.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.KeyboardTest.Location = new System.Drawing.Point(313, 3);
+            this.KeyboardTest.Name = "KeyboardTest";
+            this.KeyboardTest.Size = new System.Drawing.Size(97, 23);
+            this.KeyboardTest.TabIndex = 0;
+            this.KeyboardTest.Text = "Test keyboard";
             this.KeyboardTest.UseVisualStyleBackColor = true;
             // 
             // SignatureFolder
             // 
-            this.SignatureFolder.Anchor =
-                ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top |
-                                                       System.Windows.Forms.AnchorStyles.Right)));
-            this.SignatureFolder.Location                = new System.Drawing.Point(416, 3);
-            this.SignatureFolder.Name                    = "SignatureFolder";
-            this.SignatureFolder.Size                    = new System.Drawing.Size(116, 23);
-            this.SignatureFolder.TabIndex                = 13;
-            this.SignatureFolder.Text                    = "Open Data folder";
+            this.SignatureFolder.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.SignatureFolder.Location = new System.Drawing.Point(416, 3);
+            this.SignatureFolder.Name = "SignatureFolder";
+            this.SignatureFolder.Size = new System.Drawing.Size(116, 23);
+            this.SignatureFolder.TabIndex = 13;
+            this.SignatureFolder.Text = "Open Data folder";
             this.SignatureFolder.UseVisualStyleBackColor = true;
             // 
             // SettingsScrollPanel
             // 
             this.SettingsScrollPanel.AutoScroll = true;
-            this.SettingsScrollPanel.Controls.Add(this.verboseToggle);
-            this.SettingsScrollPanel.Controls.Add(this.sigCheckbox);
-            this.SettingsScrollPanel.Controls.Add(this.SettingChatSave);
+            this.SettingsScrollPanel.Controls.Add(this.panel2);
+            this.SettingsScrollPanel.Controls.Add(this.panel1);
             this.SettingsScrollPanel.Controls.Add(this.SettingsTable);
-            this.SettingsScrollPanel.Dock     = System.Windows.Forms.DockStyle.Fill;
+            this.SettingsScrollPanel.Dock = System.Windows.Forms.DockStyle.Fill;
             this.SettingsScrollPanel.Location = new System.Drawing.Point(3, 18);
-            this.SettingsScrollPanel.Margin   = new System.Windows.Forms.Padding(0);
-            this.SettingsScrollPanel.Name     = "SettingsScrollPanel";
-            this.SettingsScrollPanel.Padding  = new System.Windows.Forms.Padding(8);
-            this.SettingsScrollPanel.Size     = new System.Drawing.Size(540, 304);
+            this.SettingsScrollPanel.Margin = new System.Windows.Forms.Padding(0);
+            this.SettingsScrollPanel.Name = "SettingsScrollPanel";
+            this.SettingsScrollPanel.Padding = new System.Windows.Forms.Padding(8);
+            this.SettingsScrollPanel.Size = new System.Drawing.Size(540, 304);
             this.SettingsScrollPanel.TabIndex = 12;
+            // 
+            // panel2
+            // 
+            this.panel2.AutoSize = true;
+            this.panel2.Controls.Add(this.noteCooldownLabel);
+            this.panel2.Controls.Add(this.noteCooldownLength);
+            this.panel2.Controls.Add(this.noteCooldownLabelMs);
+            this.panel2.Location = new System.Drawing.Point(270, 113);
+            this.panel2.Name = "panel2";
+            this.panel2.Size = new System.Drawing.Size(260, 100);
+            this.panel2.TabIndex = 25;
+            // 
+            // noteCooldownLabel
+            // 
+            this.noteCooldownLabel.AutoSize = true;
+            this.noteCooldownLabel.Location = new System.Drawing.Point(12, 12);
+            this.noteCooldownLabel.Name = "noteCooldownLabel";
+            this.noteCooldownLabel.Size = new System.Drawing.Size(124, 13);
+            this.noteCooldownLabel.TabIndex = 22;
+            this.noteCooldownLabel.Text = "Note cooldown length";
+            this.HelpTip.SetToolTip(this.noteCooldownLabel, "Specifies the minimum accepted delay between two notes.\r\nValue should be close, b" +
+        "ut higher than the minimum frame-time\r\nto prevent dropped notes (ex. 17ms for 60" +
+        "fps).");
+            // 
+            // noteCooldownLength
+            // 
+            this.noteCooldownLength.Location = new System.Drawing.Point(15, 33);
+            this.noteCooldownLength.Name = "noteCooldownLength";
+            this.noteCooldownLength.Size = new System.Drawing.Size(49, 22);
+            this.noteCooldownLength.TabIndex = 21;
+            this.HelpTip.SetToolTip(this.noteCooldownLength, "Specifies the minimum accepted delay between two notes.\r\nValue should be close, b" +
+        "ut higher than the minimum frame-time\r\nto prevent dropped notes (ex. 17ms for 60" +
+        "fps).\r\n");
+            this.noteCooldownLength.ValueChanged += new System.EventHandler(this.noteCooldownLength_ValueChanged);
+            // 
+            // noteCooldownLabelMs
+            // 
+            this.noteCooldownLabelMs.AutoSize = true;
+            this.noteCooldownLabelMs.Location = new System.Drawing.Point(70, 38);
+            this.noteCooldownLabelMs.Name = "noteCooldownLabelMs";
+            this.noteCooldownLabelMs.Size = new System.Drawing.Size(21, 13);
+            this.noteCooldownLabelMs.TabIndex = 23;
+            this.noteCooldownLabelMs.Text = "ms";
+            // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.verboseToggle);
+            this.panel1.Controls.Add(this.sigCheckbox);
+            this.panel1.Controls.Add(this.SettingChatSave);
+            this.panel1.Location = new System.Drawing.Point(11, 113);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(260, 100);
+            this.panel1.TabIndex = 24;
             // 
             // verboseToggle
             // 
             this.verboseToggle.AutoSize = true;
-            this.verboseToggle.Location = new System.Drawing.Point(26, 169);
-            this.verboseToggle.Name     = "verboseToggle";
-            this.verboseToggle.Size     = new System.Drawing.Size(136, 17);
+            this.verboseToggle.Location = new System.Drawing.Point(16, 15);
+            this.verboseToggle.Name = "verboseToggle";
+            this.verboseToggle.Size = new System.Drawing.Size(136, 17);
             this.verboseToggle.TabIndex = 20;
-            this.verboseToggle.Text     = "Enable verbose mode";
+            this.verboseToggle.Text = "Enable verbose mode";
             this.HelpTip.SetToolTip(this.verboseToggle, "Print various kinds of information to the log window.");
-            this.verboseToggle.UseVisualStyleBackColor =  true;
-            this.verboseToggle.CheckedChanged          += new System.EventHandler(this.verboseToggle_CheckedChanged);
+            this.verboseToggle.UseVisualStyleBackColor = true;
+            this.verboseToggle.CheckedChanged += new System.EventHandler(this.verboseToggle_CheckedChanged);
             // 
             // sigCheckbox
             // 
-            this.sigCheckbox.AutoSize                =  true;
-            this.sigCheckbox.Location                =  new System.Drawing.Point(26, 123);
-            this.sigCheckbox.Name                    =  "sigCheckbox";
-            this.sigCheckbox.Size                    =  new System.Drawing.Size(152, 17);
-            this.sigCheckbox.TabIndex                =  15;
-            this.sigCheckbox.Text                    =  "Ignore signature update";
-            this.sigCheckbox.UseVisualStyleBackColor =  true;
-            this.sigCheckbox.CheckedChanged          += new System.EventHandler(this.sigCheckbox_CheckedChanged);
+            this.sigCheckbox.AutoSize = true;
+            this.sigCheckbox.Location = new System.Drawing.Point(16, 38);
+            this.sigCheckbox.Name = "sigCheckbox";
+            this.sigCheckbox.Size = new System.Drawing.Size(152, 17);
+            this.sigCheckbox.TabIndex = 15;
+            this.sigCheckbox.Text = "Ignore signature update";
+            this.sigCheckbox.UseVisualStyleBackColor = true;
+            this.sigCheckbox.CheckedChanged += new System.EventHandler(this.sigCheckbox_CheckedChanged);
             // 
             // SettingChatSave
             // 
             this.SettingChatSave.AutoSize = true;
-            this.SettingChatSave.Location = new System.Drawing.Point(26, 146);
-            this.SettingChatSave.Name     = "SettingChatSave";
-            this.SettingChatSave.Size     = new System.Drawing.Size(177, 17);
+            this.SettingChatSave.Location = new System.Drawing.Point(16, 61);
+            this.SettingChatSave.Name = "SettingChatSave";
+            this.SettingChatSave.Size = new System.Drawing.Size(177, 17);
             this.SettingChatSave.TabIndex = 5;
-            this.SettingChatSave.Text     = "Save chatlogs to \"logs\" folder";
+            this.SettingChatSave.Text = "Save chatlogs to \"logs\" folder";
             this.HelpTip.SetToolTip(this.SettingChatSave, "Toggling this on requires a program restart.");
             this.SettingChatSave.UseVisualStyleBackColor = true;
             this.SettingChatSave.CheckedChanged += new System.EventHandler(this.SettingChatSave_CheckedChanged);
             // 
             // SettingsTable
             // 
-            this.SettingsTable.Anchor =
-                ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top |
-                                                        System.Windows.Forms.AnchorStyles.Left)
-                                                       | System.Windows.Forms.AnchorStyles.Right)));
+            this.SettingsTable.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.SettingsTable.ColumnCount = 2;
-            this.SettingsTable.ColumnStyles.Add(
-                new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.SettingsTable.ColumnStyles.Add(
-                new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.SettingsTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.SettingsTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.SettingsTable.Controls.Add(this.ChatSettings, 0, 0);
             this.SettingsTable.Controls.Add(this.PlaybackSettings, 1, 0);
             this.SettingsTable.Location = new System.Drawing.Point(11, 11);
-            this.SettingsTable.Name     = "SettingsTable";
+            this.SettingsTable.Name = "SettingsTable";
             this.SettingsTable.RowCount = 1;
-            this.SettingsTable.RowStyles.Add(
-                new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.SettingsTable.Size     = new System.Drawing.Size(518, 96);
+            this.SettingsTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            this.SettingsTable.Size = new System.Drawing.Size(525, 96);
             this.SettingsTable.TabIndex = 18;
             // 
             // ChatSettings
@@ -171,56 +222,55 @@
             this.ChatSettings.Controls.Add(this.SettingBringGame);
             this.ChatSettings.Controls.Add(this.UnequipPause);
             this.ChatSettings.Controls.Add(this.SettingBringBmp);
-            this.ChatSettings.Dock     = System.Windows.Forms.DockStyle.Fill;
+            this.ChatSettings.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ChatSettings.Location = new System.Drawing.Point(0, 0);
-            this.ChatSettings.Margin   = new System.Windows.Forms.Padding(0, 0, 1, 0);
-            this.ChatSettings.Name     = "ChatSettings";
-            this.ChatSettings.Padding  = new System.Windows.Forms.Padding(0);
-            this.ChatSettings.Size     = new System.Drawing.Size(258, 96);
+            this.ChatSettings.Margin = new System.Windows.Forms.Padding(0, 0, 1, 0);
+            this.ChatSettings.Name = "ChatSettings";
+            this.ChatSettings.Padding = new System.Windows.Forms.Padding(0);
+            this.ChatSettings.Size = new System.Drawing.Size(261, 96);
             this.ChatSettings.TabIndex = 11;
-            this.ChatSettings.TabStop  = false;
-            this.ChatSettings.Text     = "Game";
+            this.ChatSettings.TabStop = false;
+            this.ChatSettings.Text = "Game";
             // 
             // SettingBringGame
             // 
-            this.SettingBringGame.AutoSize   = true;
-            this.SettingBringGame.Checked    = true;
+            this.SettingBringGame.AutoSize = true;
+            this.SettingBringGame.Checked = true;
             this.SettingBringGame.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.SettingBringGame.Location   = new System.Drawing.Point(15, 18);
-            this.SettingBringGame.Name       = "SettingBringGame";
-            this.SettingBringGame.Size       = new System.Drawing.Size(127, 17);
-            this.SettingBringGame.TabIndex   = 3;
-            this.SettingBringGame.Text       = "Bring FFXIV to front";
+            this.SettingBringGame.Location = new System.Drawing.Point(15, 18);
+            this.SettingBringGame.Name = "SettingBringGame";
+            this.SettingBringGame.Size = new System.Drawing.Size(127, 17);
+            this.SettingBringGame.TabIndex = 3;
+            this.SettingBringGame.Text = "Bring FFXIV to front";
             this.HelpTip.SetToolTip(this.SettingBringGame, "When playing the song, bring FFXIV to front.");
             this.SettingBringGame.UseVisualStyleBackColor = true;
             this.SettingBringGame.CheckedChanged += new System.EventHandler(this.SettingBringGame_CheckedChanged);
             // 
             // UnequipPause
             // 
-            this.UnequipPause.AutoSize   = true;
-            this.UnequipPause.Checked    = true;
+            this.UnequipPause.AutoSize = true;
+            this.UnequipPause.Checked = true;
             this.UnequipPause.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.UnequipPause.Location   = new System.Drawing.Point(15, 63);
-            this.UnequipPause.Name       = "UnequipPause";
-            this.UnequipPause.Size       = new System.Drawing.Size(149, 17);
-            this.UnequipPause.TabIndex   = 19;
-            this.UnequipPause.Text       = "Pause song on unequip";
-            this.HelpTip.SetToolTip(this.UnequipPause,
-                "Pause the playing song when unequipping the instrument.\r\nUseful for switching ins" +
-                "trument mid-performance.");
-            this.UnequipPause.UseVisualStyleBackColor =  true;
-            this.UnequipPause.CheckedChanged          += new System.EventHandler(this.UnequipPause_CheckedChanged);
+            this.UnequipPause.Location = new System.Drawing.Point(15, 63);
+            this.UnequipPause.Name = "UnequipPause";
+            this.UnequipPause.Size = new System.Drawing.Size(149, 17);
+            this.UnequipPause.TabIndex = 19;
+            this.UnequipPause.Text = "Pause song on unequip";
+            this.HelpTip.SetToolTip(this.UnequipPause, "Pause the playing song when unequipping the instrument.\r\nUseful for switching ins" +
+        "trument mid-performance.");
+            this.UnequipPause.UseVisualStyleBackColor = true;
+            this.UnequipPause.CheckedChanged += new System.EventHandler(this.UnequipPause_CheckedChanged);
             // 
             // SettingBringBmp
             // 
-            this.SettingBringBmp.AutoSize   = true;
-            this.SettingBringBmp.Checked    = true;
+            this.SettingBringBmp.AutoSize = true;
+            this.SettingBringBmp.Checked = true;
             this.SettingBringBmp.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.SettingBringBmp.Location   = new System.Drawing.Point(15, 40);
-            this.SettingBringBmp.Name       = "SettingBringBmp";
-            this.SettingBringBmp.Size       = new System.Drawing.Size(121, 17);
-            this.SettingBringBmp.TabIndex   = 4;
-            this.SettingBringBmp.Text       = "Bring BMP to front";
+            this.SettingBringBmp.Location = new System.Drawing.Point(15, 40);
+            this.SettingBringBmp.Name = "SettingBringBmp";
+            this.SettingBringBmp.Size = new System.Drawing.Size(121, 17);
+            this.SettingBringBmp.TabIndex = 4;
+            this.SettingBringBmp.Text = "Bring BMP to front";
             this.HelpTip.SetToolTip(this.SettingBringBmp, "When Performance is opened in FFXIV, bring BMP to front.");
             this.SettingBringBmp.UseVisualStyleBackColor = true;
             this.SettingBringBmp.CheckedChanged += new System.EventHandler(this.SettingBringBmp_CheckedChanged);
@@ -231,24 +281,24 @@
             this.PlaybackSettings.Controls.Add(this.ForceOpenToggle);
             this.PlaybackSettings.Controls.Add(this.MidiInputLabel);
             this.PlaybackSettings.Controls.Add(this.SettingMidiInput);
-            this.PlaybackSettings.Dock     = System.Windows.Forms.DockStyle.Fill;
-            this.PlaybackSettings.Location = new System.Drawing.Point(260, 0);
-            this.PlaybackSettings.Margin   = new System.Windows.Forms.Padding(1, 0, 0, 0);
-            this.PlaybackSettings.Name     = "PlaybackSettings";
-            this.PlaybackSettings.Padding  = new System.Windows.Forms.Padding(0);
-            this.PlaybackSettings.Size     = new System.Drawing.Size(258, 96);
+            this.PlaybackSettings.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.PlaybackSettings.Location = new System.Drawing.Point(263, 0);
+            this.PlaybackSettings.Margin = new System.Windows.Forms.Padding(1, 0, 0, 0);
+            this.PlaybackSettings.Name = "PlaybackSettings";
+            this.PlaybackSettings.Padding = new System.Windows.Forms.Padding(0);
+            this.PlaybackSettings.Size = new System.Drawing.Size(262, 96);
             this.PlaybackSettings.TabIndex = 12;
-            this.PlaybackSettings.TabStop  = false;
-            this.PlaybackSettings.Text     = "Playback";
+            this.PlaybackSettings.TabStop = false;
+            this.PlaybackSettings.Text = "Playback";
             // 
             // SettingHoldNotes
             // 
             this.SettingHoldNotes.AutoSize = true;
             this.SettingHoldNotes.Location = new System.Drawing.Point(13, 20);
-            this.SettingHoldNotes.Name     = "SettingHoldNotes";
-            this.SettingHoldNotes.Size     = new System.Drawing.Size(83, 17);
+            this.SettingHoldNotes.Name = "SettingHoldNotes";
+            this.SettingHoldNotes.Size = new System.Drawing.Size(83, 17);
             this.SettingHoldNotes.TabIndex = 1;
-            this.SettingHoldNotes.Text     = "Hold notes";
+            this.SettingHoldNotes.Text = "Hold notes";
             this.HelpTip.SetToolTip(this.SettingHoldNotes, "Enables held notes.");
             this.SettingHoldNotes.UseVisualStyleBackColor = true;
             this.SettingHoldNotes.CheckedChanged += new System.EventHandler(this.SettingHoldNotes_CheckedChanged);
@@ -257,57 +307,52 @@
             // 
             this.ForceOpenToggle.AutoSize = true;
             this.ForceOpenToggle.Location = new System.Drawing.Point(13, 43);
-            this.ForceOpenToggle.Name     = "ForceOpenToggle";
-            this.ForceOpenToggle.Size     = new System.Drawing.Size(102, 17);
+            this.ForceOpenToggle.Name = "ForceOpenToggle";
+            this.ForceOpenToggle.Size = new System.Drawing.Size(102, 17);
             this.ForceOpenToggle.TabIndex = 16;
-            this.ForceOpenToggle.Text     = "Force playback";
-            this.HelpTip.SetToolTip(this.ForceOpenToggle,
-                "Ignores the current performance status and plays anyways.\r\n* Recommended to only " +
-                "be used when patches break playback.\r\n* Ignored when hooked to non-FFXIV applica" +
-                "tions.");
+            this.ForceOpenToggle.Text = "Force playback";
+            this.HelpTip.SetToolTip(this.ForceOpenToggle, "Ignores the current performance status and plays anyways.\r\n* Recommended to only " +
+        "be used when patches break playback.\r\n* Ignored when hooked to non-FFXIV applica" +
+        "tions.");
             this.ForceOpenToggle.UseVisualStyleBackColor = true;
             this.ForceOpenToggle.CheckedChanged += new System.EventHandler(this.ForceOpenToggle_CheckedChanged);
             // 
             // MidiInputLabel
             // 
-            this.MidiInputLabel.Location  = new System.Drawing.Point(11, 65);
-            this.MidiInputLabel.Name      = "MidiInputLabel";
-            this.MidiInputLabel.Size      = new System.Drawing.Size(104, 21);
-            this.MidiInputLabel.TabIndex  = 14;
-            this.MidiInputLabel.Text      = "MIDI Input device:";
+            this.MidiInputLabel.Location = new System.Drawing.Point(11, 65);
+            this.MidiInputLabel.Name = "MidiInputLabel";
+            this.MidiInputLabel.Size = new System.Drawing.Size(104, 21);
+            this.MidiInputLabel.TabIndex = 14;
+            this.MidiInputLabel.Text = "MIDI Input device:";
             this.MidiInputLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // SettingMidiInput
             // 
-            this.SettingMidiInput.Anchor =
-                ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top |
-                                                        System.Windows.Forms.AnchorStyles.Left)
-                                                       | System.Windows.Forms.AnchorStyles.Right)));
-            this.SettingMidiInput.DropDownStyle     = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.SettingMidiInput.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.SettingMidiInput.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.SettingMidiInput.FormattingEnabled = true;
-            this.SettingMidiInput.Items.AddRange(new object[]
-            {
-                "None"
-            });
+            this.SettingMidiInput.Items.AddRange(new object[] {
+            "None"});
             this.SettingMidiInput.Location = new System.Drawing.Point(121, 66);
-            this.SettingMidiInput.Name     = "SettingMidiInput";
-            this.SettingMidiInput.Size     = new System.Drawing.Size(124, 21);
+            this.SettingMidiInput.Name = "SettingMidiInput";
+            this.SettingMidiInput.Size = new System.Drawing.Size(125, 21);
             this.SettingMidiInput.TabIndex = 13;
             // 
             // HelpTip
             // 
             this.HelpTip.AutoPopDelay = 5000;
-            this.HelpTip.BackColor    = System.Drawing.Color.White;
-            this.HelpTip.ForeColor    = System.Drawing.Color.Black;
+            this.HelpTip.BackColor = System.Drawing.Color.White;
+            this.HelpTip.ForeColor = System.Drawing.Color.Black;
             this.HelpTip.InitialDelay = 100;
-            this.HelpTip.ReshowDelay  = 100;
+            this.HelpTip.ReshowDelay = 100;
             this.HelpTip.UseAnimation = false;
-            this.HelpTip.UseFading    = false;
+            this.HelpTip.UseFading = false;
             // 
             // BmpSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode       = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.GeneralSettings);
             this.Font = new System.Drawing.Font("Segoe UI", 8F);
             this.Name = "BmpSettings";
@@ -315,6 +360,11 @@
             this.GeneralSettings.ResumeLayout(false);
             this.SettingsScrollPanel.ResumeLayout(false);
             this.SettingsScrollPanel.PerformLayout();
+            this.panel2.ResumeLayout(false);
+            this.panel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.noteCooldownLength)).EndInit();
+            this.panel1.ResumeLayout(false);
+            this.panel1.PerformLayout();
             this.SettingsTable.ResumeLayout(false);
             this.ChatSettings.ResumeLayout(false);
             this.ChatSettings.PerformLayout();
@@ -322,6 +372,7 @@
             this.PlaybackSettings.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
+
         }
 
         #endregion
@@ -346,5 +397,10 @@
         private System.Windows.Forms.CheckBox verboseToggle;
         private System.Windows.Forms.NumericUpDown DelaySongsChange;
         private System.Windows.Forms.CheckBox WaitBetweenSongsToggle;
+        private System.Windows.Forms.Label noteCooldownLabelMs;
+        private System.Windows.Forms.Label noteCooldownLabel;
+        private System.Windows.Forms.NumericUpDown noteCooldownLength;
+        private System.Windows.Forms.Panel panel2;
+        private System.Windows.Forms.Panel panel1;
     }
 }

--- a/FFBardMusicPlayer/Controls/BmpSettings.Designer.cs
+++ b/FFBardMusicPlayer/Controls/BmpSettings.Designer.cs
@@ -138,10 +138,15 @@
             // noteCooldownLength
             // 
             this.noteCooldownLength.Location = new System.Drawing.Point(15, 33);
+            this.noteCooldownLength.Maximum = new decimal(new int[] {
+            50,
+            0,
+            0,
+            0});
             this.noteCooldownLength.Name = "noteCooldownLength";
             this.noteCooldownLength.Size = new System.Drawing.Size(49, 22);
             this.noteCooldownLength.TabIndex = 21;
-            this.HelpTip.SetToolTip(this.noteCooldownLength, resources.GetString("noteCooldownLength.ToolTip"));
+            this.HelpTip.SetToolTip(this.noteCooldownLength, "Enter a value between 0-50ms.");
             this.noteCooldownLength.ValueChanged += new System.EventHandler(this.noteCooldownLength_ValueChanged);
             // 
             // noteCooldownLabelMs

--- a/FFBardMusicPlayer/Controls/BmpSettings.Designer.cs
+++ b/FFBardMusicPlayer/Controls/BmpSettings.Designer.cs
@@ -30,6 +30,7 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(BmpSettings));
             this.GeneralSettings = new System.Windows.Forms.GroupBox();
             this.KeyboardTest = new System.Windows.Forms.Button();
             this.SignatureFolder = new System.Windows.Forms.Button();
@@ -132,9 +133,7 @@
             this.noteCooldownLabel.Size = new System.Drawing.Size(124, 13);
             this.noteCooldownLabel.TabIndex = 22;
             this.noteCooldownLabel.Text = "Note cooldown length";
-            this.HelpTip.SetToolTip(this.noteCooldownLabel, "Specifies the minimum accepted delay between two notes.\r\nValue should be close, b" +
-        "ut higher than the minimum frame-time\r\nto prevent dropped notes (ex. 17ms for 60" +
-        "fps).");
+            this.HelpTip.SetToolTip(this.noteCooldownLabel, resources.GetString("noteCooldownLabel.ToolTip"));
             // 
             // noteCooldownLength
             // 
@@ -142,9 +141,7 @@
             this.noteCooldownLength.Name = "noteCooldownLength";
             this.noteCooldownLength.Size = new System.Drawing.Size(49, 22);
             this.noteCooldownLength.TabIndex = 21;
-            this.HelpTip.SetToolTip(this.noteCooldownLength, "Specifies the minimum accepted delay between two notes.\r\nValue should be close, b" +
-        "ut higher than the minimum frame-time\r\nto prevent dropped notes (ex. 17ms for 60" +
-        "fps).\r\n");
+            this.HelpTip.SetToolTip(this.noteCooldownLength, resources.GetString("noteCooldownLength.ToolTip"));
             this.noteCooldownLength.ValueChanged += new System.EventHandler(this.noteCooldownLength_ValueChanged);
             // 
             // noteCooldownLabelMs

--- a/FFBardMusicPlayer/Controls/BmpSettings.cs
+++ b/FFBardMusicPlayer/Controls/BmpSettings.cs
@@ -76,6 +76,7 @@ namespace FFBardMusicPlayer.Controls
             UnequipPause.Checked     = Properties.Settings.Default.UnequipPause;
             verboseToggle.Checked    = Properties.Settings.Default.Verbose;
             SettingHoldNotes.Checked = Properties.Settings.Default.HoldNotes;
+            noteCooldownLength.Value = (decimal)Properties.Settings.Default.NoteCooldownLength;
         }
 
         private void SettingMidiInput_SelectedValueChanged(object sender, EventArgs e)
@@ -198,6 +199,12 @@ namespace FFBardMusicPlayer.Controls
         private void verboseToggle_CheckedChanged(object sender, EventArgs e)
         {
             Properties.Settings.Default.Verbose = verboseToggle.Checked;
+            Properties.Settings.Default.Save();
+        }
+
+        private void noteCooldownLength_ValueChanged(object sender, EventArgs e)
+        {
+            Properties.Settings.Default.NoteCooldownLength = (float)noteCooldownLength.Value;
             Properties.Settings.Default.Save();
         }
     }

--- a/FFBardMusicPlayer/Controls/BmpSettings.resx
+++ b/FFBardMusicPlayer/Controls/BmpSettings.resx
@@ -126,10 +126,4 @@ Value should be close, but higher than the minimum frame-time
 to prevent dropped notes (ex. 17ms for 60fps).
 * Only applied when no MIDI file is playing</value>
   </data>
-  <data name="noteCooldownLength.ToolTip" xml:space="preserve">
-    <value>Specifies the minimum accepted delay between two notes.
-Value should be close, but higher than the minimum frame-time
-to prevent dropped notes (ex. 17ms for 60fps).
-* Only applied when no MIDI file is playing</value>
-  </data>
 </root>

--- a/FFBardMusicPlayer/Controls/BmpSettings.resx
+++ b/FFBardMusicPlayer/Controls/BmpSettings.resx
@@ -120,7 +120,4 @@
   <metadata name="HelpTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="HelpTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
 </root>

--- a/FFBardMusicPlayer/Controls/BmpSettings.resx
+++ b/FFBardMusicPlayer/Controls/BmpSettings.resx
@@ -120,4 +120,16 @@
   <metadata name="HelpTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="noteCooldownLabel.ToolTip" xml:space="preserve">
+    <value>Specifies the minimum accepted delay between two notes.
+Value should be close, but higher than the minimum frame-time
+to prevent dropped notes (ex. 17ms for 60fps).
+* Only applied when no MIDI file is playing</value>
+  </data>
+  <data name="noteCooldownLength.ToolTip" xml:space="preserve">
+    <value>Specifies the minimum accepted delay between two notes.
+Value should be close, but higher than the minimum frame-time
+to prevent dropped notes (ex. 17ms for 60fps).
+* Only applied when no MIDI file is playing</value>
+  </data>
 </root>

--- a/FFBardMusicPlayer/FFBardMusicPlayer.csproj
+++ b/FFBardMusicPlayer/FFBardMusicPlayer.csproj
@@ -334,6 +334,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Controls\BmpSettings.resx">
       <DependentUpon>BmpSettings.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\BmpMain.resx">
       <DependentUpon>BmpMain.cs</DependentUpon>

--- a/FFBardMusicPlayer/Forms/BmpMain.Designer.cs
+++ b/FFBardMusicPlayer/Forms/BmpMain.Designer.cs
@@ -30,27 +30,26 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources =
-                new System.ComponentModel.ComponentResourceManager(typeof(BmpMain));
-            this.MainTable         = new System.Windows.Forms.TableLayoutPanel();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(BmpMain));
+            this.MainTable = new System.Windows.Forms.TableLayoutPanel();
             this.ChatPlaylistTable = new System.Windows.Forms.TableLayoutPanel();
-            this.InfoTabs          = new System.Windows.Forms.TabControl();
-            this.ChatAllTab        = new System.Windows.Forms.TabPage();
-            this.CommandTab        = new System.Windows.Forms.TabPage();
+            this.Playlist = new FFBardMusicPlayer.Controls.BmpPlaylist();
+            this.InfoTabs = new System.Windows.Forms.TabControl();
+            this.ChatAllTab = new System.Windows.Forms.TabPage();
+            this.ChatLogAll = new FFBardMusicPlayer.Components.BmpChatLog(this.components);
+            this.CommandTab = new System.Windows.Forms.TabPage();
+            this.ChatLogCmd = new FFBardMusicPlayer.Components.BmpChatLog(this.components);
             this.localOrchestraTab = new System.Windows.Forms.TabPage();
-            this.SettingsTab       = new System.Windows.Forms.TabPage();
-            this.StatisticTab      = new System.Windows.Forms.TabPage();
-            this.BottomTable       = new System.Windows.Forms.TableLayoutPanel();
-            this.DonationButton    = new System.Windows.Forms.Button();
-            this.Playlist          = new FFBardMusicPlayer.Controls.BmpPlaylist();
-            this.ChatLogAll        = new FFBardMusicPlayer.Components.BmpChatLog(this.components);
-            this.ChatLogCmd        = new FFBardMusicPlayer.Components.BmpChatLog(this.components);
-            this.LocalOrchestra    = new FFBardMusicPlayer.Controls.BmpLocalOrchestra();
-            this.Settings          = new FFBardMusicPlayer.Controls.BmpSettings();
-            this.Statistics        = new FFBardMusicPlayer.Controls.BmpStatistics();
-            this.Explorer          = new FFBardMusicPlayer.Controls.BmpExplorer();
-            this.Player            = new FFBardMusicPlayer.Controls.BmpPlayer();
-            this.FFXIV             = new FFBardMusicPlayer.Controls.BmpHook();
+            this.LocalOrchestra = new FFBardMusicPlayer.Controls.BmpLocalOrchestra();
+            this.SettingsTab = new System.Windows.Forms.TabPage();
+            this.Settings = new FFBardMusicPlayer.Controls.BmpSettings();
+            this.StatisticTab = new System.Windows.Forms.TabPage();
+            this.Statistics = new FFBardMusicPlayer.Controls.BmpStatistics();
+            this.Explorer = new FFBardMusicPlayer.Controls.BmpExplorer();
+            this.Player = new FFBardMusicPlayer.Controls.BmpPlayer();
+            this.BottomTable = new System.Windows.Forms.TableLayoutPanel();
+            this.FFXIV = new FFBardMusicPlayer.Controls.BmpHook();
+            this.DonationButton = new System.Windows.Forms.Button();
             this.MainTable.SuspendLayout();
             this.ChatPlaylistTable.SuspendLayout();
             this.InfoTabs.SuspendLayout();
@@ -65,49 +64,53 @@
             // MainTable
             // 
             this.MainTable.ColumnCount = 1;
-            this.MainTable.ColumnStyles.Add(
-                new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.MainTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.MainTable.Controls.Add(this.ChatPlaylistTable, 0, 1);
             this.MainTable.Controls.Add(this.Explorer, 0, 2);
             this.MainTable.Controls.Add(this.Player, 0, 3);
             this.MainTable.Controls.Add(this.BottomTable, 0, 4);
-            this.MainTable.Dock     = System.Windows.Forms.DockStyle.Fill;
+            this.MainTable.Dock = System.Windows.Forms.DockStyle.Fill;
             this.MainTable.Location = new System.Drawing.Point(0, 0);
-            this.MainTable.Margin   = new System.Windows.Forms.Padding(0);
-            this.MainTable.Name     = "MainTable";
+            this.MainTable.Margin = new System.Windows.Forms.Padding(0);
+            this.MainTable.Name = "MainTable";
             this.MainTable.RowCount = 5;
             this.MainTable.RowStyles.Add(new System.Windows.Forms.RowStyle());
-            this.MainTable.RowStyles.Add(
-                new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.MainTable.RowStyles.Add(
-                new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
-            this.MainTable.RowStyles.Add(
-                new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 220F));
-            this.MainTable.RowStyles.Add(
-                new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
-            this.MainTable.Size     = new System.Drawing.Size(584, 461);
+            this.MainTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.MainTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 30F));
+            this.MainTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 220F));
+            this.MainTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 24F));
+            this.MainTable.Size = new System.Drawing.Size(745, 572);
             this.MainTable.TabIndex = 1;
             // 
             // ChatPlaylistTable
             // 
             this.ChatPlaylistTable.ColumnCount = 3;
             this.ChatPlaylistTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.ChatPlaylistTable.ColumnStyles.Add(
-                new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.ChatPlaylistTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.ChatPlaylistTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.ChatPlaylistTable.Controls.Add(this.Playlist, 0, 0);
             this.ChatPlaylistTable.Controls.Add(this.InfoTabs, 1, 0);
-            this.ChatPlaylistTable.Dock     = System.Windows.Forms.DockStyle.Fill;
+            this.ChatPlaylistTable.Dock = System.Windows.Forms.DockStyle.Fill;
             this.ChatPlaylistTable.Location = new System.Drawing.Point(0, 0);
-            this.ChatPlaylistTable.Margin   = new System.Windows.Forms.Padding(0);
-            this.ChatPlaylistTable.Name     = "ChatPlaylistTable";
+            this.ChatPlaylistTable.Margin = new System.Windows.Forms.Padding(0);
+            this.ChatPlaylistTable.Name = "ChatPlaylistTable";
             this.ChatPlaylistTable.RowCount = 1;
-            this.ChatPlaylistTable.RowStyles.Add(
-                new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.ChatPlaylistTable.RowStyles.Add(
-                new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 187F));
-            this.ChatPlaylistTable.Size     = new System.Drawing.Size(584, 187);
+            this.ChatPlaylistTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.ChatPlaylistTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 312F));
+            this.ChatPlaylistTable.Size = new System.Drawing.Size(745, 298);
             this.ChatPlaylistTable.TabIndex = 1;
+            // 
+            // Playlist
+            // 
+            this.Playlist.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.Playlist.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.Playlist.Location = new System.Drawing.Point(0, 0);
+            this.Playlist.LoopMode = false;
+            this.Playlist.Margin = new System.Windows.Forms.Padding(0);
+            this.Playlist.Name = "Playlist";
+            this.Playlist.RandomMode = false;
+            this.Playlist.Size = new System.Drawing.Size(200, 298);
+            this.Playlist.TabIndex = 0;
             // 
             // InfoTabs
             // 
@@ -116,213 +119,197 @@
             this.InfoTabs.Controls.Add(this.localOrchestraTab);
             this.InfoTabs.Controls.Add(this.SettingsTab);
             this.InfoTabs.Controls.Add(this.StatisticTab);
-            this.InfoTabs.Dock          = System.Windows.Forms.DockStyle.Fill;
-            this.InfoTabs.Location      = new System.Drawing.Point(200, 0);
-            this.InfoTabs.Margin        = new System.Windows.Forms.Padding(0);
-            this.InfoTabs.Name          = "InfoTabs";
+            this.InfoTabs.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.InfoTabs.Location = new System.Drawing.Point(200, 0);
+            this.InfoTabs.Margin = new System.Windows.Forms.Padding(0);
+            this.InfoTabs.Name = "InfoTabs";
             this.InfoTabs.SelectedIndex = 0;
-            this.InfoTabs.Size          = new System.Drawing.Size(384, 187);
-            this.InfoTabs.TabIndex      = 1;
+            this.InfoTabs.Size = new System.Drawing.Size(545, 298);
+            this.InfoTabs.TabIndex = 1;
             // 
             // ChatAllTab
             // 
             this.ChatAllTab.Controls.Add(this.ChatLogAll);
-            this.ChatAllTab.Location                = new System.Drawing.Point(4, 22);
-            this.ChatAllTab.Name                    = "ChatAllTab";
-            this.ChatAllTab.Size                    = new System.Drawing.Size(376, 161);
-            this.ChatAllTab.TabIndex                = 0;
-            this.ChatAllTab.Text                    = "[Chat] All";
+            this.ChatAllTab.Location = new System.Drawing.Point(4, 22);
+            this.ChatAllTab.Name = "ChatAllTab";
+            this.ChatAllTab.Size = new System.Drawing.Size(610, 286);
+            this.ChatAllTab.TabIndex = 0;
+            this.ChatAllTab.Text = "[Chat] All";
             this.ChatAllTab.UseVisualStyleBackColor = true;
+            // 
+            // ChatLogAll
+            // 
+            this.ChatLogAll.BackColor = System.Drawing.Color.Gray;
+            this.ChatLogAll.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.ChatLogAll.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ChatLogAll.Location = new System.Drawing.Point(0, 0);
+            this.ChatLogAll.Margin = new System.Windows.Forms.Padding(0);
+            this.ChatLogAll.Name = "ChatLogAll";
+            this.ChatLogAll.ReadOnly = true;
+            this.ChatLogAll.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.ForcedVertical;
+            this.ChatLogAll.Size = new System.Drawing.Size(610, 286);
+            this.ChatLogAll.TabIndex = 0;
+            this.ChatLogAll.Text = "";
             // 
             // CommandTab
             // 
             this.CommandTab.Controls.Add(this.ChatLogCmd);
-            this.CommandTab.Location                = new System.Drawing.Point(4, 22);
-            this.CommandTab.Name                    = "CommandTab";
-            this.CommandTab.Size                    = new System.Drawing.Size(376, 161);
-            this.CommandTab.TabIndex                = 1;
-            this.CommandTab.Text                    = "[Chat] Commands";
+            this.CommandTab.Location = new System.Drawing.Point(4, 22);
+            this.CommandTab.Name = "CommandTab";
+            this.CommandTab.Size = new System.Drawing.Size(610, 286);
+            this.CommandTab.TabIndex = 1;
+            this.CommandTab.Text = "[Chat] Commands";
             this.CommandTab.UseVisualStyleBackColor = true;
+            // 
+            // ChatLogCmd
+            // 
+            this.ChatLogCmd.BackColor = System.Drawing.Color.Gray;
+            this.ChatLogCmd.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.ChatLogCmd.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ChatLogCmd.Location = new System.Drawing.Point(0, 0);
+            this.ChatLogCmd.Margin = new System.Windows.Forms.Padding(0);
+            this.ChatLogCmd.Name = "ChatLogCmd";
+            this.ChatLogCmd.ReadOnly = true;
+            this.ChatLogCmd.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.ForcedVertical;
+            this.ChatLogCmd.Size = new System.Drawing.Size(610, 286);
+            this.ChatLogCmd.TabIndex = 0;
+            this.ChatLogCmd.Text = "";
             // 
             // localOrchestraTab
             // 
             this.localOrchestraTab.Controls.Add(this.LocalOrchestra);
-            this.localOrchestraTab.Location                = new System.Drawing.Point(4, 22);
-            this.localOrchestraTab.Name                    = "localOrchestraTab";
-            this.localOrchestraTab.Padding                 = new System.Windows.Forms.Padding(3);
-            this.localOrchestraTab.Size                    = new System.Drawing.Size(376, 161);
-            this.localOrchestraTab.TabIndex                = 4;
-            this.localOrchestraTab.Text                    = "Local orchestra";
+            this.localOrchestraTab.Location = new System.Drawing.Point(4, 22);
+            this.localOrchestraTab.Name = "localOrchestraTab";
+            this.localOrchestraTab.Padding = new System.Windows.Forms.Padding(3);
+            this.localOrchestraTab.Size = new System.Drawing.Size(610, 286);
+            this.localOrchestraTab.TabIndex = 4;
+            this.localOrchestraTab.Text = "Local orchestra";
             this.localOrchestraTab.UseVisualStyleBackColor = true;
+            // 
+            // LocalOrchestra
+            // 
+            this.LocalOrchestra.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.LocalOrchestra.Location = new System.Drawing.Point(3, 3);
+            this.LocalOrchestra.Name = "LocalOrchestra";
+            this.LocalOrchestra.OrchestraEnabled = false;
+            this.LocalOrchestra.Sequencer = null;
+            this.LocalOrchestra.Size = new System.Drawing.Size(604, 280);
+            this.LocalOrchestra.TabIndex = 0;
             // 
             // SettingsTab
             // 
             this.SettingsTab.Controls.Add(this.Settings);
-            this.SettingsTab.Location                = new System.Drawing.Point(4, 22);
-            this.SettingsTab.Name                    = "SettingsTab";
-            this.SettingsTab.Size                    = new System.Drawing.Size(376, 161);
-            this.SettingsTab.TabIndex                = 2;
-            this.SettingsTab.Text                    = "Settings";
+            this.SettingsTab.Location = new System.Drawing.Point(4, 22);
+            this.SettingsTab.Name = "SettingsTab";
+            this.SettingsTab.Size = new System.Drawing.Size(537, 272);
+            this.SettingsTab.TabIndex = 2;
+            this.SettingsTab.Text = "Settings";
             this.SettingsTab.UseVisualStyleBackColor = true;
+            // 
+            // Settings
+            // 
+            this.Settings.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.Settings.Font = new System.Drawing.Font("Segoe UI", 8F);
+            this.Settings.Location = new System.Drawing.Point(0, 0);
+            this.Settings.Margin = new System.Windows.Forms.Padding(0);
+            this.Settings.Name = "Settings";
+            this.Settings.Size = new System.Drawing.Size(537, 272);
+            this.Settings.TabIndex = 0;
             // 
             // StatisticTab
             // 
             this.StatisticTab.Controls.Add(this.Statistics);
-            this.StatisticTab.Location                = new System.Drawing.Point(4, 22);
-            this.StatisticTab.Name                    = "StatisticTab";
-            this.StatisticTab.Padding                 = new System.Windows.Forms.Padding(3);
-            this.StatisticTab.Size                    = new System.Drawing.Size(376, 161);
-            this.StatisticTab.TabIndex                = 3;
-            this.StatisticTab.Text                    = "Statistics";
+            this.StatisticTab.Location = new System.Drawing.Point(4, 22);
+            this.StatisticTab.Name = "StatisticTab";
+            this.StatisticTab.Padding = new System.Windows.Forms.Padding(3);
+            this.StatisticTab.Size = new System.Drawing.Size(610, 286);
+            this.StatisticTab.TabIndex = 3;
+            this.StatisticTab.Text = "Statistics";
             this.StatisticTab.UseVisualStyleBackColor = true;
-            // 
-            // BottomTable
-            // 
-            this.BottomTable.ColumnCount = 3;
-            this.BottomTable.ColumnStyles.Add(
-                new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.BottomTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.BottomTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.BottomTable.Controls.Add(this.FFXIV, 0, 0);
-            this.BottomTable.Controls.Add(this.DonationButton, 1, 0);
-            this.BottomTable.Dock     = System.Windows.Forms.DockStyle.Fill;
-            this.BottomTable.Location = new System.Drawing.Point(0, 437);
-            this.BottomTable.Margin   = new System.Windows.Forms.Padding(0);
-            this.BottomTable.Name     = "BottomTable";
-            this.BottomTable.RowCount = 1;
-            this.BottomTable.RowStyles.Add(
-                new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.BottomTable.Size     = new System.Drawing.Size(584, 24);
-            this.BottomTable.TabIndex = 6;
-            // 
-            // DonationButton
-            // 
-            this.DonationButton.BackColor               =  System.Drawing.Color.Khaki;
-            this.DonationButton.Location                =  new System.Drawing.Point(527, 0);
-            this.DonationButton.Margin                  =  new System.Windows.Forms.Padding(0);
-            this.DonationButton.Name                    =  "DonationButton";
-            this.DonationButton.Size                    =  new System.Drawing.Size(57, 23);
-            this.DonationButton.TabIndex                =  6;
-            this.DonationButton.Text                    =  "About";
-            this.DonationButton.UseVisualStyleBackColor =  false;
-            this.DonationButton.Click                   += new System.EventHandler(this.DonationButton_Click);
-            // 
-            // Playlist
-            // 
-            this.Playlist.Dock       = System.Windows.Forms.DockStyle.Fill;
-            this.Playlist.Font       = new System.Drawing.Font("Segoe UI", 9F);
-            this.Playlist.Location   = new System.Drawing.Point(0, 0);
-            this.Playlist.LoopMode   = false;
-            this.Playlist.Margin     = new System.Windows.Forms.Padding(0);
-            this.Playlist.Name       = "Playlist";
-            this.Playlist.RandomMode = false;
-            this.Playlist.Size       = new System.Drawing.Size(200, 187);
-            this.Playlist.TabIndex   = 0;
-            // 
-            // ChatLogAll
-            // 
-            this.ChatLogAll.BackColor   = System.Drawing.Color.Gray;
-            this.ChatLogAll.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.ChatLogAll.Dock        = System.Windows.Forms.DockStyle.Fill;
-            this.ChatLogAll.Location    = new System.Drawing.Point(0, 0);
-            this.ChatLogAll.Margin      = new System.Windows.Forms.Padding(0);
-            this.ChatLogAll.Name        = "ChatLogAll";
-            this.ChatLogAll.ReadOnly    = true;
-            this.ChatLogAll.ScrollBars  = System.Windows.Forms.RichTextBoxScrollBars.ForcedVertical;
-            this.ChatLogAll.Size        = new System.Drawing.Size(376, 161);
-            this.ChatLogAll.TabIndex    = 0;
-            this.ChatLogAll.Text        = "";
-            // 
-            // ChatLogCmd
-            // 
-            this.ChatLogCmd.BackColor   = System.Drawing.Color.Gray;
-            this.ChatLogCmd.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.ChatLogCmd.Dock        = System.Windows.Forms.DockStyle.Fill;
-            this.ChatLogCmd.Location    = new System.Drawing.Point(0, 0);
-            this.ChatLogCmd.Margin      = new System.Windows.Forms.Padding(0);
-            this.ChatLogCmd.Name        = "ChatLogCmd";
-            this.ChatLogCmd.ReadOnly    = true;
-            this.ChatLogCmd.ScrollBars  = System.Windows.Forms.RichTextBoxScrollBars.ForcedVertical;
-            this.ChatLogCmd.Size        = new System.Drawing.Size(376, 161);
-            this.ChatLogCmd.TabIndex    = 0;
-            this.ChatLogCmd.Text        = "";
-            // 
-            // LocalOrchestra
-            // 
-            this.LocalOrchestra.Dock             = System.Windows.Forms.DockStyle.Fill;
-            this.LocalOrchestra.Location         = new System.Drawing.Point(3, 3);
-            this.LocalOrchestra.Name             = "LocalOrchestra";
-            this.LocalOrchestra.OrchestraEnabled = false;
-            this.LocalOrchestra.Sequencer        = null;
-            this.LocalOrchestra.Size             = new System.Drawing.Size(370, 155);
-            this.LocalOrchestra.TabIndex         = 0;
-            // 
-            // Settings
-            // 
-            this.Settings.Dock     = System.Windows.Forms.DockStyle.Fill;
-            this.Settings.Font     = new System.Drawing.Font("Segoe UI", 8F);
-            this.Settings.Location = new System.Drawing.Point(0, 0);
-            this.Settings.Margin   = new System.Windows.Forms.Padding(0);
-            this.Settings.Name     = "Settings";
-            this.Settings.Size     = new System.Drawing.Size(376, 161);
-            this.Settings.TabIndex = 0;
             // 
             // Statistics
             // 
-            this.Statistics.Dock     = System.Windows.Forms.DockStyle.Fill;
+            this.Statistics.Dock = System.Windows.Forms.DockStyle.Fill;
             this.Statistics.Location = new System.Drawing.Point(3, 3);
-            this.Statistics.Name     = "Statistics";
-            this.Statistics.Size     = new System.Drawing.Size(370, 155);
+            this.Statistics.Name = "Statistics";
+            this.Statistics.Size = new System.Drawing.Size(604, 280);
             this.Statistics.TabIndex = 0;
             // 
             // Explorer
             // 
-            this.Explorer.Dock               = System.Windows.Forms.DockStyle.Fill;
-            this.Explorer.Location           = new System.Drawing.Point(3, 190);
-            this.Explorer.Name               = "Explorer";
-            this.Explorer.Size               = new System.Drawing.Size(578, 24);
+            this.Explorer.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.Explorer.Location = new System.Drawing.Point(3, 301);
+            this.Explorer.Name = "Explorer";
+            this.Explorer.Size = new System.Drawing.Size(739, 24);
             this.Explorer.SongBrowserVisible = false;
-            this.Explorer.TabIndex           = 3;
+            this.Explorer.TabIndex = 3;
             // 
             // Player
             // 
-            this.Player.Dock         = System.Windows.Forms.DockStyle.Fill;
-            this.Player.Font         = new System.Drawing.Font("Segoe UI", 8F);
+            this.Player.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.Player.Font = new System.Drawing.Font("Segoe UI", 8F);
             this.Player.Interactable = true;
-            this.Player.Location     = new System.Drawing.Point(3, 220);
-            this.Player.Loop         = false;
-            this.Player.Name         = "Player";
-            this.Player.OctaveShift  = 0;
-            this.Player.Size         = new System.Drawing.Size(578, 214);
-            this.Player.SpeedShift   = 1F;
-            this.Player.Status       = FFBardMusicPlayer.Controls.BmpPlayer.PlayerStatus.Performing;
-            this.Player.TabIndex     = 4;
-            this.Player.Tempo        = 0;
-            this.Player.TrackName    = null;
+            this.Player.Location = new System.Drawing.Point(3, 331);
+            this.Player.Loop = false;
+            this.Player.Name = "Player";
+            this.Player.OctaveShift = 0;
+            this.Player.Size = new System.Drawing.Size(739, 214);
+            this.Player.SpeedShift = 1F;
+            this.Player.Status = FFBardMusicPlayer.Controls.BmpPlayer.PlayerStatus.Performing;
+            this.Player.TabIndex = 4;
+            this.Player.Tempo = 0;
+            this.Player.TrackName = null;
+            // 
+            // BottomTable
+            // 
+            this.BottomTable.ColumnCount = 3;
+            this.BottomTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.BottomTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.BottomTable.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.BottomTable.Controls.Add(this.FFXIV, 0, 0);
+            this.BottomTable.Controls.Add(this.DonationButton, 1, 0);
+            this.BottomTable.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.BottomTable.Location = new System.Drawing.Point(0, 548);
+            this.BottomTable.Margin = new System.Windows.Forms.Padding(0);
+            this.BottomTable.Name = "BottomTable";
+            this.BottomTable.RowCount = 1;
+            this.BottomTable.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.BottomTable.Size = new System.Drawing.Size(745, 24);
+            this.BottomTable.TabIndex = 6;
             // 
             // FFXIV
             // 
-            this.FFXIV.DataBindings.Add(new System.Windows.Forms.Binding("Location",
-                global::FFBardMusicPlayer.Properties.Settings.Default, "Location", true,
-                System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
-            this.FFXIV.Dock     = System.Windows.Forms.DockStyle.Fill;
+            this.FFXIV.DataBindings.Add(new System.Windows.Forms.Binding("Location", global::FFBardMusicPlayer.Properties.Settings.Default, "Location", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+            this.FFXIV.Dock = System.Windows.Forms.DockStyle.Fill;
             this.FFXIV.Location = global::FFBardMusicPlayer.Properties.Settings.Default.Location;
-            this.FFXIV.Margin   = new System.Windows.Forms.Padding(0);
-            this.FFXIV.Name     = "FFXIV";
-            this.FFXIV.Size     = new System.Drawing.Size(527, 24);
+            this.FFXIV.Margin = new System.Windows.Forms.Padding(0);
+            this.FFXIV.Name = "FFXIV";
+            this.FFXIV.Size = new System.Drawing.Size(688, 24);
             this.FFXIV.TabIndex = 5;
+            // 
+            // DonationButton
+            // 
+            this.DonationButton.BackColor = System.Drawing.Color.Khaki;
+            this.DonationButton.Location = new System.Drawing.Point(688, 0);
+            this.DonationButton.Margin = new System.Windows.Forms.Padding(0);
+            this.DonationButton.Name = "DonationButton";
+            this.DonationButton.Size = new System.Drawing.Size(57, 23);
+            this.DonationButton.TabIndex = 6;
+            this.DonationButton.Text = "About";
+            this.DonationButton.UseVisualStyleBackColor = false;
+            this.DonationButton.Click += new System.EventHandler(this.DonationButton_Click);
             // 
             // BmpMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode       = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize          = new System.Drawing.Size(584, 461);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(745, 572);
             this.Controls.Add(this.MainTable);
-            this.Font        = new System.Drawing.Font("Segoe UI", 8F);
-            this.Icon        = ((System.Drawing.Icon) (resources.GetObject("$this.Icon")));
+            this.Font = new System.Drawing.Font("Segoe UI", 8F);
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MinimumSize = new System.Drawing.Size(500, 500);
-            this.Name        = "BmpMain";
-            this.Text        = "BmpMain";
+            this.Name = "BmpMain";
+            this.Text = "BmpMain";
             this.MainTable.ResumeLayout(false);
             this.ChatPlaylistTable.ResumeLayout(false);
             this.InfoTabs.ResumeLayout(false);
@@ -333,6 +320,7 @@
             this.StatisticTab.ResumeLayout(false);
             this.BottomTable.ResumeLayout(false);
             this.ResumeLayout(false);
+
         }
 
         #endregion

--- a/FFBardMusicPlayer/Forms/BmpMain.cs
+++ b/FFBardMusicPlayer/Forms/BmpMain.cs
@@ -833,18 +833,18 @@ namespace FFBardMusicPlayer.Forms
 
             if (!FFXIV.IsPerformanceReady())
                 return;
-            
+
             // If from midi file
             if (onNote.Track != Player.Player.LoadedTrack)
                 return;
-
+            
             if (Sharlayan.Reader.CanGetChatInput() && FFXIV.Memory.ChatInputOpen)
                 return;
             
 
             if (FFXIV.Hotkeys.GetKeybindFromNoteByte(onNote.Note) is FFXIVKeybindDat.Keybind keybind)
             {
-                if (Player.Player.IsPlaying && NoteCooldownLength != 0)
+                if (!Player.Player.IsPlaying && NoteCooldownLength != 0)
                 {
                     long diff = Stopwatch.GetTimestamp() / 10000 - lastNoteTimestamp;
                     if (diff < NoteCooldownLength)

--- a/FFBardMusicPlayer/Forms/BmpMain.cs
+++ b/FFBardMusicPlayer/Forms/BmpMain.cs
@@ -844,12 +844,16 @@ namespace FFBardMusicPlayer.Forms
 
             if (FFXIV.Hotkeys.GetKeybindFromNoteByte(onNote.Note) is FFXIVKeybindDat.Keybind keybind)
             {
-                long diff = Stopwatch.GetTimestamp() / 10000 - lastNoteTimestamp;
-                if (diff < NoteCooldownLength)
+                if (Player.Player.IsPlaying && NoteCooldownLength != 0)
                 {
-                    int sleepDuration = (int)(NoteCooldownLength - diff);
-                    Console.WriteLine($"Inputs too close! Sleep for {sleepDuration} ms.");
-                    Thread.Sleep(sleepDuration);
+                    long diff = Stopwatch.GetTimestamp() / 10000 - lastNoteTimestamp;
+                    if (diff < NoteCooldownLength)
+                    {
+                        int sleepDuration = (int)(NoteCooldownLength - diff);
+                        Console.WriteLine($"Inputs too close! Sleep for {sleepDuration} ms.");
+                        Thread.Sleep(sleepDuration);
+                    }
+                    lastNoteTimestamp = Stopwatch.GetTimestamp() / 10000;
                 }
 
                 if (WantsHold)
@@ -860,8 +864,6 @@ namespace FFBardMusicPlayer.Forms
                 {
                     FFXIV.Hook.SendAsyncKeybind(keybind);
                 }
-
-                lastNoteTimestamp = Stopwatch.GetTimestamp() / 10000;
             }
         }
 

--- a/FFBardMusicPlayer/Properties/Settings.Designer.cs
+++ b/FFBardMusicPlayer/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace FFBardMusicPlayer.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -331,6 +331,18 @@ namespace FFBardMusicPlayer.Properties {
             }
             set {
                 this["PlayAllTracks"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public float NoteCooldownLength {
+            get {
+                return ((float)(this["NoteCooldownLength"]));
+            }
+            set {
+                this["NoteCooldownLength"] = value;
             }
         }
     }

--- a/FFBardMusicPlayer/Properties/Settings.settings
+++ b/FFBardMusicPlayer/Properties/Settings.settings
@@ -80,5 +80,8 @@
     <Setting Name="PlayAllTracks" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="NoteCooldownLength" Type="System.Single" Scope="User">
+      <Value Profile="(Default)">0</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/FFBardMusicPlayer/app.config
+++ b/FFBardMusicPlayer/app.config
@@ -89,6 +89,9 @@
       <setting name="PlayAllTracks" serializeAs="String">
         <value>False</value>
       </setting>
+      <setting name="NoteCooldownLength" serializeAs="String">
+        <value>0</value>
+      </setting>
     </FFBardMusicPlayer.Properties.Settings>
   </userSettings>
 </configuration>


### PR DESCRIPTION
## Note Cooldown
Hello, I implemented a feature to add a delay on notes, to prevent notes from dropping when playing "Live" (using a keyboard, gamepad or a MIDI keyboard).


![image](https://user-images.githubusercontent.com/24420253/174847555-59b23590-3950-4a2c-80a0-feca8b8fbe88.png)


This detects when two notes are played under the threshold set by the user, and will delay the second note to the set value. Since the game can only play one note each client-side frame, this delay should be set _higher than, but close to_ the expected frame length (ex: about 17ms for 60fps).

## Improvements

I didn't manage to make the input fields "responsive", would be nice if they were 😅
