### PR TITLE
Disable Chat

### DIFF
--- a/BardMusicPlayer/UI_Classic/Classic_MainView.xaml
+++ b/BardMusicPlayer/UI_Classic/Classic_MainView.xaml
@@ -131,7 +131,7 @@
                     <ColumnDefinition Width="275*"/>
                 </Grid.ColumnDefinitions>
                 <TabControl Grid.ColumnSpan="2">
-                    <TabItem Header="[Chat] All">
+                    <!-- <TabItem Header="[Chat] All">
                         <RichTextBox x:Name="ChatBox" IsReadOnly="False" ScrollViewer.VerticalScrollBarVisibility="Auto" ScrollViewer.IsDeferredScrollingEnabled="True" Background="Gray">
                             <RichTextBox.Style>
                                 <Style TargetType="RichTextBox">
@@ -146,7 +146,7 @@
                                 </Style>
                             </RichTextBox.Style>
                         </RichTextBox>
-                    </TabItem>
+                    </TabItem> -->
                     <TabItem Header="Performers">
                         <Grid Background="WhiteSmoke">
                             <control:BardView x:Name="BardsList"/>

--- a/BardMusicPlayer/UI_Classic/Classic_MainView.xaml.cs
+++ b/BardMusicPlayer/UI_Classic/Classic_MainView.xaml.cs
@@ -192,11 +192,11 @@ namespace BardMusicPlayer.Ui.Classic
 
         public void AppendChatLog(Seer.Events.ChatLog ev)
         {
-            if (BmpMaestro.Instance.GetHostPid() == ev.ChatLogGame.Pid)
+            /*if (BmpMaestro.Instance.GetHostPid() == ev.ChatLogGame.Pid)
             {
                 BmpChatParser.AppendText(ChatBox, ev);
                 this.ChatBox.ScrollToEnd();
-            }
+            }*/
 
             if (ev.ChatLogCode == "0039")
             {


### PR DESCRIPTION
* Disable chat tab
* Don't append logs

This is kind of useless because you can just look at your game if you want to see chat. It also is a slow memory leak since there is no maximum chat lines in the window or any clean-up the longer the app is running.