### PR TITLE
Correct Naming

### DIFF
--- a/BardMusicPlayer/Controls/NetworkWindow.xaml
+++ b/BardMusicPlayer/Controls/NetworkWindow.xaml
@@ -10,7 +10,7 @@
     <UserControl.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="pack://application:,,,/LightAmp;component/Resources/ImageButtonStyle.xaml"/>
+                <ResourceDictionary Source="pack://application:,,,/BardMusicPlayer;component/Resources/ImageButtonStyle.xaml"/>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
 

--- a/BardMusicPlayer/Globals/InfoBox.xaml
+++ b/BardMusicPlayer/Globals/InfoBox.xaml
@@ -15,7 +15,6 @@
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" Grid.Row="0" Text="LightAmp" VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="26" Foreground="#FFFFD200" FontFamily="Comic Sans MS"/>
             <Grid Grid.Column="0" Grid.Row="2">
                 <Border Width="500" HorizontalAlignment="Center" VerticalAlignment="Center" Height="25" ClipToBounds="True" BorderThickness="1.5" BorderBrush="Transparent">
                     <Border x:Name="moving_border">
@@ -45,7 +44,6 @@
                     </Border>
                 </Border>
             </Grid>
-            <TextBlock Grid.Column="0" Grid.Row="3" Text="Special thanks to the BoL crew." VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="18" Foreground="#FFFFD200" FontFamily="Comic Sans MS"/>
         </Grid>
     </Grid>
 </Window>

--- a/BardMusicPlayer/UI_Classic/Classic_Siren.cs
+++ b/BardMusicPlayer/UI_Classic/Classic_Siren.cs
@@ -285,7 +285,7 @@ namespace BardMusicPlayer.UI_Classic
                 file.WriteLine("[ti:" + BmpSiren.Instance.CurrentSong.DisplayedTitle + "]");
             else
                 file.WriteLine("[ti:" + BmpSiren.Instance.CurrentSong.Title + "]");
-            file.WriteLine("[re:LightAmp]");
+            file.WriteLine("[re:BardMusicPlayer]");
             file.WriteLine("[ve:" + Assembly.GetExecutingAssembly().GetName().Version + "]");
 
             foreach (var l in lyricsData)


### PR DESCRIPTION
* Renamed most LightAmp references (except LightAmp-DalamudBridge) back to BMP.

InfoBox.xaml will have to be redone to look better in the future.