### PR TITLE
[Siren] fix if song ends, no other songs will be able to be played

### DIFF
--- a/BardMusicPlayer.Maestro/Orchestrator.cs
+++ b/BardMusicPlayer.Maestro/Orchestrator.cs
@@ -141,7 +141,7 @@ namespace BardMusicPlayer.Maestro
 
                 if (helper.legacy)  //legacy mode
                 {
-                    string songName = $"{helper.channelType.ChannelCode} {helper.prefix} {song.Title} {helper.prefix}";
+                    string songName = $"{helper.channelType.ChannelShortCut} {helper.prefix} {song.Title} {helper.prefix}";
                     _song_Title_Parsing_Performer.Value.SendText(songName);
                 }
                 else //dalamud plugin

--- a/BardMusicPlayer.Seer/Game.cs
+++ b/BardMusicPlayer.Seer/Game.cs
@@ -218,6 +218,8 @@ namespace BardMusicPlayer.Seer
 
         public void SetAffinity(long AffinityMask)
         {
+            if (AffinityMask == 0)
+                return;
             this.Process.ProcessorAffinity = (IntPtr)AffinityMask;
         }
     }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/AlphaSynth.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/AlphaSynth.cs
@@ -145,8 +145,16 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
             };
             Output.Finished += () =>
             {
-                // stop everything
-                Stop();
+                //The Ui will trigger Stop() to reduce the CPU load
+                //If stop is triggered here, there's no playback possible anymore
+                {
+                    State = PlayerState.Paused;
+                    OnStateChanged(new PlayerStateChangedEventArgs(State, false));
+                    _sequencer.Stop();
+                    _synthesizer.NoteOffAll(true);
+                    TickPosition = _sequencer.PlaybackRange != null ? _sequencer.PlaybackRange.StartTick : 0;
+                }
+
                 Logger.Debug("AlphaSynth", "Finished playback");
                 OnFinished();
                 if (_sequencer.IsLooping)

--- a/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml
+++ b/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml
@@ -118,11 +118,11 @@
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="50"/>
                             <ColumnDefinition Width="50"/>
-                            <ColumnDefinition Width="50"/>
+                            <ColumnDefinition Width="80"/>
                         </Grid.ColumnDefinitions>
                         <Button Grid.Column="0" x:Name="Save_CPU" Content="Set" Click="Save_CPU_Click"/>
                         <Button Grid.Column="1" x:Name="Clear_CPU" Content="Clear" Click="Clear_CPU_Click"/>
-                        <Button Grid.Column="2" x:Name="Reset_CPU" Content="Reset" Click="Reset_CPU_Click"/>
+                        <Button Grid.Column="2" x:Name="Reset_CPU" Content="All Processors" Click="Reset_CPU_Click"/>
                     </Grid>
                 </Grid>
             </TabItem>

--- a/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml.cs
+++ b/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml.cs
@@ -198,7 +198,15 @@ namespace BardMusicPlayer.Ui.Controls
                     mask += 0b0 << idx;
                 idx++;
             }
-            _performer.game.SetAffinity(mask);
+            //If mask == 0 show an error
+            if (mask == 0)
+            {
+                var result = MessageBox.Show("No CPU was selected", "Error Affinity", MessageBoxButton.OK, MessageBoxImage.Error);
+                if (result == MessageBoxResult.OK)
+                    return;
+            }
+            else
+                _performer.game.SetAffinity(mask);
         }
 
         private void Clear_CPU_Click(object sender, RoutedEventArgs e)
@@ -217,7 +225,5 @@ namespace BardMusicPlayer.Ui.Controls
             }
         }
         #endregion
-
-
     }
 }

--- a/BardMusicPlayer/UI_Classic/Classic_MainView.xaml
+++ b/BardMusicPlayer/UI_Classic/Classic_MainView.xaml
@@ -246,20 +246,22 @@
                                 <ColumnDefinition Width="30*"/>
                                 <ColumnDefinition Width="60*"/>
                             </Grid.ColumnDefinitions>
+<!--
                             <Label Grid.Row="1" Grid.Column="0" Content="Beats per minute" />
                             <Label Grid.Row="1" Grid.Column="1" x:Name="Statistics_BPM_Label" />
+-->
+                            <Label Grid.Row="1" Grid.Column="0" Content="Total tracks" />
+                            <Label Grid.Row="1" Grid.Column="1" x:Name="Statistics_Total_Tracks_Label" />
 
-                            <Label Grid.Row="2" Grid.Column="0" Content="Total tracks" />
-                            <Label Grid.Row="2" Grid.Column="1" x:Name="Statistics_Total_Tracks_Label" />
+                            <Label Grid.Row="2" Grid.Column="0" Content="Total note count" />
+                            <Label Grid.Row="2" Grid.Column="1" x:Name="Statistics_Total_Note_Count_Label" />
 
-                            <Label Grid.Row="3" Grid.Column="0" Content="Total note count" />
-                            <Label Grid.Row="3" Grid.Column="1" x:Name="Statistics_Total_Note_Count_Label" />
-
-                            <Label Grid.Row="4" Grid.Column="0" Content="Track note count" />
-                            <Label Grid.Row="4" Grid.Column="1" x:Name="Statistics_Track_Note_Count_Label" />
-
+                            <Label Grid.Row="3" Grid.Column="0" Content="Track note count" />
+                            <Label Grid.Row="3" Grid.Column="1" x:Name="Statistics_Track_Note_Count_Label" />
+<!--
                             <Label Grid.Row="5" Grid.Column="0" Content="Note per second" />
                             <Label Grid.Row="5" Grid.Column="1" x:Name="Statistics_Note_Per_Second_Label" />
+-->
                         </Grid>
                     </TabItem>
                     <TabItem Header="Song Preview">

--- a/BardMusicPlayer/UI_Classic/Classic_Siren.cs
+++ b/BardMusicPlayer/UI_Classic/Classic_Siren.cs
@@ -106,6 +106,10 @@ namespace BardMusicPlayer.Ui.Classic
         /// <param name="endTime"></param>
         private void Siren_PlaybackTimeChanged(double currentTime, double endTime)
         {
+            //if we are finished, stop the playback
+            if (currentTime >= endTime)
+                BmpSiren.Instance.Stop();
+
             TimeSpan t;
             if (Siren_Position.Maximum != endTime)
             {

--- a/BardMusicPlayer/UI_Skinned/Playlist/Skinned_PlaylistView_Siren.cs
+++ b/BardMusicPlayer/UI_Skinned/Playlist/Skinned_PlaylistView_Siren.cs
@@ -28,6 +28,10 @@ namespace BardMusicPlayer.Ui.Skinned
         /// </summary>
         private void Instance_SynthTimePositionChanged(string songTitle, double currentTime, double endTime, int activeVoices)
         {
+            //if we are finished, stop the playback
+            if (currentTime >= endTime)
+                BmpSiren.Instance.Stop();
+
             //Scrolling
             if (lasttime + 500 < currentTime)
             {


### PR DESCRIPTION
Fixes: 
- https://github.com/BardMusicPlayer/BardMusicPlayer/issues/91
- https://github.com/BardMusicPlayer/BardMusicPlayer/issues/124

Partially Fixes:

- https://github.com/BardMusicPlayer/BardMusicPlayer/issues/127

Removed: 
- BPM in statistics tab, cause of confusion: https://github.com/BardMusicPlayer/BardMusicPlayer/issues/98