### PR TITLE
Fix instruments sometimes not pulling out.

### DIFF
--- a/BardMusicPlayer.Seer/Reader/Backend/DatFile/HotbarDatFile.cs
+++ b/BardMusicPlayer.Seer/Reader/Backend/DatFile/HotbarDatFile.cs
@@ -114,7 +114,7 @@ namespace BardMusicPlayer.Seer.Reader.Backend.DatFile
         public string GetInstrumentKeyMap(Instrument instrument)
         {
             var slots = GetSlotsFromType(SlotType.Instrument);
-            foreach (var slot in slots.Where(slot => slot.Action == instrument))
+            foreach (var slot in slots.Where(slot => (slot.Action == instrument) && (slot.Job == 0x17) ))
             {
                 return slot.ToString();
             }


### PR DESCRIPTION
* Fixes issue https://github.com/BardMusicPlayer/BardMusicPlayer/issues/156 with instruments failing to open.

This is caused entirely by if the client has performance instrument actions on hotbars across multiple jobs. Opening this fix ahead of Kalle but can be closed if superseded by a future PR which contains the commit change.