### PR TITLE
Partially implement up/down functionality to performers tab boxes

### DIFF
--- a/BardMusicPlayer/Controls/OctaveNumericUpDown.xaml
+++ b/BardMusicPlayer/Controls/OctaveNumericUpDown.xaml
@@ -11,7 +11,7 @@
             <ColumnDefinition Width="10"/>
         </Grid.ColumnDefinitions>
         <!-- Track Selection-->
-        <TextBox Grid.Column="0" x:Name="Text" TextChanged="TextChanged" TextAlignment="Center" FontSize="14" HorizontalAlignment="Right" Width="28" Height="25" VerticalAlignment="Top" />
+        <TextBox Grid.Column="0" x:Name="Text" TextChanged="TextChanged" TextAlignment="Center" FontSize="14" HorizontalAlignment="Right" Width="28" Height="25" VerticalAlignment="Top" KeyUp="OctaveNumericUpDown_Key"/>
         <Grid Grid.Column="1" Margin="0,0,-7,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="*"/>

--- a/BardMusicPlayer/Controls/OctaveNumericUpDown.xaml.cs
+++ b/BardMusicPlayer/Controls/OctaveNumericUpDown.xaml.cs
@@ -64,6 +64,21 @@ namespace BardMusicPlayer.Ui.Controls
             NumValue--;
         }
 
+        private void OctaveNumericUpDown_Key(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            switch (e.Key)
+            {
+                case System.Windows.Input.Key.Up:
+                    NumUp_Click(sender, e);
+                    break;
+                case System.Windows.Input.Key.Down:
+                    NumDown_Click(sender, e);
+                    break;
+                default:
+                    break;
+            }
+        }
+
         private void TextChanged(object sender, TextChangedEventArgs e)
         {
             if (Text == null)

--- a/BardMusicPlayer/Controls/TrackNumericUpDown.xaml
+++ b/BardMusicPlayer/Controls/TrackNumericUpDown.xaml
@@ -11,7 +11,7 @@
             <ColumnDefinition Width="10"/>
         </Grid.ColumnDefinitions>
         <!-- Track Selection-->
-        <TextBox Grid.Column="0" x:Name="Text" TextChanged="TextChanged" TextAlignment="Center" FontSize="14" HorizontalAlignment="Right" Width="28" Height="25" VerticalAlignment="Top" />
+        <TextBox Grid.Column="0" x:Name="Text" TextChanged="TextChanged" TextAlignment="Center" FontSize="14" HorizontalAlignment="Right" Width="28" Height="25" VerticalAlignment="Top" KeyUp="TrackNumericUpDown_Key"/>
         <Grid Grid.Column="1" Margin="0,0,-7,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="*"/>

--- a/BardMusicPlayer/Controls/TrackNumericUpDown.xaml.cs
+++ b/BardMusicPlayer/Controls/TrackNumericUpDown.xaml.cs
@@ -54,6 +54,7 @@ namespace BardMusicPlayer.Ui.Controls
                 return;
             }
         }
+
         private void NumUp_Click(object sender, RoutedEventArgs e)
         {
             if (PlaybackFunctions.CurrentSong == null)
@@ -70,6 +71,19 @@ namespace BardMusicPlayer.Ui.Controls
             NumValue--;
         }
 
+        private void TrackNumericUpDown_Key(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            switch (e.Key)
+            {
+                case System.Windows.Input.Key.Up:
+                    NumUp_Click(sender, e);
+                    break;
+                case System.Windows.Input.Key.Down:
+                    NumDown_Click(sender, e);
+                    break;
+            }
+        }
+        
         private void TextChanged(object sender, TextChangedEventArgs e)
         {
             if (Text == null)


### PR DESCRIPTION
https://github.com/BardMusicPlayer/BardMusicPlayer/issues/178

* Partially implement functionality to use arrow keys on track & octave boxes in performers tab.

However seems to lose focus when the text is changed so you have to continuously click in the box each time you use your keyboard arrow keys instead of the UI arrows.