### PR TITLE
Fix play button not returning on close.

### DIFF
--- a/BardMusicPlayer/Controls/BardView.xaml.cs
+++ b/BardMusicPlayer/Controls/BardView.xaml.cs
@@ -13,6 +13,8 @@ using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Linq;
+using BardMusicPlayer.Ui.Classic;
+using BardMusicPlayer.Ui.Functions;
 
 namespace BardMusicPlayer.Ui.Controls
 {
@@ -104,6 +106,13 @@ namespace BardMusicPlayer.Ui.Controls
 
         private void CloseInstrumentButton_Click(object sender, RoutedEventArgs e)
         {
+            if (PlaybackFunctions.PlaybackState == PlaybackFunctions.PlaybackState_Enum.PLAYBACK_STATE_PLAYING)
+            {
+                PlaybackFunctions.PauseSong();
+                Classic_MainView.CurrentInstance.Play_Button_State(false);
+            }
+
+            BmpMaestro.Instance.StopLocalPerformer();
             BmpMaestro.Instance.UnEquipInstruments();
         }
 

--- a/BardMusicPlayer/UI_Classic/Classic_MainView.xaml.cs
+++ b/BardMusicPlayer/UI_Classic/Classic_MainView.xaml.cs
@@ -18,9 +18,11 @@ namespace BardMusicPlayer.Ui.Classic
         private int MaxTracks = 1;
         private bool _directLoaded { get; set; } = false; //indicates if a song was loaded directly or from playlist
         //private NetworkPlayWindow _networkWindow = null;
+        public static Classic_MainView CurrentInstance { get; private set; }
         public Classic_MainView()
         {
             InitializeComponent();
+            CurrentInstance = this;
             //Always start with the playlists
             _showingPlaylists = true;
             //Fill the list

--- a/BardMusicPlayer/UI_Classic/Classic_MainViewPlaycontrols.cs
+++ b/BardMusicPlayer/UI_Classic/Classic_MainViewPlaycontrols.cs
@@ -19,7 +19,7 @@ namespace BardMusicPlayer.Ui.Classic
         private bool _Siren_Playbar_dragStarted = false;
 
         /* Playbuttonstate */
-        private void Play_Button_State(bool playing = false)
+        public void Play_Button_State(bool playing = false)
         {
             if (!playing)
                 Play_Button.Content = @"▶";


### PR DESCRIPTION
* Fixes issue https://github.com/BardMusicPlayer/BardMusicPlayer/issues/106 with notes sending key presses after you click stop.
* Also fixes issue with close button not returning from pause icon back to play icon if you close with the close button.