### PR TITLE
Fix directory loading issues.

### DIFF
--- a/BardMusicPlayer/Functions/PlaybackFunctions.cs
+++ b/BardMusicPlayer/Functions/PlaybackFunctions.cs
@@ -36,6 +36,7 @@ namespace BardMusicPlayer.Ui.Functions
         {
             var openFileDialog = new OpenFileDialog
             {
+                InitialDirectory = Globals.Globals.DirectoryPath,
                 Filter = Globals.Globals.FileFilters,
                 Multiselect = true
             };
@@ -47,7 +48,9 @@ namespace BardMusicPlayer.Ui.Functions
                 return false;
 
             PlaybackState = PlaybackState_Enum.PLAYBACK_STATE_STOPPED;
-            
+
+			Globals.Globals.DirectoryPath = Path.GetDirectoryName(openFileDialog.FileName);
+
             CurrentSong = BmpSong.OpenFile(openFileDialog.FileName).Result;
             BmpMaestro.Instance.SetSong(CurrentSong);
             return true;

--- a/BardMusicPlayer/Globals/Globals.cs
+++ b/BardMusicPlayer/Globals/Globals.cs
@@ -8,6 +8,7 @@ namespace BardMusicPlayer.Ui.Globals
 {
     public static class Globals
     {
+        public static string DirectoryPath = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
         public static string FileFilters = "MIDI file|*.mid;*.midi;*.mmsong;*.mml";
         public static string MusicCatalogFilters = "Amp Catalog file|*.db";
         public static string DataPath;


### PR DESCRIPTION
* Fixes issue https://github.com/BardMusicPlayer/BardMusicPlayer/issues/152 with the directory path not resetting back to the last loaded directory of the current song on next song load.
* Also fixes it so the first-time searching of songs defaults to the directory of where the app is located. 
Useful so you don't come back a month later deep in some random folder or folder that may no longer exist.