### PR TITLE
Fix sustain drop.

### DIFF
--- a/BardMusicPlayer.Transmogrify/Song/BmpSong.cs
+++ b/BardMusicPlayer.Transmogrify/Song/BmpSong.cs
@@ -425,10 +425,18 @@ namespace BardMusicPlayer.Transmogrify.Song
 
                         if (j + 1 < notesToFix.Count())
                         {
-                            if (notesToFix[j + 1].Time <= notesToFix[j].Time + notesToFix[j].Length + 25)
+                            // BACON MEOWCHESTRA
+                            // Bandaid fix: If sustained note is 100ms or greater, ensure 60ms between the end of that note and the beginning of the next note.
+                            // Otherwise, leave the behavior as it was before.
+                            if (notesToFix[j].Length >= 100 && notesToFix[j + 1].Time <= notesToFix[j].Time + notesToFix[j].Length + 60)
+                            {
+                                dur = notesToFix[j + 1].Time - notesToFix[j].Time - 60;
+                                dur = dur < 60 ? 60 : dur;
+                            }
+                            else if (notesToFix[j].Length < 100 && notesToFix[j + 1].Time <= notesToFix[j].Time + notesToFix[j].Length + 25)
                             {
                                 dur = notesToFix[j + 1].Time - notesToFix[j].Time - 25;
-                                dur = dur < 25 ? 1 : dur;
+                                dur = dur < 25 ? 25 : dur;
                             }
                         }
                         fixedNotes.Add(new Note(noteNum, dur, time)
@@ -797,10 +805,18 @@ namespace BardMusicPlayer.Transmogrify.Song
 
                         if (j + 1 < notesToFix.Count())
                         {
-                            if (notesToFix[j + 1].Time <= notesToFix[j].Time + notesToFix[j].Length + 25)
+                            // BACON MEOWCHESTRA
+                            // Bandaid fix: If sustained note is 100ms or greater, ensure 60ms between the end of that note and the beginning of the next note.
+                            // Otherwise, leave the behavior as it was before.
+                            if (notesToFix[j].Length >= 100 && notesToFix[j + 1].Time <= notesToFix[j].Time + notesToFix[j].Length + 60)
+                            {
+                                dur = notesToFix[j + 1].Time - notesToFix[j].Time - 60;
+                                dur = dur < 60 ? 60 : dur;
+                            }
+                            else if (notesToFix[j].Length < 100 && notesToFix[j + 1].Time <= notesToFix[j].Time + notesToFix[j].Length + 25)
                             {
                                 dur = notesToFix[j + 1].Time - notesToFix[j].Time - 25;
-                                dur = dur < 25 ? 1 : dur;
+                                dur = dur < 25 ? 25 : dur;
                             }
                         }
                         fixedNotes.Add(new Note(noteNum, dur, time)


### PR DESCRIPTION
* Fixing issue https://github.com/BardMusicPlayer/BardMusicPlayer/issues/158 with sustains being randomly dropped.
* Also fixing logic mistake of notes incorrectly being set to 1ms if less than 25ms to match ``25 ? 25`` logic used everywhere else.

75ms is probably a saner default if you want it changed but 60ms is tested to work fine and is tighter for slightly longer sustains.