### PR TITLE
Send ensemble without requiring host on party lead

### DIFF
--- a/BardMusicPlayer.Maestro/BmpMaestro.cs
+++ b/BardMusicPlayer.Maestro/BmpMaestro.cs
@@ -266,8 +266,7 @@ namespace BardMusicPlayer.Maestro
             
             var perf = _orchestrator.GetAllPerformers();
             foreach (var p in perf)
-                if (p.HostProcess)
-                    p.DoReadyCheck();
+                p.DoReadyCheck();
         }
 
         /// <summary>


### PR DESCRIPTION
While it is a good idea to only send ensemble from the actual party leader, requiring the host box to be selected on the lead manually is not a hands-off approach.

If the in-game leader ever changes due to disconnects, game crashes, or handoffs, or you restart the app for whatever reason (causing the host box to change), the ensemble button won't work until you re-select manually who the leader is. Since the game doesn't accept ensemble start requests unless you are party leader, there doesn't seem to be any harm in all clients making the attempt. This brings behavior closer to how MogAmp/Doot did it.

Better behavior would be;
* Auto-detecting who the party leader is to select them as host / make the attempt.
* Sorting host / your main client at the top of the performers list so it's less tedious to select if at the bottom of the list.