### PR TITLE
Revert AutostartMethod

### DIFF
--- a/BardMusicPlayer.Maestro/Orchestrator.cs
+++ b/BardMusicPlayer.Maestro/Orchestrator.cs
@@ -719,7 +719,7 @@ namespace BardMusicPlayer.Maestro
         /// <param name="seerEvent"></param>
         private void Instance_EnsembleStarted(Seer.Events.EnsembleStarted seerEvent)
         {
-            if (BmpPigeonhole.Instance.AutostartMethod != AutostartMethod.EnsembleMetronome)
+            if (BmpPigeonhole.Instance.AutostartMethod != 1)
                 return;
 
             start(0, seerEvent.Game.Pid);
@@ -731,7 +731,7 @@ namespace BardMusicPlayer.Maestro
         /// <param name="seerEvent"></param>
         private void Instance_EnsembleStopped(Seer.Events.EnsembleStopped seerEvent)
         {
-            if (BmpPigeonhole.Instance.AutostartMethod != AutostartMethod.EnsembleMetronome)
+            if (BmpPigeonhole.Instance.AutostartMethod != 1)
                 return;
 
             if (_performers.Count() == 0)

--- a/BardMusicPlayer.Pigeonhole/BmpPigeonhole.cs
+++ b/BardMusicPlayer.Pigeonhole/BmpPigeonhole.cs
@@ -66,7 +66,7 @@ namespace BardMusicPlayer.Pigeonhole
         /// <summary>
         /// Sets the autostart method
         /// </summary>
-        public virtual AutostartMethod AutostartMethod { get; set; } = AutostartMethod.EnsembleMetronome;
+        public virtual int AutostartMethod { get; set; } = 1;
 
         /// <summary>
         /// Sets UnequipPause

--- a/BardMusicPlayer/UI_Classic/Classic_Settings.cs
+++ b/BardMusicPlayer/UI_Classic/Classic_Settings.cs
@@ -32,8 +32,8 @@ namespace BardMusicPlayer.Ui.Classic
             LiveMidiDelay.IsChecked = BmpPigeonhole.Instance.LiveMidiPlayDelay;
 
             //Misc
-            this.Autostart_source.SelectedIndex = (int)BmpPigeonhole.Instance.AutostartMethod;
-            this.AutoequipDalamud.IsChecked = BmpPigeonhole.Instance.UsePluginForInstrumentOpen;
+            this.Autostart_source.SelectedIndex = BmpPigeonhole.Instance.AutostartMethod;
+            this.AutoequipDalamud.IsChecked     = BmpPigeonhole.Instance.UsePluginForInstrumentOpen;
 
             //Local orchestra
             this.LocalOrchestraBox.IsChecked = BmpPigeonhole.Instance.LocalOrchestra;
@@ -81,7 +81,7 @@ namespace BardMusicPlayer.Ui.Classic
         private void Autostart_source_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             int d = Autostart_source.SelectedIndex;
-            BmpPigeonhole.Instance.AutostartMethod = (AutostartMethod)d;
+            BmpPigeonhole.Instance.AutostartMethod = (int)d;
         }
 
         private void AutoequipDalamud_Checked(object sender, RoutedEventArgs e)


### PR DESCRIPTION
* Temporarily revert changes to AutostartMethod to fix start functionality working and UI option displaying by default at first launch.

This will re-introduce a breaking config change for people who have ``"AutostartMethod": 2,`` already set but reselecting the option in the UI or a fresh data folder works fine.