### PR TITLE
Modernize & Optimize Jamboree

### DIFF
--- a/BardMusicPlayer.Jamboree/BmpJamboree.cs
+++ b/BardMusicPlayer.Jamboree/BmpJamboree.cs
@@ -5,18 +5,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.Net;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using BardMusicPlayer.Jamboree.PartyClient.PartyManagement;
-using ZeroTier.Core;
 
 namespace BardMusicPlayer.Jamboree
 {
     public partial class BmpJamboree : IDisposable
     {
-        private Pydna _pydna = null;
+        private Pydna _pydna;
 
 #region Instance Constructor/Destructor
         private static readonly Lazy<BmpJamboree> LazyInstance = new(() => new BmpJamboree());

--- a/BardMusicPlayer.Jamboree/BmpJamboree.cs
+++ b/BardMusicPlayer.Jamboree/BmpJamboree.cs
@@ -8,104 +8,103 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using BardMusicPlayer.Jamboree.PartyClient.PartyManagement;
 
-namespace BardMusicPlayer.Jamboree
+namespace BardMusicPlayer.Jamboree;
+
+public partial class BmpJamboree : IDisposable
 {
-    public partial class BmpJamboree : IDisposable
+    private Pydna _pydna;
+
+    #region Instance Constructor/Destructor
+    private static readonly Lazy<BmpJamboree> LazyInstance = new(() => new BmpJamboree());
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public bool Started { get; private set; }
+
+
+    private BmpJamboree()
     {
-        private Pydna _pydna;
-
-#region Instance Constructor/Destructor
-        private static readonly Lazy<BmpJamboree> LazyInstance = new(() => new BmpJamboree());
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public bool Started { get; private set; }
-
-
-        private BmpJamboree()
-        {
-            _pydna = new Pydna();
-        }
-
-        public static BmpJamboree Instance => LazyInstance.Value;
-
-        /// <summary>
-        /// Start the eventhandler
-        /// </summary>
-        /// <returns></returns>
-        public void Start()
-        {
-            if (Started) return;
-            StartEventsHandler();
-            Started = true;
-        }
-
-        /// <summary>
-        /// Stop the eventhandler
-        /// </summary>
-        /// <returns></returns>
-        public void Stop()
-        {
-            if (!Started) return;
-            StopEventsHandler();
-            Started = false;
-        }
-
-        ~BmpJamboree() { Dispose(); }
-
-        public void Dispose()
-        {
-            Stop();
-            GC.SuppressFinalize(this);
-        }
-#endregion
-
-        public void JoinParty(string networkId, byte type, string name)
-        {
-            _pydna ??= new Pydna();
-            Task.Run(() => _pydna.JoinParty(networkId, type, name));
-        }
-
-        public void LeaveParty()
-        {
-            _pydna ??= new Pydna();
-            _pydna.LeaveParty();
-        }
-
-        public void SendPerformanceStart()
-        {
-            _pydna ??= new Pydna();
-            Pydna.SendPerformanceStart();
-        }
-
-        /// <summary>
-        /// Send we joined the party
-        /// | type 0 = bard
-        /// | type 1 = dancer
-        /// </summary>
-        /// <param name="type"></param>
-        /// <param name="performer_name"></param>
-        public void SendPerformerJoin(byte type, string performer_name)
-        {
-            _pydna ??= new Pydna();
-            _pydna.SendPerformerJoin(type, performer_name);
-        }
-
-        public void SendClientPacket(byte[] packet)
-        {
-            _pydna?.SendClientPacket(packet);
-        }
-
-        public void SendServerPacket(byte [] packet)
-        {
-            _pydna?.SendServerPacket(packet);
-        }
-
-        public List<PartyClientInfo> GetPartyMembers()
-        {
-            return PartyManager.Instance.GetPartyMembers();
-        }
-
+        _pydna = new Pydna();
     }
+
+    public static BmpJamboree Instance => LazyInstance.Value;
+
+    /// <summary>
+    /// Start the eventhandler
+    /// </summary>
+    /// <returns></returns>
+    public void Start()
+    {
+        if (Started) return;
+        StartEventsHandler();
+        Started = true;
+    }
+
+    /// <summary>
+    /// Stop the eventhandler
+    /// </summary>
+    /// <returns></returns>
+    public void Stop()
+    {
+        if (!Started) return;
+        StopEventsHandler();
+        Started = false;
+    }
+
+    ~BmpJamboree() { Dispose(); }
+
+    public void Dispose()
+    {
+        Stop();
+        GC.SuppressFinalize(this);
+    }
+    #endregion
+
+    public void JoinParty(string networkId, byte type, string name)
+    {
+        _pydna ??= new Pydna();
+        Task.Run(() => _pydna.JoinParty(networkId, type, name));
+    }
+
+    public void LeaveParty()
+    {
+        _pydna ??= new Pydna();
+        _pydna.LeaveParty();
+    }
+
+    public void SendPerformanceStart()
+    {
+        _pydna ??= new Pydna();
+        Pydna.SendPerformanceStart();
+    }
+
+    /// <summary>
+    /// Send we joined the party
+    /// | type 0 = bard
+    /// | type 1 = dancer
+    /// </summary>
+    /// <param name="type"></param>
+    /// <param name="performer_name"></param>
+    public void SendPerformerJoin(byte type, string performer_name)
+    {
+        _pydna ??= new Pydna();
+        _pydna.SendPerformerJoin(type, performer_name);
+    }
+
+    public void SendClientPacket(byte[] packet)
+    {
+        _pydna?.SendClientPacket(packet);
+    }
+
+    public void SendServerPacket(byte [] packet)
+    {
+        _pydna?.SendServerPacket(packet);
+    }
+
+    public List<PartyClientInfo> GetPartyMembers()
+    {
+        return PartyManager.Instance.GetPartyMembers();
+    }
+
 }

--- a/BardMusicPlayer.Jamboree/BmpJamboree.cs
+++ b/BardMusicPlayer.Jamboree/BmpJamboree.cs
@@ -63,23 +63,20 @@ namespace BardMusicPlayer.Jamboree
 
         public void JoinParty(string networkId, byte type, string name)
         {
-            if(_pydna == null)
-                _pydna = new Pydna();
+            _pydna ??= new Pydna();
             Task.Run(() => _pydna.JoinParty(networkId, type, name));
         }
 
         public void LeaveParty()
         {
-            if (_pydna == null)
-                _pydna = new Pydna();
+            _pydna ??= new Pydna();
             _pydna.LeaveParty();
         }
 
         public void SendPerformanceStart()
         {
-            if (_pydna == null)
-                _pydna = new Pydna();
-            _pydna.SendPerformanceStart();
+            _pydna ??= new Pydna();
+            Pydna.SendPerformanceStart();
         }
 
         /// <summary>
@@ -91,23 +88,18 @@ namespace BardMusicPlayer.Jamboree
         /// <param name="performer_name"></param>
         public void SendPerformerJoin(byte type, string performer_name)
         {
-            if (_pydna == null)
-                _pydna = new Pydna();
+            _pydna ??= new Pydna();
             _pydna.SendPerformerJoin(type, performer_name);
         }
 
         public void SendClientPacket(byte[] packet)
         {
-            if (_pydna == null)
-                return;
-            _pydna.SendClientPacket(packet);
+            _pydna?.SendClientPacket(packet);
         }
 
         public void SendServerPacket(byte [] packet)
         {
-            if (_pydna == null)
-                return;
-            _pydna.SendServerPacket(packet);
+            _pydna?.SendServerPacket(packet);
         }
 
         public List<PartyClientInfo> GetPartyMembers()

--- a/BardMusicPlayer.Jamboree/BmpJamboreeEvents.cs
+++ b/BardMusicPlayer.Jamboree/BmpJamboreeEvents.cs
@@ -61,10 +61,12 @@ namespace BardMusicPlayer.Jamboree
                                     break;
                                 OnPerformanceStart(this, performanceStart);
                                 break;
-                        };
+                        }
                     }
                     catch
-                    { }
+                    {
+                        // ignored
+                    }
                 }
                 await Task.Delay(25, token).ContinueWith(tsk => { });
             }

--- a/BardMusicPlayer.Jamboree/BmpJamboreeEvents.cs
+++ b/BardMusicPlayer.Jamboree/BmpJamboreeEvents.cs
@@ -32,34 +32,22 @@ namespace BardMusicPlayer.Jamboree
                         switch (meastroEvent)
                         {
                             case PartyCreatedEvent partyCreated:
-                                if (OnPartyCreated == null)
-                                    break;
-                                OnPartyCreated(this, partyCreated);
+                                OnPartyCreated?.Invoke(this, partyCreated);
                                 break;
                             case PartyLogEvent partyLog:
-                                if (OnPartyLog == null)
-                                    break;
-                                OnPartyLog(this, partyLog);
+                                OnPartyLog?.Invoke(this, partyLog);
                                 break;
                             case PartyDebugLogEvent partyDebugLog:
-                                if (OnPartyDebugLog == null)
-                                    break;
-                                OnPartyDebugLog(this, partyDebugLog);
+                                OnPartyDebugLog?.Invoke(this, partyDebugLog);
                                 break;
                             case PartyConnectionChangedEvent connectionChanged:
-                                if (OnPartyConnectionChanged == null)
-                                    break;
-                                OnPartyConnectionChanged(this, connectionChanged);
+                                OnPartyConnectionChanged?.Invoke(this, connectionChanged);
                                 break;
                             case PartyChangedEvent partyChanged:
-                                if (OnPartyChanged == null)
-                                    break;
-                                OnPartyChanged(this, partyChanged);
+                                OnPartyChanged?.Invoke(this, partyChanged);
                                 break;
                             case PerformanceStartEvent performanceStart:
-                                if (OnPerformanceStart == null)
-                                    break;
-                                OnPerformanceStart(this, performanceStart);
+                                OnPerformanceStart?.Invoke(this, performanceStart);
                                 break;
                         }
                     }
@@ -68,7 +56,7 @@ namespace BardMusicPlayer.Jamboree
                         // ignored
                     }
                 }
-                await Task.Delay(25, token).ContinueWith(tsk => { });
+                await Task.Delay(25, token).ContinueWith(tsk => { }, token);
             }
         }
 
@@ -91,12 +79,12 @@ namespace BardMusicPlayer.Jamboree
             }
         }
 
-        internal void PublishEvent(JamboreeEvent meastroEvent)
+        internal void PublishEvent(JamboreeEvent maestroEvent)
         {
             if (!_eventQueueOpen)
                 return;
 
-            _eventQueue.Enqueue(meastroEvent);
+            _eventQueue.Enqueue(maestroEvent);
         }
     }
 }

--- a/BardMusicPlayer.Jamboree/BmpJamboreeEvents.cs
+++ b/BardMusicPlayer.Jamboree/BmpJamboreeEvents.cs
@@ -4,87 +4,86 @@ using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace BardMusicPlayer.Jamboree
+namespace BardMusicPlayer.Jamboree;
+
+public partial class BmpJamboree
 {
-    public partial class BmpJamboree
+    public EventHandler<PartyCreatedEvent> OnPartyCreated;
+    public EventHandler<PartyLogEvent> OnPartyLog;
+    public EventHandler<PartyDebugLogEvent> OnPartyDebugLog;
+    public EventHandler<PartyConnectionChangedEvent> OnPartyConnectionChanged;
+    public EventHandler<PartyChangedEvent> OnPartyChanged;
+    public EventHandler<PerformanceStartEvent> OnPerformanceStart;
+
+    private ConcurrentQueue<JamboreeEvent> _eventQueue;
+    private bool _eventQueueOpen;
+
+    private async Task RunEventsHandler(CancellationToken token)
     {
-        public EventHandler<PartyCreatedEvent> OnPartyCreated;
-        public EventHandler<PartyLogEvent> OnPartyLog;
-        public EventHandler<PartyDebugLogEvent> OnPartyDebugLog;
-        public EventHandler<PartyConnectionChangedEvent> OnPartyConnectionChanged;
-        public EventHandler<PartyChangedEvent> OnPartyChanged;
-        public EventHandler<PerformanceStartEvent> OnPerformanceStart;
-
-        private ConcurrentQueue<JamboreeEvent> _eventQueue;
-        private bool _eventQueueOpen;
-
-        private async Task RunEventsHandler(CancellationToken token)
+        while (!token.IsCancellationRequested)
         {
-            while (!token.IsCancellationRequested)
+            while (_eventQueue.TryDequeue(out var meastroEvent))
             {
-                while (_eventQueue.TryDequeue(out var meastroEvent))
-                {
-                    if (token.IsCancellationRequested)
-                        break;
+                if (token.IsCancellationRequested)
+                    break;
 
-                    try
+                try
+                {
+                    switch (meastroEvent)
                     {
-                        switch (meastroEvent)
-                        {
-                            case PartyCreatedEvent partyCreated:
-                                OnPartyCreated?.Invoke(this, partyCreated);
-                                break;
-                            case PartyLogEvent partyLog:
-                                OnPartyLog?.Invoke(this, partyLog);
-                                break;
-                            case PartyDebugLogEvent partyDebugLog:
-                                OnPartyDebugLog?.Invoke(this, partyDebugLog);
-                                break;
-                            case PartyConnectionChangedEvent connectionChanged:
-                                OnPartyConnectionChanged?.Invoke(this, connectionChanged);
-                                break;
-                            case PartyChangedEvent partyChanged:
-                                OnPartyChanged?.Invoke(this, partyChanged);
-                                break;
-                            case PerformanceStartEvent performanceStart:
-                                OnPerformanceStart?.Invoke(this, performanceStart);
-                                break;
-                        }
-                    }
-                    catch
-                    {
-                        // ignored
+                        case PartyCreatedEvent partyCreated:
+                            OnPartyCreated?.Invoke(this, partyCreated);
+                            break;
+                        case PartyLogEvent partyLog:
+                            OnPartyLog?.Invoke(this, partyLog);
+                            break;
+                        case PartyDebugLogEvent partyDebugLog:
+                            OnPartyDebugLog?.Invoke(this, partyDebugLog);
+                            break;
+                        case PartyConnectionChangedEvent connectionChanged:
+                            OnPartyConnectionChanged?.Invoke(this, connectionChanged);
+                            break;
+                        case PartyChangedEvent partyChanged:
+                            OnPartyChanged?.Invoke(this, partyChanged);
+                            break;
+                        case PerformanceStartEvent performanceStart:
+                            OnPerformanceStart?.Invoke(this, performanceStart);
+                            break;
                     }
                 }
-                await Task.Delay(25, token).ContinueWith(tsk => { }, token);
+                catch
+                {
+                    // ignored
+                }
             }
+            await Task.Delay(25, token).ContinueWith(tsk => { }, token);
         }
+    }
 
-        private CancellationTokenSource _eventsTokenSource;
+    private CancellationTokenSource _eventsTokenSource;
 
-        private void StartEventsHandler()
+    private void StartEventsHandler()
+    {
+        _eventQueue        = new ConcurrentQueue<JamboreeEvent>();
+        _eventsTokenSource = new CancellationTokenSource();
+        Task.Factory.StartNew(() => RunEventsHandler(_eventsTokenSource.Token), TaskCreationOptions.LongRunning);
+        _eventQueueOpen = true;
+    }
+
+    private void StopEventsHandler()
+    {
+        _eventQueueOpen = false;
+        _eventsTokenSource.Cancel();
+        while (_eventQueue.TryDequeue(out _))
         {
-            _eventQueue = new ConcurrentQueue<JamboreeEvent>();
-            _eventsTokenSource = new CancellationTokenSource();
-            Task.Factory.StartNew(() => RunEventsHandler(_eventsTokenSource.Token), TaskCreationOptions.LongRunning);
-            _eventQueueOpen = true;
         }
+    }
 
-        private void StopEventsHandler()
-        {
-            _eventQueueOpen = false;
-            _eventsTokenSource.Cancel();
-            while (_eventQueue.TryDequeue(out _))
-            {
-            }
-        }
+    internal void PublishEvent(JamboreeEvent maestroEvent)
+    {
+        if (!_eventQueueOpen)
+            return;
 
-        internal void PublishEvent(JamboreeEvent maestroEvent)
-        {
-            if (!_eventQueueOpen)
-                return;
-
-            _eventQueue.Enqueue(maestroEvent);
-        }
+        _eventQueue.Enqueue(maestroEvent);
     }
 }

--- a/BardMusicPlayer.Jamboree/Events/JamboreeEvent.cs
+++ b/BardMusicPlayer.Jamboree/Events/JamboreeEvent.cs
@@ -1,30 +1,29 @@
 ﻿using System;
 using BardMusicPlayer.Quotidian.UtcMilliTime;
 
-namespace BardMusicPlayer.Jamboree.Events
+namespace BardMusicPlayer.Jamboree.Events;
+
+public abstract class JamboreeEvent
 {
-    public abstract class JamboreeEvent
+    internal JamboreeEvent(byte dedupeThreshold = 0, bool highPriority = false)
     {
-        internal JamboreeEvent(byte dedupeThreshold = 0, bool highPriority = false)
-        {
-            DedupeThreshold = dedupeThreshold;
-            HighPriority = highPriority;
-            TimeStamp = Clock.Time.Now;
-        }
-
-        public long TimeStamp { get; }
-
-        internal byte DedupeThreshold { get; }
-
-        internal bool HighPriority { get; }
-
-        public Type EventType { get; protected set; }
-
-        /// <summary>
-        /// Used to determine if the Reader was able to successfully obtain the
-        /// data it was expecting to grab, and the Event is safe to use.
-        /// </summary>
-        /// <returns>True, if the Event should be used to update data.</returns>
-        public abstract bool IsValid();
+        DedupeThreshold = dedupeThreshold;
+        HighPriority    = highPriority;
+        TimeStamp       = Clock.Time.Now;
     }
+
+    public long TimeStamp { get; }
+
+    internal byte DedupeThreshold { get; }
+
+    internal bool HighPriority { get; }
+
+    public Type EventType { get; protected set; }
+
+    /// <summary>
+    /// Used to determine if the Reader was able to successfully obtain the
+    /// data it was expecting to grab, and the Event is safe to use.
+    /// </summary>
+    /// <returns>True, if the Event should be used to update data.</returns>
+    public abstract bool IsValid();
 }

--- a/BardMusicPlayer.Jamboree/Events/PartyChanged.cs
+++ b/BardMusicPlayer.Jamboree/Events/PartyChanged.cs
@@ -1,17 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace BardMusicPlayer.Jamboree.Events
+﻿namespace BardMusicPlayer.Jamboree.Events
 {
     /// <summary>
     /// if the connection 
     /// </summary>
     public sealed class PartyChangedEvent : JamboreeEvent
     {
-        internal PartyChangedEvent() : base(0, false)
+        internal PartyChangedEvent()
         {
             EventType = GetType();
         }

--- a/BardMusicPlayer.Jamboree/Events/PartyChanged.cs
+++ b/BardMusicPlayer.Jamboree/Events/PartyChanged.cs
@@ -1,15 +1,14 @@
-﻿namespace BardMusicPlayer.Jamboree.Events
-{
-    /// <summary>
-    /// if the connection 
-    /// </summary>
-    public sealed class PartyChangedEvent : JamboreeEvent
-    {
-        internal PartyChangedEvent()
-        {
-            EventType = GetType();
-        }
+﻿namespace BardMusicPlayer.Jamboree.Events;
 
-        public override bool IsValid() => true;
+/// <summary>
+/// if the connection 
+/// </summary>
+public sealed class PartyChangedEvent : JamboreeEvent
+{
+    internal PartyChangedEvent()
+    {
+        EventType = GetType();
     }
+
+    public override bool IsValid() => true;
 }

--- a/BardMusicPlayer.Jamboree/Events/PartyConnectionChangedEvent.cs
+++ b/BardMusicPlayer.Jamboree/Events/PartyConnectionChangedEvent.cs
@@ -1,28 +1,27 @@
-﻿namespace BardMusicPlayer.Jamboree.Events
+﻿namespace BardMusicPlayer.Jamboree.Events;
+
+/// <summary>
+/// if the connection 
+/// </summary>
+public sealed class PartyConnectionChangedEvent : JamboreeEvent
 {
-    /// <summary>
-    /// if the connection 
-    /// </summary>
-    public sealed class PartyConnectionChangedEvent : JamboreeEvent
+    public enum ResponseCode
     {
-        public enum ResponseCode
-        {
-            ERROR =-1,
-            OK,
-            MESSAGE
-        }
-
-        internal PartyConnectionChangedEvent(ResponseCode code, string message)
-        {
-            EventType = GetType();
-            Code = code;
-            Message = message;
-        }
-
-        public ResponseCode Code { get; }
-
-        public string Message { get; }
-
-        public override bool IsValid() => true;
+        ERROR =-1,
+        OK,
+        MESSAGE
     }
+
+    internal PartyConnectionChangedEvent(ResponseCode code, string message)
+    {
+        EventType = GetType();
+        Code      = code;
+        Message   = message;
+    }
+
+    public ResponseCode Code { get; }
+
+    public string Message { get; }
+
+    public override bool IsValid() => true;
 }

--- a/BardMusicPlayer.Jamboree/Events/PartyConnectionChangedEvent.cs
+++ b/BardMusicPlayer.Jamboree/Events/PartyConnectionChangedEvent.cs
@@ -1,24 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace BardMusicPlayer.Jamboree.Events
+﻿namespace BardMusicPlayer.Jamboree.Events
 {
     /// <summary>
     /// if the connection 
     /// </summary>
     public sealed class PartyConnectionChangedEvent : JamboreeEvent
     {
-        public enum ResponseCode : int
+        public enum ResponseCode
         {
             ERROR =-1,
             OK,
             MESSAGE
         }
 
-        internal PartyConnectionChangedEvent(ResponseCode code, string message) : base(0, false)
+        internal PartyConnectionChangedEvent(ResponseCode code, string message)
         {
             EventType = GetType();
             Code = code;

--- a/BardMusicPlayer.Jamboree/Events/PartyCreatedEvent.cs
+++ b/BardMusicPlayer.Jamboree/Events/PartyCreatedEvent.cs
@@ -1,26 +1,24 @@
-﻿namespace BardMusicPlayer.Jamboree.Events
+﻿namespace BardMusicPlayer.Jamboree.Events;
+
+/// <summary>
+/// Called only on host side
+/// </summary>
+public sealed class PartyCreatedEvent : JamboreeEvent
 {
     /// <summary>
-    /// Called only on host side
+    /// on host, when a party and token was created
     /// </summary>
-    public sealed class PartyCreatedEvent : JamboreeEvent
+    /// <param name="token"></param>
+    internal PartyCreatedEvent(string token)
     {
-        /// <summary>
-        /// on host, when a party and token was created
-        /// </summary>
-        /// <param name="token"></param>
-        internal PartyCreatedEvent(string token)
-        {
-            EventType = GetType();
-            Token = token;
-        }
-
-        /// <summary>
-        /// the base64 token for the clients to join
-        /// </summary>
-        public string Token { get; }
-
-        public override bool IsValid() => true;
+        EventType = GetType();
+        Token     = token;
     }
 
+    /// <summary>
+    /// the base64 token for the clients to join
+    /// </summary>
+    public string Token { get; }
+
+    public override bool IsValid() => true;
 }

--- a/BardMusicPlayer.Jamboree/Events/PartyCreatedEvent.cs
+++ b/BardMusicPlayer.Jamboree/Events/PartyCreatedEvent.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace BardMusicPlayer.Jamboree.Events
+﻿namespace BardMusicPlayer.Jamboree.Events
 {
     /// <summary>
     /// Called only on host side
@@ -15,7 +9,7 @@ namespace BardMusicPlayer.Jamboree.Events
         /// on host, when a party and token was created
         /// </summary>
         /// <param name="token"></param>
-        internal PartyCreatedEvent(string token) : base(0, false)
+        internal PartyCreatedEvent(string token)
         {
             EventType = GetType();
             Token = token;

--- a/BardMusicPlayer.Jamboree/Events/PartyDebugLogEvent.cs
+++ b/BardMusicPlayer.Jamboree/Events/PartyDebugLogEvent.cs
@@ -9,7 +9,7 @@
         /// on host, when a party and token was created
         /// </summary>
         /// <param name="token"></param>
-        internal PartyDebugLogEvent(string logstring) : base(0, false)
+        internal PartyDebugLogEvent(string logstring)
         {
             EventType = GetType();
             LogString = logstring;

--- a/BardMusicPlayer.Jamboree/Events/PartyDebugLogEvent.cs
+++ b/BardMusicPlayer.Jamboree/Events/PartyDebugLogEvent.cs
@@ -1,26 +1,24 @@
-﻿namespace BardMusicPlayer.Jamboree.Events
+﻿namespace BardMusicPlayer.Jamboree.Events;
+
+/// <summary>
+/// Called only on host side
+/// </summary>
+public sealed class PartyDebugLogEvent : JamboreeEvent
 {
     /// <summary>
-    /// Called only on host side
+    /// on host, when a party and token was created
     /// </summary>
-    public sealed class PartyDebugLogEvent : JamboreeEvent
+    /// <param name="token"></param>
+    internal PartyDebugLogEvent(string logstring)
     {
-        /// <summary>
-        /// on host, when a party and token was created
-        /// </summary>
-        /// <param name="token"></param>
-        internal PartyDebugLogEvent(string logstring)
-        {
-            EventType = GetType();
-            LogString = logstring;
-        }
-
-        /// <summary>
-        /// the base64 token for the clients to join
-        /// </summary>
-        public string LogString { get; }
-
-        public override bool IsValid() => true;
+        EventType = GetType();
+        LogString = logstring;
     }
 
+    /// <summary>
+    /// the base64 token for the clients to join
+    /// </summary>
+    public string LogString { get; }
+
+    public override bool IsValid() => true;
 }

--- a/BardMusicPlayer.Jamboree/Events/PartyLogEvent.cs
+++ b/BardMusicPlayer.Jamboree/Events/PartyLogEvent.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace BardMusicPlayer.Jamboree.Events
+﻿namespace BardMusicPlayer.Jamboree.Events
 {
     /// <summary>
     /// Called only on host side
@@ -15,7 +9,7 @@ namespace BardMusicPlayer.Jamboree.Events
         /// on host, when a party and token was created
         /// </summary>
         /// <param name="token"></param>
-        internal PartyLogEvent(string logstring) : base(0, false)
+        internal PartyLogEvent(string logstring)
         {
             EventType = GetType();
             LogString = logstring;

--- a/BardMusicPlayer.Jamboree/Events/PartyLogEvent.cs
+++ b/BardMusicPlayer.Jamboree/Events/PartyLogEvent.cs
@@ -1,26 +1,24 @@
-﻿namespace BardMusicPlayer.Jamboree.Events
+﻿namespace BardMusicPlayer.Jamboree.Events;
+
+/// <summary>
+/// Called only on host side
+/// </summary>
+public sealed class PartyLogEvent : JamboreeEvent
 {
     /// <summary>
-    /// Called only on host side
+    /// on host, when a party and token was created
     /// </summary>
-    public sealed class PartyLogEvent : JamboreeEvent
+    /// <param name="token"></param>
+    internal PartyLogEvent(string logstring)
     {
-        /// <summary>
-        /// on host, when a party and token was created
-        /// </summary>
-        /// <param name="token"></param>
-        internal PartyLogEvent(string logstring)
-        {
-            EventType = GetType();
-            LogString = logstring;
-        }
-
-        /// <summary>
-        /// the base64 token for the clients to join
-        /// </summary>
-        public string LogString { get; }
-
-        public override bool IsValid() => true;
+        EventType = GetType();
+        LogString = logstring;
     }
 
+    /// <summary>
+    /// the base64 token for the clients to join
+    /// </summary>
+    public string LogString { get; }
+
+    public override bool IsValid() => true;
 }

--- a/BardMusicPlayer.Jamboree/Events/PerformanceStartEvent.cs
+++ b/BardMusicPlayer.Jamboree/Events/PerformanceStartEvent.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace BardMusicPlayer.Jamboree.Events
+﻿namespace BardMusicPlayer.Jamboree.Events
 {
     public sealed class PerformanceStartEvent : JamboreeEvent
     {
@@ -12,7 +6,7 @@ namespace BardMusicPlayer.Jamboree.Events
         /// Start the performance received
         /// </summary>
         /// <param name="timestampinMillis">in milliseconds</param>
-        internal PerformanceStartEvent(long timestampinMillis, bool start) : base(0, false)
+        internal PerformanceStartEvent(long timestampinMillis, bool start)
         {
             EventType = GetType();
             SenderTimestamp_in_millis = timestampinMillis;

--- a/BardMusicPlayer.Jamboree/Events/PerformanceStartEvent.cs
+++ b/BardMusicPlayer.Jamboree/Events/PerformanceStartEvent.cs
@@ -1,25 +1,23 @@
-﻿namespace BardMusicPlayer.Jamboree.Events
+﻿namespace BardMusicPlayer.Jamboree.Events;
+
+public sealed class PerformanceStartEvent : JamboreeEvent
 {
-    public sealed class PerformanceStartEvent : JamboreeEvent
+    /// <summary>
+    /// Start the performance received
+    /// </summary>
+    /// <param name="timestampinMillis">in milliseconds</param>
+    internal PerformanceStartEvent(long timestampinMillis, bool start)
     {
-        /// <summary>
-        /// Start the performance received
-        /// </summary>
-        /// <param name="timestampinMillis">in milliseconds</param>
-        internal PerformanceStartEvent(long timestampinMillis, bool start)
-        {
-            EventType = GetType();
-            SenderTimestamp_in_millis = timestampinMillis;
-            Play = start;
-        }
-
-        /// <summary>
-        /// The host time in milis
-        /// </summary>
-        public long SenderTimestamp_in_millis { get; }
-        public bool Play { get; }
-
-        public override bool IsValid() => true;
+        EventType                 = GetType();
+        SenderTimestamp_in_millis = timestampinMillis;
+        Play                      = start;
     }
 
+    /// <summary>
+    /// The host time in milis
+    /// </summary>
+    public long SenderTimestamp_in_millis { get; }
+    public bool Play { get; }
+
+    public override bool IsValid() => true;
 }

--- a/BardMusicPlayer.Jamboree/PartyClient/PartyManagement/IPartyClient.cs
+++ b/BardMusicPlayer.Jamboree/PartyClient/PartyManagement/IPartyClient.cs
@@ -7,82 +7,81 @@ using System;
 using System.Collections.Generic;
 using BardMusicPlayer.Jamboree.PartyNetworking.Server_Client;
 
-namespace BardMusicPlayer.Jamboree.PartyClient.PartyManagement
+namespace BardMusicPlayer.Jamboree.PartyClient.PartyManagement;
+
+internal interface IPartyClient : IDisposable
 {
-    internal interface IPartyClient : IDisposable
-    {
-        /// <summary>
-        /// asks for a new party uuid
-        /// </summary>
-        /// <returns></returns>
-        string RequestParty();
+    /// <summary>
+    /// asks for a new party uuid
+    /// </summary>
+    /// <returns></returns>
+    string RequestParty();
 
-        /// <summary>
-        /// joins a party
-        /// </summary>
-        /// <param name="party">string uuid</param>
-        /// <returns>true if successful</returns>
-        bool JoinParty(string party);
+    /// <summary>
+    /// joins a party
+    /// </summary>
+    /// <param name="party">string uuid</param>
+    /// <returns>true if successful</returns>
+    bool JoinParty(string party);
         
-        /// <summary>
-        /// requests a list of party members.
-        /// </summary>
-        /// <returns>list of string uuid</returns>
-        List<string> RequestPartyMembers();
+    /// <summary>
+    /// requests a list of party members.
+    /// </summary>
+    /// <returns>list of string uuid</returns>
+    List<string> RequestPartyMembers();
 
-        /// <summary>
-        /// Fired when the PartyMembers changes
-        /// </summary>
-        /// <param name="partyMembers"></param>
-        delegate void PartyMembersChangedHandler(List<string> partyMembers);
+    /// <summary>
+    /// Fired when the PartyMembers changes
+    /// </summary>
+    /// <param name="partyMembers"></param>
+    delegate void PartyMembersChangedHandler(List<string> partyMembers);
 
-        /// <summary>
-        /// Fired when the PartyMembers changes
-        /// </summary>
-        event PartyMembersChangedHandler PartyMembersChanged;
+    /// <summary>
+    /// Fired when the PartyMembers changes
+    /// </summary>
+    event PartyMembersChangedHandler PartyMembersChanged;
         
-        /// <summary>
-        /// assigns someone else to be the party leader.
-        /// </summary>
-        /// <param name="partyMember">string uuid</param>
-        /// <returns>true if successful</returns>
-        bool AssignPartyLeader(string partyMember);
+    /// <summary>
+    /// assigns someone else to be the party leader.
+    /// </summary>
+    /// <param name="partyMember">string uuid</param>
+    /// <returns>true if successful</returns>
+    bool AssignPartyLeader(string partyMember);
         
-        /// <summary>
-        /// returns the current party leader.
-        /// </summary>
-        /// <returns>uuid of current party leader</returns>
-        string RequestPartyLeader();
+    /// <summary>
+    /// returns the current party leader.
+    /// </summary>
+    /// <returns>uuid of current party leader</returns>
+    string RequestPartyLeader();
 
-        /// <summary>
-        /// Fired when the PartyLeader changes
-        /// </summary>
-        /// <param name="partyLeader"></param>
-        delegate void PartyLeaderChangedHandler(string partyLeader);
+    /// <summary>
+    /// Fired when the PartyLeader changes
+    /// </summary>
+    /// <param name="partyLeader"></param>
+    delegate void PartyLeaderChangedHandler(string partyLeader);
 
-        /// <summary>
-        /// Fired when the PartyLeader changes
-        /// </summary>
-        event PartyLeaderChangedHandler PartyLeaderChanged;
+    /// <summary>
+    /// Fired when the PartyLeader changes
+    /// </summary>
+    event PartyLeaderChangedHandler PartyLeaderChanged;
 
-        /// <summary>
-        /// requests all PartyGame structs from a partyMember.
-        /// </summary>
-        /// <param name="partyMember">string uuid</param>
-        /// <returns>list of games</returns>
-        List<NetworkSocket> RequestPartyGames(string partyMember);
+    /// <summary>
+    /// requests all PartyGame structs from a partyMember.
+    /// </summary>
+    /// <param name="partyMember">string uuid</param>
+    /// <returns>list of games</returns>
+    List<NetworkSocket> RequestPartyGames(string partyMember);
 
-        /// <summary>
-        /// Fired when the PartyGame list changes in a PartyMember
-        /// </summary>
-        /// <param name="partyMember"></param>
-        /// <param name="partyGames"></param>
-        delegate void PartyGamesChangedHandler(string partyMember, List<NetworkSocket> partyGames);
+    /// <summary>
+    /// Fired when the PartyGame list changes in a PartyMember
+    /// </summary>
+    /// <param name="partyMember"></param>
+    /// <param name="partyGames"></param>
+    delegate void PartyGamesChangedHandler(string partyMember, List<NetworkSocket> partyGames);
 
-        /// <summary>
-        /// Fired when the PartyGame list changes in a PartyMember
-        /// </summary>
-        event PartyGamesChangedHandler PartyGamesChanged;
+    /// <summary>
+    /// Fired when the PartyGame list changes in a PartyMember
+    /// </summary>
+    event PartyGamesChangedHandler PartyGamesChanged;
 
-    }
 }

--- a/BardMusicPlayer.Jamboree/PartyClient/PartyManagement/IPartyClient.cs
+++ b/BardMusicPlayer.Jamboree/PartyClient/PartyManagement/IPartyClient.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using BardMusicPlayer.Jamboree.PartyNetworking;
 using BardMusicPlayer.Jamboree.PartyNetworking.Server_Client;
 
 namespace BardMusicPlayer.Jamboree.PartyClient.PartyManagement

--- a/BardMusicPlayer.Jamboree/PartyClient/PartyManagement/PartyClient.cs
+++ b/BardMusicPlayer.Jamboree/PartyClient/PartyManagement/PartyClient.cs
@@ -12,7 +12,7 @@ namespace BardMusicPlayer.Jamboree.PartyClient.PartyManagement
         public string Performer_Name { get; set; } = "Unknown";
 
 
-        private Queue<NetworkPacket> _inPackets = new Queue<NetworkPacket>();
+        private Queue<NetworkPacket> _inPackets = new();
 
         public void AddPacket(NetworkPacket packet)
         {

--- a/BardMusicPlayer.Jamboree/PartyClient/PartyManagement/PartyClient.cs
+++ b/BardMusicPlayer.Jamboree/PartyClient/PartyManagement/PartyClient.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using BardMusicPlayer.Jamboree.PartyNetworking;
 using BardMusicPlayer.Jamboree.PartyNetworking.Server_Client;
 
 namespace BardMusicPlayer.Jamboree.PartyClient.PartyManagement
@@ -14,9 +13,6 @@ namespace BardMusicPlayer.Jamboree.PartyClient.PartyManagement
 
 
         private Queue<NetworkPacket> _inPackets = new Queue<NetworkPacket>();
-
-        public PartyClientInfo()
-        {}
 
         public void AddPacket(NetworkPacket packet)
         {

--- a/BardMusicPlayer.Jamboree/PartyClient/PartyManagement/PartyClient.cs
+++ b/BardMusicPlayer.Jamboree/PartyClient/PartyManagement/PartyClient.cs
@@ -1,22 +1,21 @@
 ﻿using System.Collections.Generic;
 using BardMusicPlayer.Jamboree.PartyNetworking.Server_Client;
 
-namespace BardMusicPlayer.Jamboree.PartyClient.PartyManagement
+namespace BardMusicPlayer.Jamboree.PartyClient.PartyManagement;
+
+public class PartyClientInfo
 {
-    public class PartyClientInfo
+    /// <summary>
+    /// Is this session a (0) bard, (1) dancer
+    /// </summary>
+    public byte Performer_Type { get; set; } = 254;
+    public string Performer_Name { get; set; } = "Unknown";
+
+
+    private Queue<NetworkPacket> _inPackets = new();
+
+    public void AddPacket(NetworkPacket packet)
     {
-        /// <summary>
-        /// Is this session a (0) bard, (1) dancer
-        /// </summary>
-        public byte Performer_Type { get; set; } = 254;
-        public string Performer_Name { get; set; } = "Unknown";
-
-
-        private Queue<NetworkPacket> _inPackets = new();
-
-        public void AddPacket(NetworkPacket packet)
-        {
-            _inPackets.Enqueue(packet);
-        }
+        _inPackets.Enqueue(packet);
     }
 }

--- a/BardMusicPlayer.Jamboree/PartyClient/PartyManagement/PartyManager.cs
+++ b/BardMusicPlayer.Jamboree/PartyClient/PartyManagement/PartyManager.cs
@@ -2,46 +2,45 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace BardMusicPlayer.Jamboree.PartyClient.PartyManagement
+namespace BardMusicPlayer.Jamboree.PartyClient.PartyManagement;
+
+internal class PartyManager
 {
-    internal class PartyManager
+    public List<PartyClientInfo> GetPartyMembers() { return _partyClients; }
+    private List<PartyClientInfo> _partyClients = new();
+
+    #region Instance Constructor/Destructor
+    private static readonly Lazy<PartyManager> LazyInstance = new(() => new PartyManager());
+    private PartyManager()
     {
-        public List<PartyClientInfo> GetPartyMembers() { return _partyClients; }
-        private List<PartyClientInfo> _partyClients = new();
-
-#region Instance Constructor/Destructor
-        private static readonly Lazy<PartyManager> LazyInstance = new(() => new PartyManager());
-        private PartyManager()
-        {
-            _partyClients.Clear();
-        }
-
-        public static PartyManager Instance => LazyInstance.Value;
-
-        ~PartyManager() { Dispose(); }
-
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-        }
-#endregion
-
-        public void Add(PartyClientInfo client)
-        {
-            if (_partyClients.Any(info => info.Performer_Name == client.Performer_Name))
-            {
-                return;
-            }
-
-            _partyClients.Add(client);
-        }
-
-        public void Remove(PartyClientInfo client)
-        {
-            _partyClients.Remove(client);
-        }
-
-
-
+        _partyClients.Clear();
     }
+
+    public static PartyManager Instance => LazyInstance.Value;
+
+    ~PartyManager() { Dispose(); }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+    }
+    #endregion
+
+    public void Add(PartyClientInfo client)
+    {
+        if (_partyClients.Any(info => info.Performer_Name == client.Performer_Name))
+        {
+            return;
+        }
+
+        _partyClients.Add(client);
+    }
+
+    public void Remove(PartyClientInfo client)
+    {
+        _partyClients.Remove(client);
+    }
+
+
+
 }

--- a/BardMusicPlayer.Jamboree/PartyClient/PartyManagement/PartyManager.cs
+++ b/BardMusicPlayer.Jamboree/PartyClient/PartyManagement/PartyManager.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace BardMusicPlayer.Jamboree.PartyClient.PartyManagement
 {
-    class PartyManager
+    internal class PartyManager
     {
         public List<PartyClientInfo> GetPartyMembers() { return _partyClients; }
-        private List<PartyClientInfo> _partyClients = new List<PartyClientInfo>();
+        private List<PartyClientInfo> _partyClients = new();
 
 #region Instance Constructor/Destructor
         private static readonly Lazy<PartyManager> LazyInstance = new(() => new PartyManager());
@@ -27,9 +28,11 @@ namespace BardMusicPlayer.Jamboree.PartyClient.PartyManagement
 
         public void Add(PartyClientInfo client)
         {
-            foreach(PartyClientInfo info in _partyClients)
-                if (info.Performer_Name == client.Performer_Name)
-                    return;
+            if (_partyClients.Any(info => info.Performer_Name == client.Performer_Name))
+            {
+                return;
+            }
+
             _partyClients.Add(client);
         }
 

--- a/BardMusicPlayer.Jamboree/PartyNetworking/Autodiscover/Autodiscover.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/Autodiscover/Autodiscover.cs
@@ -11,8 +11,9 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover
     /// </summary>
     internal class Autodiscover : IDisposable
     {
-        private static readonly Lazy<Autodiscover> lazy = new Lazy<Autodiscover>(() => new Autodiscover());
-        public static Autodiscover Instance { get { return lazy.Value; } }
+        private static readonly Lazy<Autodiscover> lazy = new(() => new Autodiscover());
+        public static Autodiscover Instance => lazy.Value;
+
         private Autodiscover() { }
         ~Autodiscover()
         {
@@ -35,7 +36,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover
 
         public void StartAutodiscover(string address, string version)
         {
-            BackgroundWorker objWorkerServerDiscoveryRx = new BackgroundWorker();
+            var objWorkerServerDiscoveryRx = new BackgroundWorker();
             objWorkerServerDiscoveryRx.WorkerReportsProgress = true;
             objWorkerServerDiscoveryRx.WorkerSupportsCancellation = true;
 
@@ -46,7 +47,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover
             objWorkerServerDiscoveryRx.RunWorkerAsync();
         }
 
-        private void logWorkers_ProgressChanged(object sender, ProgressChangedEventArgs e)
+        private static void logWorkers_ProgressChanged(object sender, ProgressChangedEventArgs e)
         {
             Console.WriteLine(e.UserState.ToString());
         }
@@ -66,7 +67,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover
         public string Address = "";
         public string version = "";
         public int ServerPort = 0;
-        byte[] bytes = new byte[255];
+        private byte[] bytes = new byte[255];
 
         public SocketRx(ref BackgroundWorker w, string address, string ver)
         {
@@ -78,9 +79,9 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover
 
         public void Start(object sender, DoWorkEventArgs e)
         {
-            ZeroTierExtendedSocket listener = new ZeroTierExtendedSocket(System.Net.Sockets.AddressFamily.InterNetwork, System.Net.Sockets.SocketType.Dgram, System.Net.Sockets.ProtocolType.Udp);
-            ZeroTierExtendedSocket transmitter = new ZeroTierExtendedSocket(System.Net.Sockets.AddressFamily.InterNetwork, System.Net.Sockets.SocketType.Dgram, System.Net.Sockets.ProtocolType.Udp);
-            int r = listener.SetBroadcast();
+            var listener = new ZeroTierExtendedSocket(System.Net.Sockets.AddressFamily.InterNetwork, System.Net.Sockets.SocketType.Dgram, System.Net.Sockets.ProtocolType.Udp);
+            var transmitter = new ZeroTierExtendedSocket(System.Net.Sockets.AddressFamily.InterNetwork, System.Net.Sockets.SocketType.Dgram, System.Net.Sockets.ProtocolType.Udp);
+            var r = listener.SetBroadcast();
             r = transmitter.SetBroadcast();
             iPEndPoint = new System.Net.IPEndPoint(System.Net.IPAddress.Parse(BCAddress), 5555);
             listener.ReceiveTimeout = 10;
@@ -89,23 +90,23 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover
             
             while (disposing == false)
             {
-                int bytesRec = listener.ReceiveFrom(bytes);
+                var bytesRec = listener.ReceiveFrom(bytes);
                 if (bytesRec > 0)
                 {
-                    string all = Encoding.ASCII.GetString(bytes, 0, bytesRec);
-                    string f = all.Split(' ')[0];               //Get the init
+                    var all = Encoding.ASCII.GetString(bytes, 0, bytesRec);
+                    var f = all.Split(' ')[0];               //Get the init
                     if (f.Equals("XIVAmp"))
                     {
-                        string ip = all.Split(' ')[1];          //the IP
-                        string version = all.Split(' ')[2];     //the version number
+                        var ip = all.Split(' ')[1];          //the IP
+                        var version = all.Split(' ')[2];     //the version number
                         //Add the client
                         FoundClients.Instance.Add(ip, version);
                     }
                 }
                 if (!disposing)
                 {
-                    string t = "XIVAmp " + Address + " " + version; //Send the init ip and version
-                    int p = transmitter.SendTo(iPEndPoint, Encoding.ASCII.GetBytes(t));
+                    var t = "XIVAmp " + Address + " " + version; //Send the init ip and version
+                    var p = transmitter.SendTo(iPEndPoint, Encoding.ASCII.GetBytes(t));
                     System.Threading.Thread.Sleep(3000);
                 }
             }

--- a/BardMusicPlayer.Jamboree/PartyNetworking/Autodiscover/Autodiscover.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/Autodiscover/Autodiscover.cs
@@ -4,123 +4,122 @@ using System.Text;
 using BardMusicPlayer.Jamboree.Events;
 using BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier;
 
-namespace BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover
-{
-    /// <summary>
-    /// The autodiscover, to get the client IP and version
-    /// </summary>
-    internal class Autodiscover : IDisposable
-    {
-        private static readonly Lazy<Autodiscover> lazy = new(() => new Autodiscover());
-        public static Autodiscover Instance => lazy.Value;
+namespace BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover;
 
-        private Autodiscover() { }
-        ~Autodiscover()
-        {
-            svcRx.Stop();
+/// <summary>
+/// The autodiscover, to get the client IP and version
+/// </summary>
+internal class Autodiscover : IDisposable
+{
+    private static readonly Lazy<Autodiscover> lazy = new(() => new Autodiscover());
+    public static Autodiscover Instance => lazy.Value;
+
+    private Autodiscover() { }
+    ~Autodiscover()
+    {
+        svcRx.Stop();
 #if DEBUG
             Console.WriteLine("Destructor Called.");
 #endif
-        }
+    }
 
-        void IDisposable.Dispose()
-        {
-            svcRx.Stop();
+    void IDisposable.Dispose()
+    {
+        svcRx.Stop();
 #if DEBUG
             Console.WriteLine("Dispose Called.");
 #endif
-            //GC.SuppressFinalize(this);
-        }
-
-        private SocketRx svcRx { get; set; }
-
-        public void StartAutodiscover(string address, string version)
-        {
-            var objWorkerServerDiscoveryRx = new BackgroundWorker();
-            objWorkerServerDiscoveryRx.WorkerReportsProgress = true;
-            objWorkerServerDiscoveryRx.WorkerSupportsCancellation = true;
-
-            svcRx = new SocketRx(ref objWorkerServerDiscoveryRx, address, version);
-
-            objWorkerServerDiscoveryRx.DoWork          += svcRx.Start;
-            objWorkerServerDiscoveryRx.ProgressChanged += logWorkers_ProgressChanged;
-            objWorkerServerDiscoveryRx.RunWorkerAsync();
-        }
-
-        private static void logWorkers_ProgressChanged(object sender, ProgressChangedEventArgs e)
-        {
-            Console.WriteLine(e.UserState.ToString());
-        }
-
-        public void Stop()
-        {
-            svcRx.Stop();
-        }
-
+        //GC.SuppressFinalize(this);
     }
 
-    public class SocketRx
+    private SocketRx svcRx { get; set; }
+
+    public void StartAutodiscover(string address, string version)
     {
-        public bool disposing;
-        public System.Net.IPEndPoint iPEndPoint;
-        public string BCAddress = "";
-        public string Address = "";
-        public string version = "";
-        public int ServerPort = 0;
-        private byte[] bytes = new byte[255];
+        var objWorkerServerDiscoveryRx = new BackgroundWorker();
+        objWorkerServerDiscoveryRx.WorkerReportsProgress      = true;
+        objWorkerServerDiscoveryRx.WorkerSupportsCancellation = true;
 
-        public SocketRx(ref BackgroundWorker w, string address, string ver)
-        {
-            Address = address;
-            BCAddress = address.Split('.')[0] + "." + address.Split('.')[1] + "." + address.Split('.')[2] + ".255";
-            version = ver;
-            w.ReportProgress(1, "Server");
-        }
+        svcRx = new SocketRx(ref objWorkerServerDiscoveryRx, address, version);
 
-        public void Start(object sender, DoWorkEventArgs e)
-        {
-            var listener = new ZeroTierExtendedSocket(System.Net.Sockets.AddressFamily.InterNetwork, System.Net.Sockets.SocketType.Dgram, System.Net.Sockets.ProtocolType.Udp);
-            var transmitter = new ZeroTierExtendedSocket(System.Net.Sockets.AddressFamily.InterNetwork, System.Net.Sockets.SocketType.Dgram, System.Net.Sockets.ProtocolType.Udp);
-            var r = listener.SetBroadcast();
-            r = transmitter.SetBroadcast();
-            iPEndPoint = new System.Net.IPEndPoint(System.Net.IPAddress.Parse(BCAddress), 5555);
-            listener.ReceiveTimeout = 10;
-            listener.BSD_Bind(iPEndPoint);
-            BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("[Autodiscover]: Started\r\n"));
+        objWorkerServerDiscoveryRx.DoWork          += svcRx.Start;
+        objWorkerServerDiscoveryRx.ProgressChanged += logWorkers_ProgressChanged;
+        objWorkerServerDiscoveryRx.RunWorkerAsync();
+    }
+
+    private static void logWorkers_ProgressChanged(object sender, ProgressChangedEventArgs e)
+    {
+        Console.WriteLine(e.UserState.ToString());
+    }
+
+    public void Stop()
+    {
+        svcRx.Stop();
+    }
+
+}
+
+public class SocketRx
+{
+    public bool disposing;
+    public System.Net.IPEndPoint iPEndPoint;
+    public string BCAddress = "";
+    public string Address = "";
+    public string version = "";
+    public int ServerPort = 0;
+    private byte[] bytes = new byte[255];
+
+    public SocketRx(ref BackgroundWorker w, string address, string ver)
+    {
+        Address   = address;
+        BCAddress = address.Split('.')[0] + "." + address.Split('.')[1] + "." + address.Split('.')[2] + ".255";
+        version   = ver;
+        w.ReportProgress(1, "Server");
+    }
+
+    public void Start(object sender, DoWorkEventArgs e)
+    {
+        var listener = new ZeroTierExtendedSocket(System.Net.Sockets.AddressFamily.InterNetwork, System.Net.Sockets.SocketType.Dgram, System.Net.Sockets.ProtocolType.Udp);
+        var transmitter = new ZeroTierExtendedSocket(System.Net.Sockets.AddressFamily.InterNetwork, System.Net.Sockets.SocketType.Dgram, System.Net.Sockets.ProtocolType.Udp);
+        var r = listener.SetBroadcast();
+        r                       = transmitter.SetBroadcast();
+        iPEndPoint              = new System.Net.IPEndPoint(System.Net.IPAddress.Parse(BCAddress), 5555);
+        listener.ReceiveTimeout = 10;
+        listener.BSD_Bind(iPEndPoint);
+        BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("[Autodiscover]: Started\r\n"));
             
-            while (disposing == false)
+        while (disposing == false)
+        {
+            var bytesRec = listener.ReceiveFrom(bytes);
+            if (bytesRec > 0)
             {
-                var bytesRec = listener.ReceiveFrom(bytes);
-                if (bytesRec > 0)
+                var all = Encoding.ASCII.GetString(bytes, 0, bytesRec);
+                var f = all.Split(' ')[0]; //Get the init
+                if (f.Equals("XIVAmp"))
                 {
-                    var all = Encoding.ASCII.GetString(bytes, 0, bytesRec);
-                    var f = all.Split(' ')[0];               //Get the init
-                    if (f.Equals("XIVAmp"))
-                    {
-                        var ip = all.Split(' ')[1];          //the IP
-                        var version = all.Split(' ')[2];     //the version number
-                        //Add the client
-                        FoundClients.Instance.Add(ip, version);
-                    }
-                }
-                if (!disposing)
-                {
-                    var t = "XIVAmp " + Address + " " + version; //Send the init ip and version
-                    var p = transmitter.SendTo(iPEndPoint, Encoding.ASCII.GetBytes(t));
-                    System.Threading.Thread.Sleep(3000);
+                    var ip = all.Split(' ')[1];      //the IP
+                    var version = all.Split(' ')[2]; //the version number
+                    //Add the client
+                    FoundClients.Instance.Add(ip, version);
                 }
             }
-
-            try { transmitter.Shutdown(System.Net.Sockets.SocketShutdown.Both); }
-            finally { transmitter.Close(); }
-            try { listener.Shutdown(System.Net.Sockets.SocketShutdown.Both); }
-            finally { listener.Close(); }
-            BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("[Autodiscover]: Stopped\r\n"));
+            if (!disposing)
+            {
+                var t = "XIVAmp " + Address + " " + version; //Send the init ip and version
+                var p = transmitter.SendTo(iPEndPoint, Encoding.ASCII.GetBytes(t));
+                System.Threading.Thread.Sleep(3000);
+            }
         }
 
-        public void Stop()
-        {
-            disposing = true;
-        }
+        try { transmitter.Shutdown(System.Net.Sockets.SocketShutdown.Both); }
+        finally { transmitter.Close(); }
+        try { listener.Shutdown(System.Net.Sockets.SocketShutdown.Both); }
+        finally { listener.Close(); }
+        BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("[Autodiscover]: Stopped\r\n"));
+    }
+
+    public void Stop()
+    {
+        disposing = true;
     }
 }

--- a/BardMusicPlayer.Jamboree/PartyNetworking/Autodiscover/FoundClients.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/Autodiscover/FoundClients.cs
@@ -23,8 +23,8 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover
     internal class FoundClients
     {
         public Dictionary<string, ClientInfo> GetClients() { return _partyClients; }
-        private Dictionary<string, ClientInfo> _partyClients = new Dictionary<string, ClientInfo>();
-        private List<string> _knownIP = new List<string>();
+        private Dictionary<string, ClientInfo> _partyClients = new();
+        private List<string> _knownIP = new();
         public string OwnName { get; set; } = "";
         public byte Type { get; set; } = 255;
 
@@ -60,7 +60,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover
                     _knownIP.Add(IP);
                 }
 
-                ClientInfo client = new ClientInfo(IP, version);
+                var client = new ClientInfo(IP, version);
                 lock (_partyClients)
                 {
                     _partyClients.Add(client.IPAddress, client);
@@ -85,10 +85,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover
         /// <returns>null or NetworkSocket</returns>
         public NetworkSocket FindSocket(string ip)
         {
-            ClientInfo info;
-            if (_partyClients.TryGetValue(ip, out info))
-                return info.Sockets;
-            return null;
+            return _partyClients.TryGetValue(ip, out var info) ? info.Sockets : null;
         }
 
         /// <summary>

--- a/BardMusicPlayer.Jamboree/PartyNetworking/Autodiscover/FoundClients.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/Autodiscover/FoundClients.cs
@@ -4,127 +4,125 @@ using System.Threading.Tasks;
 using BardMusicPlayer.Jamboree.Events;
 using BardMusicPlayer.Jamboree.PartyNetworking.Server_Client;
 
-namespace BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover
-{
+namespace BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover;
 
-    public class ClientInfo
+public class ClientInfo
+{
+    public ClientInfo(string IP, string version)
     {
-        public ClientInfo(string IP, string version)
-        {
-            IPAddress = IP;
-            Version = version;
-            Sockets = new NetworkSocket(IP);
-        }
-        public string IPAddress { get; set; } = "";
-        public string Version { get; set; } = "";
-        public NetworkSocket Sockets { get; set; }
+        IPAddress = IP;
+        Version   = version;
+        Sockets   = new NetworkSocket(IP);
+    }
+    public string IPAddress { get; set; } = "";
+    public string Version { get; set; } = "";
+    public NetworkSocket Sockets { get; set; }
+}
+
+internal class FoundClients
+{
+    public Dictionary<string, ClientInfo> GetClients() { return _partyClients; }
+    private Dictionary<string, ClientInfo> _partyClients = new();
+    private List<string> _knownIP = new();
+    public string OwnName { get; set; } = "";
+    public byte Type { get; set; } = 255;
+
+    public EventHandler<string> OnNewAddress;
+
+    #region Instance Constructor/Destructor
+    private static readonly Lazy<FoundClients> LazyInstance = new(() => new FoundClients());
+    private FoundClients()
+    {
+        _partyClients.Clear();
     }
 
-    internal class FoundClients
+    public static FoundClients Instance => LazyInstance.Value;
+
+    ~FoundClients() { Dispose(); }
+
+    public void Dispose()
     {
-        public Dictionary<string, ClientInfo> GetClients() { return _partyClients; }
-        private Dictionary<string, ClientInfo> _partyClients = new();
-        private List<string> _knownIP = new();
-        public string OwnName { get; set; } = "";
-        public byte Type { get; set; } = 255;
+        GC.SuppressFinalize(this);
+    }
+    #endregion
 
-        public EventHandler<string> OnNewAddress;
-
-#region Instance Constructor/Destructor
-        private static readonly Lazy<FoundClients> LazyInstance = new(() => new FoundClients());
-        private FoundClients()
+    /// <summary>
+    /// Add the found client and create a NetworkSocket
+    /// </summary>
+    /// <param name="IP"></param>
+    /// <param name="version"></param>
+    public void Add(string IP, string version)
+    {
+        if (!_partyClients.ContainsKey(IP))
         {
-            _partyClients.Clear();
-        }
-
-        public static FoundClients Instance => LazyInstance.Value;
-
-        ~FoundClients() { Dispose(); }
-
-        public void Dispose()
-        {
-            GC.SuppressFinalize(this);
-        }
-        #endregion
-
-        /// <summary>
-        /// Add the found client and create a NetworkSocket
-        /// </summary>
-        /// <param name="IP"></param>
-        /// <param name="version"></param>
-        public void Add(string IP, string version)
-        {
-            if (!_partyClients.ContainsKey(IP))
-            {
-                lock (_knownIP) {
-                    _knownIP.Add(IP);
-                }
-
-                var client = new ClientInfo(IP, version);
-                lock (_partyClients)
-                {
-                    _partyClients.Add(client.IPAddress, client);
-                    OnNewAddress(this, IP);
-                }
-                BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("Added Client IP "+IP+"\r\n"));
-            }
-        }
-
-        public void SendToAll(byte[] pck)
-        {
-            Parallel.ForEach(_partyClients, client =>
-            {
-                client.Value.Sockets.SendPacket(pck);
-            });
-        }
-
-        /// <summary>
-        /// Find the socket for the IP
-        /// </summary>
-        /// <param name="ip"></param>
-        /// <returns>null or NetworkSocket</returns>
-        public NetworkSocket FindSocket(string ip)
-        {
-            return _partyClients.TryGetValue(ip, out var info) ? info.Sockets : null;
-        }
-
-        /// <summary>
-        /// Check if the IP is in IPlist
-        /// </summary>
-        /// <param name="IP"></param>
-        /// <returns></returns>
-        public bool IsIpInList(string IP)
-        {
-            lock (_knownIP)
-            {
-                return _knownIP.Contains(IP);
-            }
-        }
-
-        /// <summary>
-        /// Remove the client by its IP
-        /// </summary>
-        /// <param name="IP"></param>
-        public void Remove(string IP)
-        {
-            lock (_knownIP)
-            {
-                _knownIP.Remove(IP);
+            lock (_knownIP) {
+                _knownIP.Add(IP);
             }
 
+            var client = new ClientInfo(IP, version);
             lock (_partyClients)
             {
-                _partyClients.Remove(IP);
+                _partyClients.Add(client.IPAddress, client);
+                OnNewAddress(this, IP);
             }
+            BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("Added Client IP "+IP+"\r\n"));
+        }
+    }
+
+    public void SendToAll(byte[] pck)
+    {
+        Parallel.ForEach(_partyClients, client =>
+        {
+            client.Value.Sockets.SendPacket(pck);
+        });
+    }
+
+    /// <summary>
+    /// Find the socket for the IP
+    /// </summary>
+    /// <param name="ip"></param>
+    /// <returns>null or NetworkSocket</returns>
+    public NetworkSocket FindSocket(string ip)
+    {
+        return _partyClients.TryGetValue(ip, out var info) ? info.Sockets : null;
+    }
+
+    /// <summary>
+    /// Check if the IP is in IPlist
+    /// </summary>
+    /// <param name="IP"></param>
+    /// <returns></returns>
+    public bool IsIpInList(string IP)
+    {
+        lock (_knownIP)
+        {
+            return _knownIP.Contains(IP);
+        }
+    }
+
+    /// <summary>
+    /// Remove the client by its IP
+    /// </summary>
+    /// <param name="IP"></param>
+    public void Remove(string IP)
+    {
+        lock (_knownIP)
+        {
+            _knownIP.Remove(IP);
         }
 
-        public void Clear()
+        lock (_partyClients)
         {
-            _partyClients.Clear();
-            lock (_knownIP)
-            {
-                _knownIP.Clear();
-            }
+            _partyClients.Remove(IP);
+        }
+    }
+
+    public void Clear()
+    {
+        _partyClients.Clear();
+        lock (_knownIP)
+        {
+            _knownIP.Clear();
         }
     }
 }

--- a/BardMusicPlayer.Jamboree/PartyNetworking/Autodiscover/FoundClients.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/Autodiscover/FoundClients.cs
@@ -17,7 +17,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover
         }
         public string IPAddress { get; set; } = "";
         public string Version { get; set; } = "";
-        public NetworkSocket Sockets { get; set; } = null;
+        public NetworkSocket Sockets { get; set; }
     }
 
     internal class FoundClients
@@ -98,7 +98,10 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover
         /// <returns></returns>
         public bool IsIpInList(string IP)
         {
-            return _knownIP.Contains(IP);
+            lock (_knownIP)
+            {
+                return _knownIP.Contains(IP);
+            }
         }
 
         /// <summary>
@@ -121,7 +124,10 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover
         public void Clear()
         {
             _partyClients.Clear();
-            _knownIP.Clear();
+            lock (_knownIP)
+            {
+                _knownIP.Clear();
+            }
         }
     }
 }

--- a/BardMusicPlayer.Jamboree/PartyNetworking/Server-Client/NetworkOpcodes.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/Server-Client/NetworkOpcodes.cs
@@ -1,49 +1,48 @@
 ﻿using System;
 
-namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
+namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client;
+
+public static class NetworkOpcodes
 {
-    public static class NetworkOpcodes
+    public enum OpcodeEnum : byte
     {
-        public enum OpcodeEnum : byte
-        {
-            NULL_OPCODE             = 0x00,
-            PING                    = 0x01,
-            PONG                    = 0x02,
-            MSG_JOIN_PARTY          = 0x03,
-            MSG_LEAVE_PARTY         = 0x04,
-            MSG_PLAY                = 0x05,
-            MSG_STOP                = 0x06,
-            MSG_SONG_DATA           = 0x07
-        }
+        NULL_OPCODE             = 0x00,
+        PING                    = 0x01,
+        PONG                    = 0x02,
+        MSG_JOIN_PARTY          = 0x03,
+        MSG_LEAVE_PARTY         = 0x04,
+        MSG_PLAY                = 0x05,
+        MSG_STOP                = 0x06,
+        MSG_SONG_DATA           = 0x07
+    }
+}
+
+public static class ZeroTierPacketBuilder
+{
+    /// <summary>
+    /// Send we joined the party
+    /// | type 0 = bard
+    /// | type 1 = dancer
+    /// </summary>
+    /// <param name="type"></param>
+    /// <param name="performer_name"></param>
+    /// <returns>data as byte[]</returns>
+    public static byte[] MSG_JOIN_PARTY(byte type, string performer_name)
+    {
+        var buffer = new NetworkPacket(NetworkOpcodes.OpcodeEnum.MSG_JOIN_PARTY);
+        buffer.WriteUInt8(type);
+        buffer.WriteCString(performer_name);
+        return buffer.GetData();
     }
 
-    public static class ZeroTierPacketBuilder
+    /// <summary>
+    /// Send the performance start
+    /// </summary>
+    /// <returns>data as byte[]</returns>
+    public static byte[] PerformanceStart()
     {
-        /// <summary>
-        /// Send we joined the party
-        /// | type 0 = bard
-        /// | type 1 = dancer
-        /// </summary>
-        /// <param name="type"></param>
-        /// <param name="performer_name"></param>
-        /// <returns>data as byte[]</returns>
-        public static byte[] MSG_JOIN_PARTY(byte type, string performer_name)
-        {
-            var buffer = new NetworkPacket(NetworkOpcodes.OpcodeEnum.MSG_JOIN_PARTY);
-            buffer.WriteUInt8(type);
-            buffer.WriteCString(performer_name);
-            return buffer.GetData();
-        }
-
-        /// <summary>
-        /// Send the performance start
-        /// </summary>
-        /// <returns>data as byte[]</returns>
-        public static byte[] PerformanceStart()
-        {
-            var buffer = new NetworkPacket(NetworkOpcodes.OpcodeEnum.MSG_PLAY);
-            buffer.WriteInt64(DateTimeOffset.Now.ToUnixTimeMilliseconds());
-            return buffer.GetData();
-        }
+        var buffer = new NetworkPacket(NetworkOpcodes.OpcodeEnum.MSG_PLAY);
+        buffer.WriteInt64(DateTimeOffset.Now.ToUnixTimeMilliseconds());
+        return buffer.GetData();
     }
 }

--- a/BardMusicPlayer.Jamboree/PartyNetworking/Server-Client/NetworkOpcodes.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/Server-Client/NetworkOpcodes.cs
@@ -29,7 +29,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
         /// <returns>data as byte[]</returns>
         public static byte[] MSG_JOIN_PARTY(byte type, string performer_name)
         {
-            NetworkPacket buffer = new NetworkPacket(NetworkOpcodes.OpcodeEnum.MSG_JOIN_PARTY);
+            var buffer = new NetworkPacket(NetworkOpcodes.OpcodeEnum.MSG_JOIN_PARTY);
             buffer.WriteUInt8(type);
             buffer.WriteCString(performer_name);
             return buffer.GetData();
@@ -41,7 +41,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
         /// <returns>data as byte[]</returns>
         public static byte[] PerformanceStart()
         {
-            NetworkPacket buffer = new NetworkPacket(NetworkOpcodes.OpcodeEnum.MSG_PLAY);
+            var buffer = new NetworkPacket(NetworkOpcodes.OpcodeEnum.MSG_PLAY);
             buffer.WriteInt64(DateTimeOffset.Now.ToUnixTimeMilliseconds());
             return buffer.GetData();
         }

--- a/BardMusicPlayer.Jamboree/PartyNetworking/Server-Client/NetworkPacket.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/Server-Client/NetworkPacket.cs
@@ -20,414 +20,413 @@ using System.IO;
 using System.Numerics;
 using System.Text;
 
-namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
+namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client;
+
+public class NetworkPacket : IDisposable
 {
-    public class NetworkPacket : IDisposable
+    public NetworkPacket()
     {
-        public NetworkPacket()
-        {
-            writeStream = new BinaryWriter(new MemoryStream());
-        }
-
-        public NetworkPacket(NetworkOpcodes.OpcodeEnum opcode)
-        {
-            writeStream = new BinaryWriter(new MemoryStream());
-            writeStream.Write((byte)opcode);
-        }
-
-        public NetworkPacket(byte[] data)
-        {
-            readStream = new BinaryReader(new MemoryStream(data));
-            Opcode = (NetworkOpcodes.OpcodeEnum)readStream.ReadByte();
-        }
-
-        public NetworkOpcodes.OpcodeEnum Opcode { get; } = NetworkOpcodes.OpcodeEnum.NULL_OPCODE;
-
-        public void Dispose()
-        {
-            writeStream?.Dispose();
-
-            readStream?.Dispose();
-        }
-
-        #region Read Methods
-        public NetworkOpcodes.OpcodeEnum ReadOpcode()
-        {
-            return (NetworkOpcodes.OpcodeEnum)readStream.ReadByte();
-        }
-
-        public sbyte ReadInt8()
-        {
-            ResetBitPos();
-            return readStream.ReadSByte();
-        }
-
-        public short ReadInt16()
-        {
-            ResetBitPos();
-            return readStream.ReadInt16();
-        }
-
-        public int ReadInt32()
-        {
-            ResetBitPos();
-            return readStream.ReadInt32();
-        }
-
-        public long ReadInt64()
-        {
-            ResetBitPos();
-            return readStream.ReadInt64();
-        }
-
-        public byte ReadUInt8()
-        {
-            ResetBitPos();
-            return readStream.ReadByte();
-        }
-
-        public ushort ReadUInt16()
-        {
-            ResetBitPos();
-            return readStream.ReadUInt16();
-        }
-
-        public uint ReadUInt32()
-        {
-            ResetBitPos();
-            return readStream.ReadUInt32();
-        }
-
-        public ulong ReadUInt64()
-        {
-            ResetBitPos();
-            return readStream.ReadUInt64();
-        }
-
-        public float ReadFloat()
-        {
-            ResetBitPos();
-            return readStream.ReadSingle();
-        }
-
-        public double ReadDouble()
-        {
-            ResetBitPos();
-            return readStream.ReadDouble();
-        }
-
-        public string ReadCString()
-        {
-            ResetBitPos();
-            StringBuilder tmpString = new();
-            var tmpChar = readStream.ReadChar();
-            var tmpEndChar = Convert.ToChar(Encoding.UTF8.GetString(new byte[] { 0 }));
-
-            while (tmpChar != tmpEndChar)
-            {
-                tmpString.Append(tmpChar);
-                tmpChar = readStream.ReadChar();
-            }
-
-            return tmpString.ToString();
-        }
-
-        public string ReadString(uint length)
-        {
-            if (length == 0)
-                return "";
-
-            ResetBitPos();
-            return Encoding.UTF8.GetString(ReadBytes(length));
-        }
-
-        public bool ReadBool()
-        {
-            ResetBitPos();
-            return readStream.ReadBoolean();
-        }
-
-        public byte[] ReadBytes(uint count)
-        {
-            ResetBitPos();
-            return readStream.ReadBytes((int)count);
-        }
-
-        public void Skip(int count)
-        {
-            ResetBitPos();
-            readStream.BaseStream.Position += count;
-        }
-
-        public Vector3 ReadVector3()
-        {
-            return new Vector3(ReadFloat(), ReadFloat(), ReadFloat());
-        }
-
-        //BitPacking
-        public byte ReadBit()
-        {
-            if (_bitPosition == 8)
-            {
-                BitValue = ReadUInt8();
-                _bitPosition = 0;
-            }
-
-            int returnValue = BitValue;
-            BitValue = (byte)(2 * returnValue);
-            ++_bitPosition;
-
-            return (byte)(returnValue >> 7);
-        }
-
-        public bool HasBit()
-        {
-            if (_bitPosition == 8)
-            {
-                BitValue = ReadUInt8();
-                _bitPosition = 0;
-            }
-
-            int returnValue = BitValue;
-            BitValue = (byte)(2 * returnValue);
-            ++_bitPosition;
-
-            return Convert.ToBoolean(returnValue >> 7);
-        }
-
-        public T ReadBits<T>(int bitCount)
-        {
-            var value = 0;
-
-            for (var i = bitCount - 1; i >= 0; --i)
-                if (HasBit())
-                    value |= 1 << i;
-
-            return (T)Convert.ChangeType(value, typeof(T));
-        }
-        #endregion
-
-        #region Write Methods
-        public void WriteOpcode(NetworkOpcodes.OpcodeEnum opcode)
-        {
-            writeStream.Write((byte)opcode);
-        }
-
-        public void WriteInt8(sbyte data)
-        {
-            FlushBits();
-            writeStream.Write(data);
-        }
-
-        public void WriteInt16(short data)
-        {
-            FlushBits();
-            writeStream.Write(data);
-        }
-
-        public void WriteInt32(int data)
-        {
-            FlushBits();
-            writeStream.Write(data);
-        }
-
-        public void WriteInt64(long data)
-        {
-            FlushBits();
-            writeStream.Write(data);
-        }
-
-        public void WriteUInt8(byte data)
-        {
-            FlushBits();
-            writeStream.Write(data);
-        }
-
-        public void WriteUInt16(ushort data)
-        {
-            FlushBits();
-            writeStream.Write(data);
-        }
-
-        public void WriteUInt32(uint data)
-        {
-            FlushBits();
-            writeStream.Write(data);
-        }
-
-        public void WriteUInt64(ulong data)
-        {
-            FlushBits();
-            writeStream.Write(data);
-        }
-
-        public void WriteFloat(float data)
-        {
-            FlushBits();
-            writeStream.Write(data);
-        }
-
-        public void WriteDouble(double data)
-        {
-            FlushBits();
-            writeStream.Write(data);
-        }
-
-        /// <summary>
-        /// Writes a string to the packet with a null terminated (0)
-        /// </summary>
-        /// <param name="str"></param>
-        public void WriteCString(string str)
-        {
-            if (string.IsNullOrEmpty(str))
-            {
-                WriteUInt8(0);
-                return;
-            }
-
-            WriteString(str);
-            WriteUInt8(0);
-        }
-
-        public void WriteString(string str)
-        {
-            if (str.Length < 1)
-                return;
-
-            var sBytes = Encoding.UTF8.GetBytes(str);
-            WriteBytes(sBytes);
-        }
-
-        public void WriteBytes(byte[] data)
-        {
-            FlushBits();
-            writeStream.Write(data, 0, data.Length);
-        }
-
-        public void WriteBytes(byte[] data, uint count)
-        {
-            FlushBits();
-            writeStream.Write(data, 0, (int)count);
-        }
-
-        public void WriteBytes(NetworkPacket buffer)
-        {
-            WriteBytes(buffer.GetData());
-        }
-
-        public void WriteVector4(Vector4 pos)
-        {
-            WriteFloat(pos.X);
-            WriteFloat(pos.Y);
-            WriteFloat(pos.Z);
-            WriteFloat(pos.W);
-        }
-
-        public void WriteVector3(Vector3 pos)
-        {
-            WriteFloat(pos.X);
-            WriteFloat(pos.Y);
-            WriteFloat(pos.Z);
-        }
-
-        public void WriteVector2(Vector2 pos)
-        {
-            WriteFloat(pos.X);
-            WriteFloat(pos.Y);
-        }
-
-        public void WritePackXYZ(Vector3 pos)
-        {
-            uint packed = 0;
-            packed |= (uint)(pos.X / 0.25f) & 0x7FF;
-            packed |= ((uint)(pos.Y / 0.25f) & 0x7FF) << 11;
-            packed |= ((uint)(pos.Z / 0.25f) & 0x3FF) << 22;
-            WriteUInt32(packed);
-        }
-
-        public bool WriteBit(bool bit)
-        {
-            --_bitPosition;
-
-            if (bit)
-                BitValue |= (byte)(1 << _bitPosition);
-
-            if (_bitPosition == 0)
-            {
-                writeStream.Write(BitValue);
-
-                _bitPosition = 8;
-                BitValue = 0;
-            }
-            return bit;
-        }
-
-        public void WriteBits(object bit, int count)
-        {
-            for (var i = count - 1; i >= 0; --i)
-                WriteBit(((Convert.ToUInt32(bit) >> i) & 1) != 0);
-        }
-        #endregion
-
-        public bool HasUnfinishedBitPack()
-        {
-            return _bitPosition != 8;
-        }
-
-        public void FlushBits()
-        {
-            if (_bitPosition == 8)
-                return;
-
-            writeStream.Write(BitValue);
-            BitValue = 0;
-            _bitPosition = 8;
-        }
-
-        public void ResetBitPos()
-        {
-            if (_bitPosition > 7)
-                return;
-
-            _bitPosition = 8;
-            BitValue = 0;
-        }
-
-        public byte[] GetData()
-        {
-            var stream = GetCurrentStream();
-
-            var data = new byte[stream.Length];
-
-            var pos = stream.Position;
-            stream.Seek(0, SeekOrigin.Begin);
-            for (var i = 0; i < data.Length; i++)
-                data[i] = (byte)stream.ReadByte();
-
-            stream.Seek(pos, SeekOrigin.Begin);
-            return data;
-        }
-
-        public uint GetSize()
-        {
-            return (uint)GetCurrentStream().Length;
-        }
-
-        public Stream GetCurrentStream()
-        {
-            return writeStream != null ? writeStream.BaseStream : readStream.BaseStream;
-        }
-
-        public void Clear()
-        {
-            _bitPosition = 8;
-            BitValue = 0;
-            writeStream = new BinaryWriter(new MemoryStream());
-        }
-
-        private byte _bitPosition = 8;
-        private byte BitValue;
-        private BinaryWriter writeStream;
-        private BinaryReader readStream;
+        writeStream = new BinaryWriter(new MemoryStream());
     }
+
+    public NetworkPacket(NetworkOpcodes.OpcodeEnum opcode)
+    {
+        writeStream = new BinaryWriter(new MemoryStream());
+        writeStream.Write((byte)opcode);
+    }
+
+    public NetworkPacket(byte[] data)
+    {
+        readStream = new BinaryReader(new MemoryStream(data));
+        Opcode     = (NetworkOpcodes.OpcodeEnum)readStream.ReadByte();
+    }
+
+    public NetworkOpcodes.OpcodeEnum Opcode { get; } = NetworkOpcodes.OpcodeEnum.NULL_OPCODE;
+
+    public void Dispose()
+    {
+        writeStream?.Dispose();
+
+        readStream?.Dispose();
+    }
+
+    #region Read Methods
+    public NetworkOpcodes.OpcodeEnum ReadOpcode()
+    {
+        return (NetworkOpcodes.OpcodeEnum)readStream.ReadByte();
+    }
+
+    public sbyte ReadInt8()
+    {
+        ResetBitPos();
+        return readStream.ReadSByte();
+    }
+
+    public short ReadInt16()
+    {
+        ResetBitPos();
+        return readStream.ReadInt16();
+    }
+
+    public int ReadInt32()
+    {
+        ResetBitPos();
+        return readStream.ReadInt32();
+    }
+
+    public long ReadInt64()
+    {
+        ResetBitPos();
+        return readStream.ReadInt64();
+    }
+
+    public byte ReadUInt8()
+    {
+        ResetBitPos();
+        return readStream.ReadByte();
+    }
+
+    public ushort ReadUInt16()
+    {
+        ResetBitPos();
+        return readStream.ReadUInt16();
+    }
+
+    public uint ReadUInt32()
+    {
+        ResetBitPos();
+        return readStream.ReadUInt32();
+    }
+
+    public ulong ReadUInt64()
+    {
+        ResetBitPos();
+        return readStream.ReadUInt64();
+    }
+
+    public float ReadFloat()
+    {
+        ResetBitPos();
+        return readStream.ReadSingle();
+    }
+
+    public double ReadDouble()
+    {
+        ResetBitPos();
+        return readStream.ReadDouble();
+    }
+
+    public string ReadCString()
+    {
+        ResetBitPos();
+        StringBuilder tmpString = new();
+        var tmpChar = readStream.ReadChar();
+        var tmpEndChar = Convert.ToChar(Encoding.UTF8.GetString(new byte[] { 0 }));
+
+        while (tmpChar != tmpEndChar)
+        {
+            tmpString.Append(tmpChar);
+            tmpChar = readStream.ReadChar();
+        }
+
+        return tmpString.ToString();
+    }
+
+    public string ReadString(uint length)
+    {
+        if (length == 0)
+            return "";
+
+        ResetBitPos();
+        return Encoding.UTF8.GetString(ReadBytes(length));
+    }
+
+    public bool ReadBool()
+    {
+        ResetBitPos();
+        return readStream.ReadBoolean();
+    }
+
+    public byte[] ReadBytes(uint count)
+    {
+        ResetBitPos();
+        return readStream.ReadBytes((int)count);
+    }
+
+    public void Skip(int count)
+    {
+        ResetBitPos();
+        readStream.BaseStream.Position += count;
+    }
+
+    public Vector3 ReadVector3()
+    {
+        return new Vector3(ReadFloat(), ReadFloat(), ReadFloat());
+    }
+
+    //BitPacking
+    public byte ReadBit()
+    {
+        if (_bitPosition == 8)
+        {
+            BitValue     = ReadUInt8();
+            _bitPosition = 0;
+        }
+
+        int returnValue = BitValue;
+        BitValue = (byte)(2 * returnValue);
+        ++_bitPosition;
+
+        return (byte)(returnValue >> 7);
+    }
+
+    public bool HasBit()
+    {
+        if (_bitPosition == 8)
+        {
+            BitValue     = ReadUInt8();
+            _bitPosition = 0;
+        }
+
+        int returnValue = BitValue;
+        BitValue = (byte)(2 * returnValue);
+        ++_bitPosition;
+
+        return Convert.ToBoolean(returnValue >> 7);
+    }
+
+    public T ReadBits<T>(int bitCount)
+    {
+        var value = 0;
+
+        for (var i = bitCount - 1; i >= 0; --i)
+            if (HasBit())
+                value |= 1 << i;
+
+        return (T)Convert.ChangeType(value, typeof(T));
+    }
+    #endregion
+
+    #region Write Methods
+    public void WriteOpcode(NetworkOpcodes.OpcodeEnum opcode)
+    {
+        writeStream.Write((byte)opcode);
+    }
+
+    public void WriteInt8(sbyte data)
+    {
+        FlushBits();
+        writeStream.Write(data);
+    }
+
+    public void WriteInt16(short data)
+    {
+        FlushBits();
+        writeStream.Write(data);
+    }
+
+    public void WriteInt32(int data)
+    {
+        FlushBits();
+        writeStream.Write(data);
+    }
+
+    public void WriteInt64(long data)
+    {
+        FlushBits();
+        writeStream.Write(data);
+    }
+
+    public void WriteUInt8(byte data)
+    {
+        FlushBits();
+        writeStream.Write(data);
+    }
+
+    public void WriteUInt16(ushort data)
+    {
+        FlushBits();
+        writeStream.Write(data);
+    }
+
+    public void WriteUInt32(uint data)
+    {
+        FlushBits();
+        writeStream.Write(data);
+    }
+
+    public void WriteUInt64(ulong data)
+    {
+        FlushBits();
+        writeStream.Write(data);
+    }
+
+    public void WriteFloat(float data)
+    {
+        FlushBits();
+        writeStream.Write(data);
+    }
+
+    public void WriteDouble(double data)
+    {
+        FlushBits();
+        writeStream.Write(data);
+    }
+
+    /// <summary>
+    /// Writes a string to the packet with a null terminated (0)
+    /// </summary>
+    /// <param name="str"></param>
+    public void WriteCString(string str)
+    {
+        if (string.IsNullOrEmpty(str))
+        {
+            WriteUInt8(0);
+            return;
+        }
+
+        WriteString(str);
+        WriteUInt8(0);
+    }
+
+    public void WriteString(string str)
+    {
+        if (str.Length < 1)
+            return;
+
+        var sBytes = Encoding.UTF8.GetBytes(str);
+        WriteBytes(sBytes);
+    }
+
+    public void WriteBytes(byte[] data)
+    {
+        FlushBits();
+        writeStream.Write(data, 0, data.Length);
+    }
+
+    public void WriteBytes(byte[] data, uint count)
+    {
+        FlushBits();
+        writeStream.Write(data, 0, (int)count);
+    }
+
+    public void WriteBytes(NetworkPacket buffer)
+    {
+        WriteBytes(buffer.GetData());
+    }
+
+    public void WriteVector4(Vector4 pos)
+    {
+        WriteFloat(pos.X);
+        WriteFloat(pos.Y);
+        WriteFloat(pos.Z);
+        WriteFloat(pos.W);
+    }
+
+    public void WriteVector3(Vector3 pos)
+    {
+        WriteFloat(pos.X);
+        WriteFloat(pos.Y);
+        WriteFloat(pos.Z);
+    }
+
+    public void WriteVector2(Vector2 pos)
+    {
+        WriteFloat(pos.X);
+        WriteFloat(pos.Y);
+    }
+
+    public void WritePackXYZ(Vector3 pos)
+    {
+        uint packed = 0;
+        packed |= (uint)(pos.X / 0.25f) & 0x7FF;
+        packed |= ((uint)(pos.Y / 0.25f) & 0x7FF) << 11;
+        packed |= ((uint)(pos.Z / 0.25f) & 0x3FF) << 22;
+        WriteUInt32(packed);
+    }
+
+    public bool WriteBit(bool bit)
+    {
+        --_bitPosition;
+
+        if (bit)
+            BitValue |= (byte)(1 << _bitPosition);
+
+        if (_bitPosition == 0)
+        {
+            writeStream.Write(BitValue);
+
+            _bitPosition = 8;
+            BitValue     = 0;
+        }
+        return bit;
+    }
+
+    public void WriteBits(object bit, int count)
+    {
+        for (var i = count - 1; i >= 0; --i)
+            WriteBit(((Convert.ToUInt32(bit) >> i) & 1) != 0);
+    }
+    #endregion
+
+    public bool HasUnfinishedBitPack()
+    {
+        return _bitPosition != 8;
+    }
+
+    public void FlushBits()
+    {
+        if (_bitPosition == 8)
+            return;
+
+        writeStream.Write(BitValue);
+        BitValue     = 0;
+        _bitPosition = 8;
+    }
+
+    public void ResetBitPos()
+    {
+        if (_bitPosition > 7)
+            return;
+
+        _bitPosition = 8;
+        BitValue     = 0;
+    }
+
+    public byte[] GetData()
+    {
+        var stream = GetCurrentStream();
+
+        var data = new byte[stream.Length];
+
+        var pos = stream.Position;
+        stream.Seek(0, SeekOrigin.Begin);
+        for (var i = 0; i < data.Length; i++)
+            data[i] = (byte)stream.ReadByte();
+
+        stream.Seek(pos, SeekOrigin.Begin);
+        return data;
+    }
+
+    public uint GetSize()
+    {
+        return (uint)GetCurrentStream().Length;
+    }
+
+    public Stream GetCurrentStream()
+    {
+        return writeStream != null ? writeStream.BaseStream : readStream.BaseStream;
+    }
+
+    public void Clear()
+    {
+        _bitPosition = 8;
+        BitValue     = 0;
+        writeStream  = new BinaryWriter(new MemoryStream());
+    }
+
+    private byte _bitPosition = 8;
+    private byte BitValue;
+    private BinaryWriter writeStream;
+    private BinaryReader readStream;
 }

--- a/BardMusicPlayer.Jamboree/PartyNetworking/Server-Client/NetworkPacket.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/Server-Client/NetworkPacket.cs
@@ -24,8 +24,6 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
 {
     public class NetworkPacket : IDisposable
     {
-        private NetworkOpcodes.OpcodeEnum _opcode = NetworkOpcodes.OpcodeEnum.NULL_OPCODE;
-
         public NetworkPacket()
         {
             writeStream = new BinaryWriter(new MemoryStream());
@@ -40,21 +38,16 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
         public NetworkPacket(byte[] data)
         {
             readStream = new BinaryReader(new MemoryStream(data));
-            _opcode = (NetworkOpcodes.OpcodeEnum)readStream.ReadByte();
+            Opcode = (NetworkOpcodes.OpcodeEnum)readStream.ReadByte();
         }
 
-        public NetworkOpcodes.OpcodeEnum Opcode
-        {
-            get { return _opcode; }
-        }
+        public NetworkOpcodes.OpcodeEnum Opcode { get; } = NetworkOpcodes.OpcodeEnum.NULL_OPCODE;
 
         public void Dispose()
         {
-            if (writeStream != null)
-                writeStream.Dispose();
+            writeStream?.Dispose();
 
-            if (readStream != null)
-                readStream.Dispose();
+            readStream?.Dispose();
         }
 
         #region Read Methods
@@ -127,8 +120,8 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
         {
             ResetBitPos();
             StringBuilder tmpString = new();
-            char tmpChar = readStream.ReadChar();
-            char tmpEndChar = Convert.ToChar(Encoding.UTF8.GetString(new byte[] { 0 }));
+            var tmpChar = readStream.ReadChar();
+            var tmpEndChar = Convert.ToChar(Encoding.UTF8.GetString(new byte[] { 0 }));
 
             while (tmpChar != tmpEndChar)
             {
@@ -204,11 +197,11 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
 
         public T ReadBits<T>(int bitCount)
         {
-            int value = 0;
+            var value = 0;
 
             for (var i = bitCount - 1; i >= 0; --i)
                 if (HasBit())
-                    value |= (1 << i);
+                    value |= 1 << i;
 
             return (T)Convert.ChangeType(value, typeof(T));
         }
@@ -301,7 +294,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
             if (str.Length < 1)
                 return;
 
-            byte[] sBytes = Encoding.UTF8.GetBytes(str);
+            var sBytes = Encoding.UTF8.GetBytes(str);
             WriteBytes(sBytes);
         }
 
@@ -346,7 +339,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
         public void WritePackXYZ(Vector3 pos)
         {
             uint packed = 0;
-            packed |= ((uint)(pos.X / 0.25f) & 0x7FF);
+            packed |= (uint)(pos.X / 0.25f) & 0x7FF;
             packed |= ((uint)(pos.Y / 0.25f) & 0x7FF) << 11;
             packed |= ((uint)(pos.Z / 0.25f) & 0x3FF) << 22;
             WriteUInt32(packed);
@@ -371,7 +364,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
 
         public void WriteBits(object bit, int count)
         {
-            for (int i = count - 1; i >= 0; --i)
+            for (var i = count - 1; i >= 0; --i)
                 WriteBit(((Convert.ToUInt32(bit) >> i) & 1) != 0);
         }
         #endregion
@@ -402,13 +395,13 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
 
         public byte[] GetData()
         {
-            Stream stream = GetCurrentStream();
+            var stream = GetCurrentStream();
 
             var data = new byte[stream.Length];
 
-            long pos = stream.Position;
+            var pos = stream.Position;
             stream.Seek(0, SeekOrigin.Begin);
-            for (int i = 0; i < data.Length; i++)
+            for (var i = 0; i < data.Length; i++)
                 data[i] = (byte)stream.ReadByte();
 
             stream.Seek(pos, SeekOrigin.Begin);
@@ -422,10 +415,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
 
         public Stream GetCurrentStream()
         {
-            if (writeStream != null)
-                return writeStream.BaseStream;
-            else
-                return readStream.BaseStream;
+            return writeStream != null ? writeStream.BaseStream : readStream.BaseStream;
         }
 
         public void Clear()
@@ -435,9 +425,9 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
             writeStream = new BinaryWriter(new MemoryStream());
         }
 
-        byte _bitPosition = 8;
-        byte BitValue;
-        BinaryWriter writeStream;
-        BinaryReader readStream;
+        private byte _bitPosition = 8;
+        private byte BitValue;
+        private BinaryWriter writeStream;
+        private BinaryReader readStream;
     }
 }

--- a/BardMusicPlayer.Jamboree/PartyNetworking/Server-Client/NetworkSocket.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/Server-Client/NetworkSocket.cs
@@ -10,23 +10,24 @@ using System.Timers;
 using BardMusicPlayer.Jamboree.Events;
 using BardMusicPlayer.Jamboree.PartyClient.PartyManagement;
 using BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover;
+using BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier;
 using ZeroTier.Sockets;
 
 namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
 {
     public class NetworkSocket
     {
-        private bool _close = false;
+        private bool _close;
         private PartyClientInfo _clientInfo = new PartyClientInfo();
 
         public PartyClientInfo PartyClient { get { return _clientInfo; } }
 
-        public ZeroTierExtendedSocket ListenSocket { get; set; } = null;
-        public ZeroTierExtendedSocket ConnectorSocket { get; set; } = null;
+        public ZeroTierExtendedSocket ListenSocket { get; set; }
+        public ZeroTierExtendedSocket ConnectorSocket { get; set; }
         private string _remoteIP = "";
 
         Timer _timer;
-        bool _await_pong = false;
+        bool _await_pong;
 
         public NetworkSocket(string IP)
         {
@@ -168,9 +169,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
                 case NetworkOpcodes.OpcodeEnum.MSG_SONG_DATA:
                     System.Diagnostics.Debug.WriteLine("");
                     break;
-                default:
-                    break;
-            };
+            }
         }
 
         public void CloseConnection()

--- a/BardMusicPlayer.Jamboree/PartyNetworking/Server-Client/ZeroTierPartyServer.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/Server-Client/ZeroTierPartyServer.cs
@@ -9,233 +9,232 @@ using BardMusicPlayer.Jamboree.PartyClient.PartyManagement;
 using BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover;
 using BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier;
 
-namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client
-{
-    public class NetworkPartyServer : IDisposable
-    {
-        private static readonly Lazy<NetworkPartyServer> lazy = new(() => new NetworkPartyServer());
-        public static NetworkPartyServer Instance => lazy.Value;
+namespace BardMusicPlayer.Jamboree.PartyNetworking.Server_Client;
 
-        private NetworkPartyServer() { }
-        ~NetworkPartyServer()
-        {
+public class NetworkPartyServer : IDisposable
+{
+    private static readonly Lazy<NetworkPartyServer> lazy = new(() => new NetworkPartyServer());
+    public static NetworkPartyServer Instance => lazy.Value;
+
+    private NetworkPartyServer() { }
+    ~NetworkPartyServer()
+    {
 #if DEBUG
             Console.WriteLine("Destructor Called."); // Breakpoint here
 #endif
-        }
+    }
 
-        void IDisposable.Dispose()
-        {
-            svcWorker.Stop();
+    void IDisposable.Dispose()
+    {
+        svcWorker.Stop();
 #if DEBUG
             Console.WriteLine("Dispose Called.");
 #endif
-            //GC.SuppressFinalize(this);
-        }
+        //GC.SuppressFinalize(this);
+    }
 
-        private SocketServer svcWorker { get; set; }
+    private SocketServer svcWorker { get; set; }
 
-        public void StartServer(IPEndPoint iPEndPoint, byte type, string name)
+    public void StartServer(IPEndPoint iPEndPoint, byte type, string name)
+    {
+        var objWorkerServerDiscovery = new BackgroundWorker();
+        objWorkerServerDiscovery.WorkerReportsProgress      = true;
+        objWorkerServerDiscovery.WorkerSupportsCancellation = true;
+
+        svcWorker = new SocketServer(ref objWorkerServerDiscovery, iPEndPoint, type, name);
+        objWorkerServerDiscovery.DoWork += svcWorker.Start;
+        objWorkerServerDiscovery.ProgressChanged += logWorkers_ProgressChanged;
+        objWorkerServerDiscovery.RunWorkerAsync();
+    }
+
+    public void Stop()
+    {
+        svcWorker.Stop();
+    }
+
+    private static void logWorkers_ProgressChanged(object sender, ProgressChangedEventArgs e)
+    {
+        Console.WriteLine(e.UserState.ToString());
+    }
+}
+
+public class SocketServer
+{
+    public bool disposing;
+    public IPEndPoint iPEndPoint;
+    public int ServerPort = 0;
+    private ZeroTierExtendedSocket listener;
+    private Dictionary<string, KeyValuePair<long, ZeroTierExtendedSocket> > _pushBacklist = new();
+
+    private List<NetworkSocket> sessions = new();
+    private List<NetworkSocket> removed_sessions = new();
+
+
+
+    private PartyClientInfo _clientInfo = new();
+
+    public SocketServer(ref BackgroundWorker w, IPEndPoint localEndPoint, byte type, string name)
+    {
+        iPEndPoint = localEndPoint;
+        w.ReportProgress(1, "Server");
+
+        _clientInfo.Performer_Type = type;
+        _clientInfo.Performer_Name = name;
+
+        FoundClients.Instance.OnNewAddress += Instance_Finished; //Triggered if a new IP was added
+    }
+
+    public void Instance_Finished(object sender, string ip)
+    {
+        if (!_pushBacklist.TryGetValue(ip, out var val))
+            return;
+
+        var handler = val.Value;
+        if (AddClient(handler))
         {
-            var objWorkerServerDiscovery = new BackgroundWorker();
-            objWorkerServerDiscovery.WorkerReportsProgress = true;
-            objWorkerServerDiscovery.WorkerSupportsCancellation = true;
-
-            svcWorker = new SocketServer(ref objWorkerServerDiscovery, iPEndPoint, type, name);
-            objWorkerServerDiscovery.DoWork += svcWorker.Start;
-            objWorkerServerDiscovery.ProgressChanged += logWorkers_ProgressChanged;
-            objWorkerServerDiscovery.RunWorkerAsync();
-        }
-
-        public void Stop()
-        {
-            svcWorker.Stop();
-        }
-
-        private static void logWorkers_ProgressChanged(object sender, ProgressChangedEventArgs e)
-        {
-            Console.WriteLine(e.UserState.ToString());
+            _pushBacklist.Remove(ip);
         }
     }
 
-    public class SocketServer
+    private bool AddClient(ZeroTierExtendedSocket handler)
     {
-        public bool disposing;
-        public IPEndPoint iPEndPoint;
-        public int ServerPort = 0;
-        private ZeroTierExtendedSocket listener;
-        private Dictionary<string, KeyValuePair<long, ZeroTierExtendedSocket> > _pushBacklist = new();
-
-        private List<NetworkSocket> sessions = new();
-        private List<NetworkSocket> removed_sessions = new();
-
-
-
-        private PartyClientInfo _clientInfo = new();
-
-        public SocketServer(ref BackgroundWorker w, IPEndPoint localEndPoint, byte type, string name)
+        var remoteIpEndPoint = handler.RemoteEndPoint as IPEndPoint;
+        if (!FoundClients.Instance.IsIpInList(remoteIpEndPoint?.Address.ToString()))
         {
-            iPEndPoint = localEndPoint;
-            w.ReportProgress(1, "Server");
-
-            _clientInfo.Performer_Type = type;
-            _clientInfo.Performer_Name = name;
-
-            FoundClients.Instance.OnNewAddress += Instance_Finished; //Triggered if a new IP was added
-        }
-
-        public void Instance_Finished(object sender, string ip)
-        {
-            if (!_pushBacklist.TryGetValue(ip, out var val))
-                return;
-
-            var handler = val.Value;
-            if (AddClient(handler))
-            {
-                _pushBacklist.Remove(ip);
-            }
-        }
-
-        private bool AddClient(ZeroTierExtendedSocket handler)
-        {
-            var remoteIpEndPoint = handler.RemoteEndPoint as IPEndPoint;
-            if (!FoundClients.Instance.IsIpInList(remoteIpEndPoint?.Address.ToString()))
-            {
-                BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("[SocketServer]: Error Ip not in list\r\n"));
-                return false;
-            }
-
-            var sockets = FoundClients.Instance.FindSocket(remoteIpEndPoint?.Address.ToString());
-            if (sockets != null)
-            {
-                BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("[SocketServer]: Session added\r\n"));
-                sockets.ListenSocket = handler;
-                lock (sessions)
-                {
-                    sessions.Add(sockets);
-                }
-                return true;
-            }
-
-            BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("[SocketServer]: Error handshake sock null\r\n"));
+            BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("[SocketServer]: Error Ip not in list\r\n"));
             return false;
         }
 
-        public void Start(object sender, DoWorkEventArgs e)
+        var sockets = FoundClients.Instance.FindSocket(remoteIpEndPoint?.Address.ToString());
+        if (sockets != null)
         {
-            System.Threading.Thread.Sleep(3000);
-            listener = new ZeroTierExtendedSocket(System.Net.Sockets.AddressFamily.InterNetwork, System.Net.Sockets.SocketType.Stream, System.Net.Sockets.ProtocolType.Tcp);
-            listener.Bind(iPEndPoint);
-            listener.Listen(10);
-            BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("[SocketServer]: Started\r\n"));
-
-            while (disposing == false)
+            BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("[SocketServer]: Session added\r\n"));
+            sockets.ListenSocket = handler;
+            lock (sessions)
             {
-                var da = DateTimeOffset.Now.ToUnixTimeSeconds();
+                sessions.Add(sockets);
+            }
+            return true;
+        }
 
-                //Only accept if a autodiscover was triggered
-                if (listener.Poll(100, System.Net.Sockets.SelectMode.SelectRead))
-                {
-                    //Incoming connection
-                    var handler = listener.Accept();
-                    var isInList = false;
-                    lock (sessions)
-                    {
-                        Parallel.ForEach(sessions, session =>
-                        {
-                            if (session.ListenSocket == handler)
-                                isInList = true;
-                        });
-                    }
-                    if (!isInList)
-                    {
-                        var remoteIpEndPoint = handler.RemoteEndPoint as IPEndPoint;
-                        if (!AddClient(handler))
-                        {
-                            var val = new KeyValuePair<long, ZeroTierExtendedSocket>(DateTimeOffset.Now.ToUnixTimeSeconds(), handler );
-                            _pushBacklist.Add(remoteIpEndPoint.Address.ToString(), val);
-                        }
-                    }
-                }
+        BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("[SocketServer]: Error handshake sock null\r\n"));
+        return false;
+    }
 
+    public void Start(object sender, DoWorkEventArgs e)
+    {
+        System.Threading.Thread.Sleep(3000);
+        listener = new ZeroTierExtendedSocket(System.Net.Sockets.AddressFamily.InterNetwork, System.Net.Sockets.SocketType.Stream, System.Net.Sockets.ProtocolType.Tcp);
+        listener.Bind(iPEndPoint);
+        listener.Listen(10);
+        BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("[SocketServer]: Started\r\n"));
+
+        while (disposing == false)
+        {
+            var da = DateTimeOffset.Now.ToUnixTimeSeconds();
+
+            //Only accept if a autodiscover was triggered
+            if (listener.Poll(100, System.Net.Sockets.SelectMode.SelectRead))
+            {
+                //Incoming connection
+                var handler = listener.Accept();
+                var isInList = false;
                 lock (sessions)
                 {
-                    //Update the sessions
-                    foreach (var session in sessions.Where(session => !session.Update()))
+                    Parallel.ForEach(sessions, session =>
                     {
-                        removed_sessions.Add(session);
-                    }
-
-                    //Remove dead sessions
-                    foreach (var session in removed_sessions)
+                        if (session.ListenSocket == handler)
+                            isInList = true;
+                    });
+                }
+                if (!isInList)
+                {
+                    var remoteIpEndPoint = handler.RemoteEndPoint as IPEndPoint;
+                    if (!AddClient(handler))
                     {
-                        sessions.Remove(session);
+                        var val = new KeyValuePair<long, ZeroTierExtendedSocket>(DateTimeOffset.Now.ToUnixTimeSeconds(), handler );
+                        _pushBacklist.Add(remoteIpEndPoint.Address.ToString(), val);
                     }
-                }
-                //And clear the list
-                removed_sessions.Clear();
-
-                //Keep the pushback list clean
-                var delPushlist = new List<string>();
-                foreach (var data in _pushBacklist)
-                {
-                    var val = data.Value;
-                    var currtime = DateTimeOffset.Now.ToUnixTimeSeconds();
-
-                    if (val.Key+60 <= currtime)
-                    {
-                        delPushlist.Add(data.Key);
-                        val.Value.Close();
-                    }
-                }
-                lock (_pushBacklist)
-                {
-                    foreach (var i in delPushlist)
-                        _pushBacklist.Remove(i);
-                }
-
-                var db = DateTimeOffset.Now.ToUnixTimeSeconds();
-                try{
-                    Task.Delay((int)(10 - (db - da)));
-                }
-                catch
-                {
-                    // ignored
                 }
             }
 
-            //Finished serving - close all
             lock (sessions)
             {
-                foreach (var s in sessions)
+                //Update the sessions
+                foreach (var session in sessions.Where(session => !session.Update()))
                 {
-                    // Release the socket.
-                    s.CloseConnection();
+                    removed_sessions.Add(session);
+                }
+
+                //Remove dead sessions
+                foreach (var session in removed_sessions)
+                {
+                    sessions.Remove(session);
                 }
             }
+            //And clear the list
+            removed_sessions.Clear();
 
-            listener.KeepAlive = false;
-            try { listener.Shutdown(System.Net.Sockets.SocketShutdown.Both); }
-            finally 
-            { 
-                listener.Close(); 
+            //Keep the pushback list clean
+            var delPushlist = new List<string>();
+            foreach (var data in _pushBacklist)
+            {
+                var val = data.Value;
+                var currtime = DateTimeOffset.Now.ToUnixTimeSeconds();
+
+                if (val.Key+60 <= currtime)
+                {
+                    delPushlist.Add(data.Key);
+                    val.Value.Close();
+                }
             }
+            lock (_pushBacklist)
+            {
+                foreach (var i in delPushlist)
+                    _pushBacklist.Remove(i);
+            }
+
+            var db = DateTimeOffset.Now.ToUnixTimeSeconds();
+            try{
+                Task.Delay((int)(10 - (db - da)));
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+
+        //Finished serving - close all
+        lock (sessions)
+        {
+            foreach (var s in sessions)
+            {
+                // Release the socket.
+                s.CloseConnection();
+            }
+        }
+
+        listener.KeepAlive = false;
+        try { listener.Shutdown(System.Net.Sockets.SocketShutdown.Both); }
+        finally 
+        { 
+            listener.Close(); 
+        }
             
-            BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("[SocketServer]: Stopped\r\n"));
-        }
+        BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("[SocketServer]: Stopped\r\n"));
+    }
 
-        public void SendToAll(byte[] pck)
+    public void SendToAll(byte[] pck)
+    {
+        lock (sessions)
         {
-            lock (sessions)
-            {
-                foreach (var session in sessions)
-                    session.SendPacket(pck);
-            }
+            foreach (var session in sessions)
+                session.SendPacket(pck);
         }
+    }
 
-        public void Stop()
-        {
-            disposing = true;
-        }
+    public void Stop()
+    {
+        disposing = true;
     }
 }

--- a/BardMusicPlayer.Jamboree/PartyNetworking/ZeroTier/ZeroTierConnector.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/ZeroTier/ZeroTierConnector.cs
@@ -3,39 +3,39 @@ using System.Threading.Tasks;
 using ZeroTier;
 using ZeroTier.Core;
 
-namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
-{
-    public class ZeroTierConnector
-    {
-        private Node node;
-        private volatile bool nodeOnline;
+namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier;
 
-        /// <summary>
-        /// start zerotier
-        /// </summary>
-        /// <param name="network"></param>
-        /// <returns>Ip address</returns>
-        public Task<string> ZeroTierConnect(string network)
-        {
-            node = new Node();
-            var ipAddress = "";
-            var networkId = (ulong)long.Parse(network, System.Globalization.NumberStyles.HexNumber);
+public class ZeroTierConnector
+{
+    private Node node;
+    private volatile bool nodeOnline;
+
+    /// <summary>
+    /// start zerotier
+    /// </summary>
+    /// <param name="network"></param>
+    /// <returns>Ip address</returns>
+    public Task<string> ZeroTierConnect(string network)
+    {
+        node = new Node();
+        var ipAddress = "";
+        var networkId = (ulong)long.Parse(network, System.Globalization.NumberStyles.HexNumber);
 #if DEBUG
             Console.WriteLine("Connecting to network...");
 #endif
-            //node.InitFromStorage(configFilePath);
-            node.InitAllowNetworkCaching(false);
-            node.InitAllowPeerCaching(false);
-            // node.InitAllowIdentityCaching(true);
-            // node.InitAllowWorldCaching(false);
-            node.InitSetEventHandler(ZeroTierEvent);
-            // node.InitSetPort(0);   // Will randomly attempt ports if not specified or is set to 0
-            node.InitSetRandomPortRange(40000, 50000);
-            // node.InitAllowSecondaryPort(false);
+        //node.InitFromStorage(configFilePath);
+        node.InitAllowNetworkCaching(false);
+        node.InitAllowPeerCaching(false);
+        // node.InitAllowIdentityCaching(true);
+        // node.InitAllowWorldCaching(false);
+        node.InitSetEventHandler(ZeroTierEvent);
+        // node.InitSetPort(0);   // Will randomly attempt ports if not specified or is set to 0
+        node.InitSetRandomPortRange(40000, 50000);
+        // node.InitAllowSecondaryPort(false);
 
-            node.Start();   // Network activity only begins after calling Start()
-            while (!nodeOnline)
-            { Task.Delay(50); }
+        node.Start(); // Network activity only begins after calling Start()
+        while (!nodeOnline)
+        { Task.Delay(50); }
 #if DEBUG
             Console.WriteLine("Id            : " + node.IdString);
             Console.WriteLine("Version       : " + node.Version);
@@ -43,33 +43,33 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
             Console.WriteLine("SecondaryPort : " + node.SecondaryPort);
             Console.WriteLine("TertiaryPort  : " + node.TertiaryPort);
 #endif
-            node.Join(networkId);
+        node.Join(networkId);
 
 #if DEBUG
             Console.WriteLine("Waiting for join to complete...");
 #endif
-            while (node.Networks.Count == 0)
-            {
-                Task.Delay(50);
-            }
+        while (node.Networks.Count == 0)
+        {
+            Task.Delay(50);
+        }
 
-            // Wait until we've joined the network and we have routes + addresses
+        // Wait until we've joined the network and we have routes + addresses
 #if DEBUG
             Console.WriteLine("Waiting for network to become transport ready...");
 #endif
-            while (!node.IsNetworkTransportReady(networkId))
-            {
-                Task.Delay(50);
-            }
+        while (!node.IsNetworkTransportReady(networkId))
+        {
+            Task.Delay(50);
+        }
 
 #if DEBUG
             Console.WriteLine("Num of assigned addresses : " + node.GetNetworkAddresses(networkId).Count);
 #endif
-            if (node.GetNetworkAddresses(networkId).Count == 1)
-            {
-                var addr = node.GetNetworkAddresses(networkId)[0];
-                ipAddress = addr.ToString();
-            }
+        if (node.GetNetworkAddresses(networkId).Count == 1)
+        {
+            var addr = node.GetNetworkAddresses(networkId)[0];
+            ipAddress = addr.ToString();
+        }
 #if DEBUG
             foreach (IPAddress addr in node.GetNetworkAddresses(networkId))
             {
@@ -86,36 +86,35 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
                     route.Metric);
             }
 #endif
-            return Task.FromResult(result: ipAddress);
-        }
+        return Task.FromResult(result: ipAddress);
+    }
 
-        public void ZeroTierDisconnect(bool free)
-        {
-            if (free)
-                node.Free();
-            else
-                node.Stop();
-        }
+    public void ZeroTierDisconnect(bool free)
+    {
+        if (free)
+            node.Free();
+        else
+            node.Stop();
+    }
 
-        private void ZeroTierEvent(Event e)
-        {
+    private void ZeroTierEvent(Event e)
+    {
 #if DEBUG
             Console.WriteLine("Event.Code = {0} ({1})", e.Code, e.Name);
 #endif
-            if (e.Code == Constants.EVENT_NODE_ONLINE)
-            {
-                nodeOnline = true;
-            }
-            if (e.Code == Constants.EVENT_PEER_PATH_DEAD)
-            {
-                Console.WriteLine("DEAD");
-            }
-            /*
-        if (e.Code == ZeroTier.Constants.EVENT_NETWORK_OK) {
-            Console.WriteLine(" - Network ID: " + e.NetworkInfo.Id.ToString("x16"));
+        if (e.Code == Constants.EVENT_NODE_ONLINE)
+        {
+            nodeOnline = true;
         }
-        */
+        if (e.Code == Constants.EVENT_PEER_PATH_DEAD)
+        {
+            Console.WriteLine("DEAD");
         }
-
+        /*
+    if (e.Code == ZeroTier.Constants.EVENT_NETWORK_OK) {
+        Console.WriteLine(" - Network ID: " + e.NetworkInfo.Id.ToString("x16"));
     }
+    */
+    }
+
 }

--- a/BardMusicPlayer.Jamboree/PartyNetworking/ZeroTier/ZeroTierConnector.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/ZeroTier/ZeroTierConnector.cs
@@ -71,17 +71,17 @@ public class ZeroTierConnector
             ipAddress = addr.ToString();
         }
 #if DEBUG
-            foreach (IPAddress addr in node.GetNetworkAddresses(networkId))
+            foreach (var addr in node.GetNetworkAddresses(networkId))
             {
                 Console.WriteLine(" - Address: " + addr);
             }
 
             Console.WriteLine("Num of routes             : " + node.GetNetworkRoutes(networkId).Count);
-            foreach (RouteInfo route in node.GetNetworkRoutes(networkId))
+            foreach (var route in node.GetNetworkRoutes(networkId))
             {
                 Console.WriteLine(" -   Route: target={0} via={1} flags={2} metric={3}",
-                    route.Target.ToString(),
-                    route.Via.ToString(),
+                    route.Target,
+                    route.Via,
                     route.Flags,
                     route.Metric);
             }

--- a/BardMusicPlayer.Jamboree/PartyNetworking/ZeroTier/ZeroTierConnector.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/ZeroTier/ZeroTierConnector.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Threading.Tasks;
 using ZeroTier;
 using ZeroTier.Core;
@@ -8,7 +7,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
 {
     public class ZeroTierConnector
     {
-        Node node;
+        private Node node;
         private volatile bool nodeOnline;
 
         /// <summary>
@@ -19,8 +18,8 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
         public Task<string> ZeroTierConnect(string network)
         {
             node = new Node();
-            string ipAddress = "";
-            ulong networkId = (ulong)Int64.Parse(network, System.Globalization.NumberStyles.HexNumber);
+            var ipAddress = "";
+            var networkId = (ulong)long.Parse(network, System.Globalization.NumberStyles.HexNumber);
 #if DEBUG
             Console.WriteLine("Connecting to network...");
 #endif
@@ -68,7 +67,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
 #endif
             if (node.GetNetworkAddresses(networkId).Count == 1)
             {
-                IPAddress addr = node.GetNetworkAddresses(networkId)[0];
+                var addr = node.GetNetworkAddresses(networkId)[0];
                 ipAddress = addr.ToString();
             }
 #if DEBUG

--- a/BardMusicPlayer.Jamboree/PartyNetworking/ZeroTier/ZeroTierConnector.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/ZeroTier/ZeroTierConnector.cs
@@ -1,19 +1,15 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using ZeroTier;
 using ZeroTier.Core;
 
-namespace ZeroTier
+namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
 {
     public class ZeroTierConnector
     {
         Node node;
-        private volatile bool nodeOnline = false;
+        private volatile bool nodeOnline;
 
         /// <summary>
         /// start zerotier

--- a/BardMusicPlayer.Jamboree/PartyNetworking/ZeroTier/ZeroTierExtendedSocket.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/ZeroTier/ZeroTierExtendedSocket.cs
@@ -5,883 +5,882 @@ using System.Runtime.InteropServices;
 using ZeroTier;
 using SocketException = ZeroTier.Sockets.SocketException;
 
-namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
+namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier;
+
+public class ZeroTierExtendedSocket
 {
-    public class ZeroTierExtendedSocket
+    /// <summary>No error.</summary>
+    public static readonly int ZTS_ERR_OK = 0;
+    /// <summary>Socket error, see Socket.ErrNo() for additional context.</summary>
+    public static readonly int ZTS_ERR_SOCKET = -1;
+    /// <summary>You probably did something at the wrong time.</summary>
+    public static readonly int ZTS_ERR_SERVICE = -2;
+    /// <summary>Invalid argument.</summary>
+    public static readonly int ZTS_ERR_ARG = -3;
+    /// <summary>No result. (not necessarily an error.)</summary>
+    public static readonly int ZTS_ERR_NO_RESULT = -4;
+    /// <summary>Consider filing a bug report.</summary>
+    public static readonly int ZTS_ERR_GENERAL = -5;
+
+    private int _fd;
+    private bool _isClosed;
+    private bool _isListening;
+    internal EndPoint _localEndPoint;
+    internal EndPoint _remoteEndPoint;
+
+    private void InitializeInternalFlags()
     {
-        /// <summary>No error.</summary>
-        public static readonly int ZTS_ERR_OK = 0;
-        /// <summary>Socket error, see Socket.ErrNo() for additional context.</summary>
-        public static readonly int ZTS_ERR_SOCKET = -1;
-        /// <summary>You probably did something at the wrong time.</summary>
-        public static readonly int ZTS_ERR_SERVICE = -2;
-        /// <summary>Invalid argument.</summary>
-        public static readonly int ZTS_ERR_ARG = -3;
-        /// <summary>No result. (not necessarily an error.)</summary>
-        public static readonly int ZTS_ERR_NO_RESULT = -4;
-        /// <summary>Consider filing a bug report.</summary>
-        public static readonly int ZTS_ERR_GENERAL = -5;
+        _isClosed    = false;
+        _isListening = false;
+    }
 
-        private int _fd;
-        private bool _isClosed;
-        private bool _isListening;
-        internal EndPoint _localEndPoint;
-        internal EndPoint _remoteEndPoint;
-
-        private void InitializeInternalFlags()
+    public ZeroTierExtendedSocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
+    {
+        var family = -1;
+        var type = -1;
+        var protocol = -1;
+        // Map .NET socket parameters to ZeroTier equivalents
+        family = addressFamily switch
         {
-            _isClosed = false;
-            _isListening = false;
+            AddressFamily.InterNetwork   => Constants.AF_INET,
+            AddressFamily.InterNetworkV6 => Constants.AF_INET6,
+            AddressFamily.Unknown        => Constants.AF_UNSPEC,
+            _                            => family
+        };
+        type = socketType switch
+        {
+            SocketType.Stream => Constants.SOCK_STREAM,
+            SocketType.Dgram  => Constants.SOCK_DGRAM,
+            _                 => type
+        };
+        protocol = protocolType switch
+        {
+            ProtocolType.Udp         => Constants.IPPROTO_UDP,
+            ProtocolType.Tcp         => Constants.IPPROTO_TCP,
+            ProtocolType.Unspecified => 0 // ?
+            ,
+            _ => protocol
+        };
+        if ((_fd = zts_bsd_socket(family, type, protocol)) < 0)
+        {
+            throw new SocketException(_fd);
+        }
+        AddressFamily = addressFamily;
+        SocketType    = socketType;
+        ProtocolType  = protocolType;
+        InitializeInternalFlags();
+    }
+
+    private ZeroTierExtendedSocket(
+        int fileDescriptor,
+        AddressFamily addressFamily,
+        SocketType socketType,
+        ProtocolType protocolType,
+        EndPoint localEndPoint,
+        EndPoint remoteEndPoint)
+    {
+        AddressFamily   = addressFamily;
+        SocketType      = socketType;
+        ProtocolType    = protocolType;
+        _localEndPoint  = localEndPoint;
+        _remoteEndPoint = remoteEndPoint;
+        _fd             = fileDescriptor;
+        InitializeInternalFlags();
+    }
+
+    public void Connect(IPEndPoint remoteEndPoint)
+    {
+        if (_isClosed)
+        {
+            throw new ObjectDisposedException("Socket has been closed");
+        }
+        if (_fd < 0)
+        {
+            // Invalid file descriptor
+            throw new SocketException(Constants.ERR_SOCKET);
+        }
+        if (remoteEndPoint == null)
+        {
+            throw new ArgumentNullException(nameof(remoteEndPoint));
+        }
+        var err = zts_connect(_fd, remoteEndPoint.Address.ToString(), (ushort)remoteEndPoint.Port, ConnectTimeout);
+        if (err < 0)
+        {
+            throw new SocketException(err, global::ZeroTier.Core.Node.ErrNo);
+        }
+        _remoteEndPoint = remoteEndPoint;
+        Connected       = true;
+    }
+
+    public void Bind(IPEndPoint localEndPoint)
+    {
+        if (_isClosed)
+        {
+            throw new ObjectDisposedException("Socket has been closed");
+        }
+        if (_fd < 0)
+        {
+            // Invalid file descriptor
+            throw new SocketException(Constants.ERR_SOCKET);
+        }
+        if (localEndPoint == null)
+        {
+            throw new ArgumentNullException(nameof(localEndPoint));
         }
 
-        public ZeroTierExtendedSocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
+        var err = localEndPoint.AddressFamily switch
         {
-            var family = -1;
-            var type = -1;
-            var protocol = -1;
-            // Map .NET socket parameters to ZeroTier equivalents
-            family = addressFamily switch
+            AddressFamily.InterNetwork   => zts_bind(_fd, "0.0.0.0", (ushort)localEndPoint.Port),
+            AddressFamily.InterNetworkV6 => zts_bind(_fd, "::", (ushort)localEndPoint.Port),
+            _                            => Constants.ERR_OK
+        };
+        if (err < 0)
+        {
+            throw new SocketException(err);
+        }
+        _localEndPoint = localEndPoint;
+        IsBound        = true;
+    }
+
+    /// <summary>
+    /// The bsd_bind used for broadcasting
+    /// </summary>
+    /// <param name="localEndPoint"></param>
+    /// <exception cref="ObjectDisposedException"></exception>
+    /// <exception cref="SocketException"></exception>
+    /// <exception cref="ArgumentNullException"></exception>
+    public void BSD_Bind(IPEndPoint localEndPoint)
+    {
+        if (_isClosed)
+        {
+            throw new ObjectDisposedException("Socket has been closed");
+        }
+        if (_fd < 0)
+        {
+            // Invalid file descriptor
+            throw new SocketException(Constants.ERR_SOCKET);
+        }
+        if (localEndPoint == null)
+        {
+            throw new ArgumentNullException(nameof(localEndPoint));
+        }
+        int err = Constants.ERR_OK;
+        var broadcast = new zts_sockaddr_in
+        {
+            sin_family = (byte)Constants.AF_INET,
+            sin_addr   = BitConverter.GetBytes(BitConverter.ToInt32(localEndPoint.Address.GetAddressBytes(), 0)),
+            sin_port   = (short)localEndPoint.Port
+        };
+
+        var bcPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(zts_sockaddr)));
+        Marshal.StructureToPtr(broadcast, bcPtr, false);
+
+        err = zts_bsd_bind(_fd, bcPtr, (ushort)Marshal.SizeOf(typeof(zts_sockaddr)));
+        if (err < 0)
+        {
+            var t = ErrNo;
+            Console.WriteLine(t);
+            throw new SocketException(err);
+        }
+        _localEndPoint = localEndPoint;
+        IsBound        = true;
+        Marshal.FreeHGlobal(bcPtr);
+    }
+
+    public void Listen(int backlog)
+    {
+        if (_isClosed)
+        {
+            throw new ObjectDisposedException("Socket has been closed");
+        }
+        if (_fd < 0)
+        {
+            // Invalid file descriptor
+            throw new SocketException(Constants.ERR_SOCKET);
+        }
+        int err = Constants.ERR_OK;
+        if ((err = zts_bsd_listen(_fd, backlog)) < 0)
+        {
+            // Invalid backlog value perhaps?
+            throw new SocketException(Constants.ERR_SOCKET);
+        }
+        _isListening = true;
+    }
+
+    public ZeroTierExtendedSocket Accept()
+    {
+        if (_isClosed)
+        {
+            throw new ObjectDisposedException("Socket has been closed");
+        }
+        if (_fd < 0)
+        {
+            // Invalid file descriptor
+            throw new SocketException(Constants.ERR_SOCKET);
+        }
+        if (_isListening == false)
+        {
+            throw new InvalidOperationException("Socket is not in a listening state. Call Listen() first");
+        }
+        var lpBuffer = Marshal.AllocHGlobal(Constants.INET6_ADDRSTRLEN);
+        var port = 0;
+        var accepted_fd = zts_accept(_fd, lpBuffer, Constants.INET6_ADDRSTRLEN, ref port);
+        // Convert buffer to managed string
+        var str = Marshal.PtrToStringAnsi(lpBuffer);
+        Marshal.FreeHGlobal(lpBuffer);
+        lpBuffer = IntPtr.Zero;
+        var clientEndPoint = new IPEndPoint(IPAddress.Parse(str ?? string.Empty), port);
+        // Create new socket by providing file descriptor returned from zts_bsd_accept call.
+        var clientSocket =
+            new ZeroTierExtendedSocket(accepted_fd, AddressFamily, SocketType, ProtocolType, _localEndPoint, clientEndPoint);
+        return clientSocket;
+    }
+
+    public void Shutdown(SocketShutdown how)
+    {
+        if (_isClosed)
+        {
+            throw new ObjectDisposedException("Socket has been closed");
+        }
+
+        var ztHow = how switch
+        {
+            SocketShutdown.Receive => Constants.O_RDONLY,
+            SocketShutdown.Send    => Constants.O_WRONLY,
+            SocketShutdown.Both    => Constants.O_RDWR,
+            _                      => 0
+        };
+        zts_bsd_shutdown(_fd, ztHow);
+    }
+
+    public void Close(int timeout = 0)
+    {
+        // TODO: Timeout needs to be implemented
+        if (_isClosed)
+        {
+            throw new ObjectDisposedException("Socket has already been closed");
+        }
+        zts_bsd_close(_fd);
+        _isClosed = true;
+    }
+
+    public bool Blocking
+    {
+        get => Convert.ToBoolean(zts_get_blocking(_fd));
+        set => zts_set_blocking(_fd, Convert.ToInt32(value));
+    }
+
+    public bool reuse_addr
+    {
+        get => Convert.ToBoolean(zts_get_reuse_addr(_fd));
+        set => zts_set_reuse_addr(_fd, Convert.ToInt32(value));
+    }
+
+    public bool Poll(int microSeconds, SelectMode mode)
+    {
+        if (_isClosed)
+        {
+            throw new ObjectDisposedException("Socket has been closed");
+        }
+        var poll_set = new zts_pollfd
+        {
+            fd = _fd
+        };
+        poll_set.events = mode switch
+        {
+            SelectMode.SelectRead  => Constants.POLLIN,
+            SelectMode.SelectWrite => Constants.POLLOUT,
+            SelectMode.SelectError => (short)((byte)Constants.POLLERR | (byte)Constants.POLLNVAL),
+            _                      => poll_set.events
+        };
+        var poll_fd_ptr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(zts_pollfd)));
+        Marshal.StructureToPtr(poll_set, poll_fd_ptr, false);
+        var result = 0;
+        var timeout_ms = microSeconds / 1000;
+        uint numfds = 1;
+        if ((result = zts_bsd_poll(poll_fd_ptr, numfds, timeout_ms)) < 0)
+        {
+            throw new SocketException(result, global::ZeroTier.Core.Node.ErrNo);
+        }
+        poll_set = (zts_pollfd)Marshal.PtrToStructure(poll_fd_ptr, typeof(zts_pollfd));
+        if (result != 0)
+        {
+            result = mode switch
             {
-                AddressFamily.InterNetwork   => Constants.AF_INET,
-                AddressFamily.InterNetworkV6 => Constants.AF_INET6,
-                AddressFamily.Unknown        => Constants.AF_UNSPEC,
-                _                            => family
+                SelectMode.SelectRead  => Convert.ToInt32(((byte)poll_set.revents & (byte)Constants.POLLIN) != 0),
+                SelectMode.SelectWrite => Convert.ToInt32(((byte)poll_set.revents & (byte)Constants.POLLOUT) != 0),
+                SelectMode.SelectError => Convert.ToInt32((poll_set.revents & (byte)Constants.POLLERR) != 0 ||
+                                                          (poll_set.revents & (byte)Constants.POLLNVAL) != 0),
+                _ => result
             };
-            type = socketType switch
-            {
-                SocketType.Stream => Constants.SOCK_STREAM,
-                SocketType.Dgram  => Constants.SOCK_DGRAM,
-                _                 => type
-            };
-            protocol = protocolType switch
-            {
-                ProtocolType.Udp         => Constants.IPPROTO_UDP,
-                ProtocolType.Tcp         => Constants.IPPROTO_TCP,
-                ProtocolType.Unspecified => 0 // ?
-                ,
-                _ => protocol
-            };
-            if ((_fd = zts_bsd_socket(family, type, protocol)) < 0)
-            {
-                throw new SocketException(_fd);
-            }
-            AddressFamily = addressFamily;
-            SocketType = socketType;
-            ProtocolType = protocolType;
-            InitializeInternalFlags();
         }
+        Marshal.FreeHGlobal(poll_fd_ptr);
+        return result > 0;
+    }
 
-        private ZeroTierExtendedSocket(
-            int fileDescriptor,
-            AddressFamily addressFamily,
-            SocketType socketType,
-            ProtocolType protocolType,
-            EndPoint localEndPoint,
-            EndPoint remoteEndPoint)
+    public int Send(byte[] buffer)
+    {
+        return Send(buffer, 0, buffer?.Length ?? 0, SocketFlags.None);
+    }
+
+    public int Send(byte[] buffer, int offset, int size, SocketFlags socketFlags)
+    {
+        if (_isClosed)
         {
-            AddressFamily = addressFamily;
-            SocketType = socketType;
-            ProtocolType = protocolType;
-            _localEndPoint = localEndPoint;
-            _remoteEndPoint = remoteEndPoint;
-            _fd = fileDescriptor;
-            InitializeInternalFlags();
+            throw new ObjectDisposedException("Socket has been closed");
         }
-
-        public void Connect(IPEndPoint remoteEndPoint)
+        if (_fd < 0)
         {
-            if (_isClosed)
-            {
-                throw new ObjectDisposedException("Socket has been closed");
-            }
-            if (_fd < 0)
-            {
-                // Invalid file descriptor
-                throw new SocketException(Constants.ERR_SOCKET);
-            }
-            if (remoteEndPoint == null)
-            {
-                throw new ArgumentNullException(nameof(remoteEndPoint));
-            }
-            var err = zts_connect(_fd, remoteEndPoint.Address.ToString(), (ushort)remoteEndPoint.Port, ConnectTimeout);
-            if (err < 0)
-            {
-                throw new SocketException(err, global::ZeroTier.Core.Node.ErrNo);
-            }
-            _remoteEndPoint = remoteEndPoint;
-            Connected = true;
+            throw new SocketException(Constants.ERR_SOCKET);
         }
-
-        public void Bind(IPEndPoint localEndPoint)
+        if (buffer == null)
         {
-            if (_isClosed)
-            {
-                throw new ObjectDisposedException("Socket has been closed");
-            }
-            if (_fd < 0)
-            {
-                // Invalid file descriptor
-                throw new SocketException(Constants.ERR_SOCKET);
-            }
-            if (localEndPoint == null)
-            {
-                throw new ArgumentNullException(nameof(localEndPoint));
-            }
-
-            var err = localEndPoint.AddressFamily switch
-            {
-                AddressFamily.InterNetwork   => zts_bind(_fd, "0.0.0.0", (ushort)localEndPoint.Port),
-                AddressFamily.InterNetworkV6 => zts_bind(_fd, "::", (ushort)localEndPoint.Port),
-                _                            => Constants.ERR_OK
-            };
-            if (err < 0)
-            {
-                throw new SocketException(err);
-            }
-            _localEndPoint = localEndPoint;
-            IsBound = true;
+            throw new ArgumentNullException(nameof(buffer));
         }
-
-        /// <summary>
-        /// The bsd_bind used for broadcasting
-        /// </summary>
-        /// <param name="localEndPoint"></param>
-        /// <exception cref="ObjectDisposedException"></exception>
-        /// <exception cref="SocketException"></exception>
-        /// <exception cref="ArgumentNullException"></exception>
-        public void BSD_Bind(IPEndPoint localEndPoint)
+        if (size < 0 || size > buffer.Length - offset)
         {
-            if (_isClosed)
-            {
-                throw new ObjectDisposedException("Socket has been closed");
-            }
-            if (_fd < 0)
-            {
-                // Invalid file descriptor
-                throw new SocketException(Constants.ERR_SOCKET);
-            }
-            if (localEndPoint == null)
-            {
-                throw new ArgumentNullException(nameof(localEndPoint));
-            }
-            int err = Constants.ERR_OK;
-            var broadcast = new zts_sockaddr_in
-            {
-                sin_family = (byte)Constants.AF_INET,
-                sin_addr   = BitConverter.GetBytes(BitConverter.ToInt32(localEndPoint.Address.GetAddressBytes(), 0)),
-                sin_port   = (short)localEndPoint.Port
-            };
-
-            var bcPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(zts_sockaddr)));
-            Marshal.StructureToPtr(broadcast, bcPtr, false);
-
-            err = zts_bsd_bind(_fd, bcPtr, (ushort)Marshal.SizeOf(typeof(zts_sockaddr)));
-            if (err < 0)
-            {
-                var t = ErrNo;
-                Console.WriteLine(t);
-                throw new SocketException(err);
-            }
-            _localEndPoint = localEndPoint;
-            IsBound = true;
-            Marshal.FreeHGlobal(bcPtr);
+            throw new ArgumentOutOfRangeException(nameof(size));
         }
-
-        public void Listen(int backlog)
+        if (offset < 0 || offset > buffer.Length)
         {
-            if (_isClosed)
-            {
-                throw new ObjectDisposedException("Socket has been closed");
-            }
-            if (_fd < 0)
-            {
-                // Invalid file descriptor
-                throw new SocketException(Constants.ERR_SOCKET);
-            }
-            int err = Constants.ERR_OK;
-            if ((err = zts_bsd_listen(_fd, backlog)) < 0)
-            {
-                // Invalid backlog value perhaps?
-                throw new SocketException(Constants.ERR_SOCKET);
-            }
-            _isListening = true;
+            throw new ArgumentOutOfRangeException(nameof(offset));
         }
+        const int flags = 0;
+        var bufferPtr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
+        return zts_bsd_send(_fd, bufferPtr + offset, (uint)Buffer.ByteLength(buffer), flags);
+    }
 
-        public ZeroTierExtendedSocket Accept()
+    /// <summary>
+    /// Used for UDP broadcast
+    /// </summary>
+    /// <param name="localEndPoint"></param>
+    /// <param name="buffer"></param>
+    /// <returns></returns>
+    public int SendTo(IPEndPoint localEndPoint, byte[] buffer)
+    {
+        return SendTo(localEndPoint, buffer, 0, buffer?.Length ?? 0, SocketFlags.None);
+    }
+
+    /// <summary>
+    /// Used for UDP broadcast
+    /// </summary>
+    /// <param name="localEndPoint"></param>
+    /// <param name="buffer"></param>
+    /// <param name="offset"></param>
+    /// <param name="size"></param>
+    /// <param name="socketFlags"></param>
+    /// <returns></returns>
+    /// <exception cref="ObjectDisposedException"></exception>
+    /// <exception cref="SocketException"></exception>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    public int SendTo(IPEndPoint localEndPoint, byte[] buffer, int offset, int size, SocketFlags socketFlags)
+    {
+        if (_isClosed)
         {
-            if (_isClosed)
-            {
-                throw new ObjectDisposedException("Socket has been closed");
-            }
-            if (_fd < 0)
-            {
-                // Invalid file descriptor
-                throw new SocketException(Constants.ERR_SOCKET);
-            }
-            if (_isListening == false)
-            {
-                throw new InvalidOperationException("Socket is not in a listening state. Call Listen() first");
-            }
-            var lpBuffer = Marshal.AllocHGlobal(Constants.INET6_ADDRSTRLEN);
-            var port = 0;
-            var accepted_fd = zts_accept(_fd, lpBuffer, Constants.INET6_ADDRSTRLEN, ref port);
-            // Convert buffer to managed string
-            var str = Marshal.PtrToStringAnsi(lpBuffer);
-            Marshal.FreeHGlobal(lpBuffer);
-            lpBuffer = IntPtr.Zero;
-            var clientEndPoint = new IPEndPoint(IPAddress.Parse(str ?? string.Empty), port);
-            // Create new socket by providing file descriptor returned from zts_bsd_accept call.
-            var clientSocket =
-                new ZeroTierExtendedSocket(accepted_fd, AddressFamily, SocketType, ProtocolType, _localEndPoint, clientEndPoint);
-            return clientSocket;
+            throw new ObjectDisposedException("Socket has been closed");
         }
-
-        public void Shutdown(SocketShutdown how)
+        if (_fd < 0)
         {
-            if (_isClosed)
-            {
-                throw new ObjectDisposedException("Socket has been closed");
-            }
-
-            var ztHow = how switch
-            {
-                SocketShutdown.Receive => Constants.O_RDONLY,
-                SocketShutdown.Send    => Constants.O_WRONLY,
-                SocketShutdown.Both    => Constants.O_RDWR,
-                _                      => 0
-            };
-            zts_bsd_shutdown(_fd, ztHow);
+            throw new SocketException(Constants.ERR_SOCKET);
         }
-
-        public void Close(int timeout = 0)
+        if (buffer == null)
         {
-            // TODO: Timeout needs to be implemented
-            if (_isClosed)
-            {
-                throw new ObjectDisposedException("Socket has already been closed");
-            }
-            zts_bsd_close(_fd);
-            _isClosed = true;
+            throw new ArgumentNullException(nameof(buffer));
         }
-
-        public bool Blocking
+        if (size < 0 || size > buffer.Length - offset)
         {
-            get => Convert.ToBoolean(zts_get_blocking(_fd));
-            set => zts_set_blocking(_fd, Convert.ToInt32(value));
+            throw new ArgumentOutOfRangeException(nameof(size));
         }
-
-        public bool reuse_addr
+        if (offset < 0 || offset > buffer.Length)
         {
-            get => Convert.ToBoolean(zts_get_reuse_addr(_fd));
-            set => zts_set_reuse_addr(_fd, Convert.ToInt32(value));
+            throw new ArgumentOutOfRangeException(nameof(offset));
         }
-
-        public bool Poll(int microSeconds, SelectMode mode)
+        var broadcast = new zts_sockaddr_in
         {
-            if (_isClosed)
-            {
-                throw new ObjectDisposedException("Socket has been closed");
-            }
-            var poll_set = new zts_pollfd
-            {
-                fd = _fd
-            };
-            poll_set.events = mode switch
-            {
-                SelectMode.SelectRead  => Constants.POLLIN,
-                SelectMode.SelectWrite => Constants.POLLOUT,
-                SelectMode.SelectError => (short)((byte)Constants.POLLERR | (byte)Constants.POLLNVAL),
-                _                      => poll_set.events
-            };
-            var poll_fd_ptr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(zts_pollfd)));
-            Marshal.StructureToPtr(poll_set, poll_fd_ptr, false);
-            var result = 0;
-            var timeout_ms = microSeconds / 1000;
-            uint numfds = 1;
-            if ((result = zts_bsd_poll(poll_fd_ptr, numfds, timeout_ms)) < 0)
-            {
-                throw new SocketException(result, global::ZeroTier.Core.Node.ErrNo);
-            }
-            poll_set = (zts_pollfd)Marshal.PtrToStructure(poll_fd_ptr, typeof(zts_pollfd));
-            if (result != 0)
-            {
-                result = mode switch
-                {
-                    SelectMode.SelectRead  => Convert.ToInt32(((byte)poll_set.revents & (byte)Constants.POLLIN) != 0),
-                    SelectMode.SelectWrite => Convert.ToInt32(((byte)poll_set.revents & (byte)Constants.POLLOUT) != 0),
-                    SelectMode.SelectError => Convert.ToInt32((poll_set.revents & (byte)Constants.POLLERR) != 0 ||
-                                                              (poll_set.revents & (byte)Constants.POLLNVAL) != 0),
-                    _ => result
-                };
-            }
-            Marshal.FreeHGlobal(poll_fd_ptr);
-            return result > 0;
-        }
+            sin_family = (byte)Constants.AF_INET,
+            sin_addr   = BitConverter.GetBytes(BitConverter.ToInt32(localEndPoint.Address.GetAddressBytes(), 0)),
+            sin_port   = (short)localEndPoint.Port
+        };
 
-        public int Send(byte[] buffer)
+        var bcPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(zts_sockaddr)));
+        Marshal.StructureToPtr(broadcast, bcPtr, false);
+
+        const int flags = 0;
+        var bufferPtr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
+        var er = zts_bsd_sendto(_fd, bufferPtr + offset, (uint)Buffer.ByteLength(buffer), flags, bcPtr, (ushort)Marshal.SizeOf(typeof(zts_sockaddr)));
+        Marshal.FreeHGlobal(bcPtr);
+        return er;
+    }
+
+    public int Available => zts_get_data_available(_fd);
+
+    public int Receive(byte[] buffer)
+    {
+        return Receive(buffer, 0, buffer?.Length ?? 0, SocketFlags.None);
+    }
+
+    public int Receive(byte[] buffer, int offset, int size, SocketFlags socketFlags)
+    {
+        if (_isClosed)
         {
-            return Send(buffer, 0, buffer?.Length ?? 0, SocketFlags.None);
+            throw new ObjectDisposedException("Socket has been closed");
         }
-
-        public int Send(byte[] buffer, int offset, int size, SocketFlags socketFlags)
+        if (_fd < 0)
         {
-            if (_isClosed)
-            {
-                throw new ObjectDisposedException("Socket has been closed");
-            }
-            if (_fd < 0)
-            {
-                throw new SocketException(Constants.ERR_SOCKET);
-            }
-            if (buffer == null)
-            {
-                throw new ArgumentNullException(nameof(buffer));
-            }
-            if (size < 0 || size > buffer.Length - offset)
-            {
-                throw new ArgumentOutOfRangeException(nameof(size));
-            }
-            if (offset < 0 || offset > buffer.Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(offset));
-            }
-            const int flags = 0;
-            var bufferPtr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
-            return zts_bsd_send(_fd, bufferPtr + offset, (uint)Buffer.ByteLength(buffer), flags);
+            throw new SocketException(Constants.ERR_SOCKET);
         }
-
-        /// <summary>
-        /// Used for UDP broadcast
-        /// </summary>
-        /// <param name="localEndPoint"></param>
-        /// <param name="buffer"></param>
-        /// <returns></returns>
-        public int SendTo(IPEndPoint localEndPoint, byte[] buffer)
+        if (buffer == null)
         {
-            return SendTo(localEndPoint, buffer, 0, buffer?.Length ?? 0, SocketFlags.None);
+            throw new ArgumentNullException(nameof(buffer));
         }
-
-        /// <summary>
-        /// Used for UDP broadcast
-        /// </summary>
-        /// <param name="localEndPoint"></param>
-        /// <param name="buffer"></param>
-        /// <param name="offset"></param>
-        /// <param name="size"></param>
-        /// <param name="socketFlags"></param>
-        /// <returns></returns>
-        /// <exception cref="ObjectDisposedException"></exception>
-        /// <exception cref="SocketException"></exception>
-        /// <exception cref="ArgumentNullException"></exception>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public int SendTo(IPEndPoint localEndPoint, byte[] buffer, int offset, int size, SocketFlags socketFlags)
+        if (size < 0 || size > buffer.Length - offset)
         {
-            if (_isClosed)
-            {
-                throw new ObjectDisposedException("Socket has been closed");
-            }
-            if (_fd < 0)
-            {
-                throw new SocketException(Constants.ERR_SOCKET);
-            }
-            if (buffer == null)
-            {
-                throw new ArgumentNullException(nameof(buffer));
-            }
-            if (size < 0 || size > buffer.Length - offset)
-            {
-                throw new ArgumentOutOfRangeException(nameof(size));
-            }
-            if (offset < 0 || offset > buffer.Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(offset));
-            }
-            var broadcast = new zts_sockaddr_in
-            {
-                sin_family = (byte)Constants.AF_INET,
-                sin_addr   = BitConverter.GetBytes(BitConverter.ToInt32(localEndPoint.Address.GetAddressBytes(), 0)),
-                sin_port   = (short)localEndPoint.Port
-            };
-
-            var bcPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(zts_sockaddr)));
-            Marshal.StructureToPtr(broadcast, bcPtr, false);
-
-            const int flags = 0;
-            var bufferPtr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
-            var er = zts_bsd_sendto(_fd, bufferPtr + offset, (uint)Buffer.ByteLength(buffer), flags, bcPtr, (ushort)Marshal.SizeOf(typeof(zts_sockaddr)));
-            Marshal.FreeHGlobal(bcPtr);
-            return er;
+            throw new ArgumentOutOfRangeException(nameof(size));
         }
-
-        public int Available => zts_get_data_available(_fd);
-
-        public int Receive(byte[] buffer)
+        if (offset < 0 || offset > buffer.Length)
         {
-            return Receive(buffer, 0, buffer?.Length ?? 0, SocketFlags.None);
+            throw new ArgumentOutOfRangeException(nameof(offset));
         }
+        const int flags = 0;
+        var bufferPtr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
+        var er = zts_bsd_recv(_fd, bufferPtr + offset, (uint)Buffer.ByteLength(buffer), flags);
+        return er;
+    }
 
-        public int Receive(byte[] buffer, int offset, int size, SocketFlags socketFlags)
+    public int ReceiveFrom(byte[] buffer)
+    {
+        return ReceiveFrom(buffer, buffer?.Length ?? 0);
+    }
+
+    public int ReceiveFrom(byte[] buffer, int size)
+    {
+        if (_isClosed)
         {
-            if (_isClosed)
-            {
-                throw new ObjectDisposedException("Socket has been closed");
-            }
-            if (_fd < 0)
-            {
-                throw new SocketException(Constants.ERR_SOCKET);
-            }
-            if (buffer == null)
-            {
-                throw new ArgumentNullException(nameof(buffer));
-            }
-            if (size < 0 || size > buffer.Length - offset)
-            {
-                throw new ArgumentOutOfRangeException(nameof(size));
-            }
-            if (offset < 0 || offset > buffer.Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(offset));
-            }
-            const int flags = 0;
-            var bufferPtr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
-            var er = zts_bsd_recv(_fd, bufferPtr + offset, (uint)Buffer.ByteLength(buffer), flags);
-            return er;
+            throw new ObjectDisposedException("Socket has been closed");
         }
-
-        public int ReceiveFrom(byte[] buffer)
+        if (_fd < 0)
         {
-            return ReceiveFrom(buffer, buffer?.Length ?? 0);
+            throw new SocketException(Constants.ERR_SOCKET);
         }
-
-        public int ReceiveFrom(byte[] buffer, int size)
+        if (buffer == null)
         {
-            if (_isClosed)
-            {
-                throw new ObjectDisposedException("Socket has been closed");
-            }
-            if (_fd < 0)
-            {
-                throw new SocketException(Constants.ERR_SOCKET);
-            }
-            if (buffer == null)
-            {
-                throw new ArgumentNullException(nameof(buffer));
-            }
-            if (size < 0 || size > buffer.Length)
-            {
-                throw new ArgumentOutOfRangeException(nameof(size));
-            }
-            const int broadcast = 0;
-            var lpBuffer = Marshal.AllocHGlobal(broadcast);
-            var bufferPtr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
-            var er = zts_bsd_recvfrom(_fd, bufferPtr, (uint)Buffer.ByteLength(buffer)-1, 0, IntPtr.Zero, lpBuffer);
-            Marshal.FreeHGlobal(lpBuffer);
-            return er;
+            throw new ArgumentNullException(nameof(buffer));
         }
-
-        public int ReceiveTimeout
+        if (size < 0 || size > buffer.Length)
         {
-            get => zts_get_recv_timeout(_fd);
-            // TODO: microseconds
-            set => zts_set_recv_timeout(_fd, value, 0);
+            throw new ArgumentOutOfRangeException(nameof(size));
         }
+        const int broadcast = 0;
+        var lpBuffer = Marshal.AllocHGlobal(broadcast);
+        var bufferPtr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
+        var er = zts_bsd_recvfrom(_fd, bufferPtr, (uint)Buffer.ByteLength(buffer)-1, 0, IntPtr.Zero, lpBuffer);
+        Marshal.FreeHGlobal(lpBuffer);
+        return er;
+    }
 
-        public int SendTimeout
+    public int ReceiveTimeout
+    {
+        get => zts_get_recv_timeout(_fd);
+        // TODO: microseconds
+        set => zts_set_recv_timeout(_fd, value, 0);
+    }
+
+    public int SendTimeout
+    {
+        get => zts_get_send_timeout(_fd);
+        // TODO: microseconds
+        set => zts_set_send_timeout(_fd, value, 0);
+    }
+
+    public int ConnectTimeout { get; set; } = 30000;
+
+    public int ReceiveBufferSize
+    {
+        get => zts_get_recv_buf_size(_fd);
+        set => zts_set_recv_buf_size(_fd, value);
+    }
+
+    public int SendBufferSize
+    {
+        get => zts_get_send_buf_size(_fd);
+        set => zts_set_send_buf_size(_fd, value);
+    }
+
+    public int SetBroadcast()
+    {
+        const int broadcast = 1;
+        var lpBuffer = Marshal.AllocHGlobal(broadcast);
+
+        return zts_bsd_setsockopt(_fd, Constants.SOL_SOCKET, Constants.SO_BROADCAST, lpBuffer, sizeof(int));
+    }
+
+    public short Ttl
+    {
+        get => Convert.ToInt16(zts_get_ttl(_fd));
+        set => zts_set_ttl(_fd, value);
+    }
+
+    public LingerOption LingerState
+    {
+        get
         {
-            get => zts_get_send_timeout(_fd);
-            // TODO: microseconds
-            set => zts_set_send_timeout(_fd, value, 0);
+            var lo =
+                new LingerOption(Convert.ToBoolean(zts_get_linger_enabled(_fd)), zts_get_linger_value(_fd));
+            return lo;
         }
+        set => zts_set_linger(_fd, Convert.ToInt32(value.Enabled), value.LingerTime);
+    }
 
-        public int ConnectTimeout { get; set; } = 30000;
+    public bool NoDelay
+    {
+        get => Convert.ToBoolean(zts_get_no_delay(_fd));
+        set => zts_set_no_delay(_fd, Convert.ToInt32(value));
+    }
 
-        public int ReceiveBufferSize
-        {
-            get => zts_get_recv_buf_size(_fd);
-            set => zts_set_recv_buf_size(_fd, value);
-        }
+    public bool KeepAlive
+    {
+        get => Convert.ToBoolean(zts_get_keepalive(_fd));
+        set => zts_set_keepalive(_fd, Convert.ToInt32(value));
+    }
 
-        public int SendBufferSize
-        {
-            get => zts_get_send_buf_size(_fd);
-            set => zts_set_send_buf_size(_fd, value);
-        }
+    public bool Connected { get; private set; }
 
-        public int SetBroadcast()
-        {
-            const int broadcast = 1;
-            var lpBuffer = Marshal.AllocHGlobal(broadcast);
+    public bool IsBound { get; private set; }
 
-            return zts_bsd_setsockopt(_fd, Constants.SOL_SOCKET, Constants.SO_BROADCAST, lpBuffer, sizeof(int));
-        }
+    public AddressFamily AddressFamily { get; }
 
-        public short Ttl
-        {
-            get => Convert.ToInt16(zts_get_ttl(_fd));
-            set => zts_set_ttl(_fd, value);
-        }
+    public SocketType SocketType { get; }
 
-        public LingerOption LingerState
-        {
-            get
-            {
-                var lo =
-                    new LingerOption(Convert.ToBoolean(zts_get_linger_enabled(_fd)), zts_get_linger_value(_fd));
-                return lo;
-            }
-            set => zts_set_linger(_fd, Convert.ToInt32(value.Enabled), value.LingerTime);
-        }
+    public ProtocolType ProtocolType { get; }
 
-        public bool NoDelay
-        {
-            get => Convert.ToBoolean(zts_get_no_delay(_fd));
-            set => zts_set_no_delay(_fd, Convert.ToInt32(value));
-        }
+    /* .NET has moved to OSSupportsIPv* but libzt isn't an OS so we keep this old convention */
+    public static bool SupportsIPv4 => true;
 
-        public bool KeepAlive
-        {
-            get => Convert.ToBoolean(zts_get_keepalive(_fd));
-            set => zts_set_keepalive(_fd, Convert.ToInt32(value));
-        }
+    /* .NET has moved to OSSupportsIPv* but libzt isn't an OS so we keep this old convention */
+    public static bool SupportsIPv6 => true;
 
-        public bool Connected { get; private set; }
+    public EndPoint RemoteEndPoint => _remoteEndPoint;
 
-        public bool IsBound { get; private set; }
+    public EndPoint LocalEndPoint => _localEndPoint;
 
-        public AddressFamily AddressFamily { get; }
+    /* Structures and functions used internally to communicate with
+    lower-level C API defined in include/ZeroTierSockets.h */
 
-        public SocketType SocketType { get; }
-
-        public ProtocolType ProtocolType { get; }
-
-        /* .NET has moved to OSSupportsIPv* but libzt isn't an OS so we keep this old convention */
-        public static bool SupportsIPv4 => true;
-
-        /* .NET has moved to OSSupportsIPv* but libzt isn't an OS so we keep this old convention */
-        public static bool SupportsIPv6 => true;
-
-        public EndPoint RemoteEndPoint => _remoteEndPoint;
-
-        public EndPoint LocalEndPoint => _localEndPoint;
-
-        /* Structures and functions used internally to communicate with
-        lower-level C API defined in include/ZeroTierSockets.h */
-
-        [DllImport(
-            "libzt",
-            CharSet = CharSet.Ansi,
-            EntryPoint = "CSharp_zts_bsd_gethostbyname")]
-        public static extern IntPtr
+    [DllImport(
+        "libzt",
+        CharSet = CharSet.Ansi,
+        EntryPoint = "CSharp_zts_bsd_gethostbyname")]
+    public static extern IntPtr
         zts_bsd_gethostbyname(string jarg1);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_select")]
-        private static extern int zts_bsd_select(int jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, IntPtr jarg5);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_select")]
+    private static extern int zts_bsd_select(int jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, IntPtr jarg5);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_get_all_stats")]
-        private static extern int zts_get_all_stats(IntPtr arg1);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_get_all_stats")]
+    private static extern int zts_get_all_stats(IntPtr arg1);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_get_protocol_stats")]
-        private static extern int zts_get_protocol_stats(int arg1, IntPtr arg2);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_get_protocol_stats")]
+    private static extern int zts_get_protocol_stats(int arg1, IntPtr arg2);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_socket")]
-        private static extern int zts_bsd_socket(int arg1, int arg2, int arg3);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_socket")]
+    private static extern int zts_bsd_socket(int arg1, int arg2, int arg3);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_connect")]
-        private static extern int zts_bsd_connect(int arg1, IntPtr arg2, ushort arg3);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_connect")]
+    private static extern int zts_bsd_connect(int arg1, IntPtr arg2, ushort arg3);
 
-        [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_bsd_connect_easy")]
-        private static extern int zts_bsd_connect_easy(int arg1, int arg2, string arg3, ushort arg4, int arg5);
+    [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_bsd_connect_easy")]
+    private static extern int zts_bsd_connect_easy(int arg1, int arg2, string arg3, ushort arg4, int arg5);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_bind")]
-        private static extern int zts_bsd_bind(int arg1, IntPtr arg2, ushort arg3);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_bind")]
+    private static extern int zts_bsd_bind(int arg1, IntPtr arg2, ushort arg3);
 
-        [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_bsd_bind_easy")]
-        private static extern int zts_bsd_bind_easy(int arg1, int arg2, string arg3, ushort arg4);
+    [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_bsd_bind_easy")]
+    private static extern int zts_bsd_bind_easy(int arg1, int arg2, string arg3, ushort arg4);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_listen")]
-        private static extern int zts_bsd_listen(int arg1, int arg2);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_listen")]
+    private static extern int zts_bsd_listen(int arg1, int arg2);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_accept")]
-        private static extern int zts_bsd_accept(int arg1, IntPtr arg2, IntPtr arg3);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_accept")]
+    private static extern int zts_bsd_accept(int arg1, IntPtr arg2, IntPtr arg3);
 
-        [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_bsd_accept_easy")]
-        private static extern int zts_bsd_accept_easy(int arg1, IntPtr remoteAddrStr, int arg2, ref int arg3);
+    [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_bsd_accept_easy")]
+    private static extern int zts_bsd_accept_easy(int arg1, IntPtr remoteAddrStr, int arg2, ref int arg3);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_setsockopt")]
-        private static extern int zts_bsd_setsockopt(int arg1, int arg2, int arg3, IntPtr arg4, ushort arg5);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_setsockopt")]
+    private static extern int zts_bsd_setsockopt(int arg1, int arg2, int arg3, IntPtr arg4, ushort arg5);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_getsockopt")]
-        private static extern int zts_bsd_getsockopt(int arg1, int arg2, int arg3, IntPtr arg4, IntPtr arg5);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_getsockopt")]
+    private static extern int zts_bsd_getsockopt(int arg1, int arg2, int arg3, IntPtr arg4, IntPtr arg5);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_getsockname")]
-        private static extern int zts_bsd_getsockname(int arg1, IntPtr arg2, IntPtr arg3);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_getsockname")]
+    private static extern int zts_bsd_getsockname(int arg1, IntPtr arg2, IntPtr arg3);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_getpeername")]
-        private static extern int zts_bsd_getpeername(int arg1, IntPtr arg2, IntPtr arg3);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_getpeername")]
+    private static extern int zts_bsd_getpeername(int arg1, IntPtr arg2, IntPtr arg3);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_close")]
-        private static extern int zts_bsd_close(int arg1);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_close")]
+    private static extern int zts_bsd_close(int arg1);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_fcntl")]
-        private static extern int zts_bsd_fcntl(int arg1, int arg2, int arg3);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_fcntl")]
+    private static extern int zts_bsd_fcntl(int arg1, int arg2, int arg3);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_poll")]
-        private static extern int zts_bsd_poll(IntPtr arg1, uint arg2, int arg3);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_poll")]
+    private static extern int zts_bsd_poll(IntPtr arg1, uint arg2, int arg3);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_ioctl")]
-        private static extern int zts_bsd_ioctl(int arg1, uint arg2, IntPtr arg3);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_ioctl")]
+    private static extern int zts_bsd_ioctl(int arg1, uint arg2, IntPtr arg3);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_send")]
-        private static extern int zts_bsd_send(int arg1, IntPtr arg2, uint arg3, int arg4);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_send")]
+    private static extern int zts_bsd_send(int arg1, IntPtr arg2, uint arg3, int arg4);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_sendto")]
-        private static extern int zts_bsd_sendto(int arg1, IntPtr arg2, uint arg3, int arg4, IntPtr arg5, ushort arg6);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_sendto")]
+    private static extern int zts_bsd_sendto(int arg1, IntPtr arg2, uint arg3, int arg4, IntPtr arg5, ushort arg6);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_sendmsg")]
-        private static extern int zts_bsd_sendmsg(int arg1, IntPtr arg2, int arg3);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_sendmsg")]
+    private static extern int zts_bsd_sendmsg(int arg1, IntPtr arg2, int arg3);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_recv")]
-        private static extern int zts_bsd_recv(int arg1, IntPtr arg2, uint arg3, int arg4);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_recv")]
+    private static extern int zts_bsd_recv(int arg1, IntPtr arg2, uint arg3, int arg4);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_recvfrom")]
-        private static extern int zts_bsd_recvfrom(int arg1, IntPtr arg2, uint arg3, int arg4, IntPtr arg5, IntPtr arg6);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_recvfrom")]
+    private static extern int zts_bsd_recvfrom(int arg1, IntPtr arg2, uint arg3, int arg4, IntPtr arg5, IntPtr arg6);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_recvmsg")]
-        private static extern int zts_bsd_recvmsg(int arg1, IntPtr arg2, int arg3);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_recvmsg")]
+    private static extern int zts_bsd_recvmsg(int arg1, IntPtr arg2, int arg3);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_read")]
-        private static extern int zts_bsd_read(int arg1, IntPtr arg2, uint arg3);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_read")]
+    private static extern int zts_bsd_read(int arg1, IntPtr arg2, uint arg3);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_readv")]
-        private static extern int zts_bsd_readv(int arg1, IntPtr arg2, int arg3);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_readv")]
+    private static extern int zts_bsd_readv(int arg1, IntPtr arg2, int arg3);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_write")]
-        private static extern int zts_bsd_write(int arg1, IntPtr arg2, uint arg3);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_write")]
+    private static extern int zts_bsd_write(int arg1, IntPtr arg2, uint arg3);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_writev")]
-        private static extern int zts_bsd_writev(int arg1, IntPtr arg2, int arg3);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_writev")]
+    private static extern int zts_bsd_writev(int arg1, IntPtr arg2, int arg3);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_shutdown")]
-        private static extern int zts_bsd_shutdown(int arg1, int arg2);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_shutdown")]
+    private static extern int zts_bsd_shutdown(int arg1, int arg2);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_get_data_available")]
-        private static extern int zts_get_data_available(int fd);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_get_data_available")]
+    private static extern int zts_get_data_available(int fd);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_set_no_delay")]
-        private static extern int zts_set_no_delay(int fd, int enabled);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_set_no_delay")]
+    private static extern int zts_set_no_delay(int fd, int enabled);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_get_no_delay")]
-        private static extern int zts_get_no_delay(int fd);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_get_no_delay")]
+    private static extern int zts_get_no_delay(int fd);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_set_linger")]
-        private static extern int zts_set_linger(int fd, int enabled, int value);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_set_linger")]
+    private static extern int zts_set_linger(int fd, int enabled, int value);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_get_linger_enabled")]
-        private static extern int zts_get_linger_enabled(int fd);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_get_linger_enabled")]
+    private static extern int zts_get_linger_enabled(int fd);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_get_linger_value")]
-        private static extern int zts_get_linger_value(int fd);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_get_linger_value")]
+    private static extern int zts_get_linger_value(int fd);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_set_reuse_addr")]
-        private static extern int zts_set_reuse_addr(int fd, int enabled);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_set_reuse_addr")]
+    private static extern int zts_set_reuse_addr(int fd, int enabled);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_get_reuse_addr")]
-        private static extern int zts_get_reuse_addr(int fd);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_get_reuse_addr")]
+    private static extern int zts_get_reuse_addr(int fd);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_set_recv_timeout")]
-        private static extern int zts_set_recv_timeout(int fd, int seconds, int microseconds);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_set_recv_timeout")]
+    private static extern int zts_set_recv_timeout(int fd, int seconds, int microseconds);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_get_recv_timeout")]
-        private static extern int zts_get_recv_timeout(int fd);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_get_recv_timeout")]
+    private static extern int zts_get_recv_timeout(int fd);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_set_send_timeout")]
-        private static extern int zts_set_send_timeout(int fd, int seconds, int microseconds);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_set_send_timeout")]
+    private static extern int zts_set_send_timeout(int fd, int seconds, int microseconds);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_get_send_timeout")]
-        private static extern int zts_get_send_timeout(int fd);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_get_send_timeout")]
+    private static extern int zts_get_send_timeout(int fd);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_set_send_buf_size")]
-        private static extern int zts_set_send_buf_size(int fd, int size);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_set_send_buf_size")]
+    private static extern int zts_set_send_buf_size(int fd, int size);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_get_send_buf_size")]
-        private static extern int zts_get_send_buf_size(int fd);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_get_send_buf_size")]
+    private static extern int zts_get_send_buf_size(int fd);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_set_recv_buf_size")]
-        private static extern int zts_set_recv_buf_size(int fd, int size);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_set_recv_buf_size")]
+    private static extern int zts_set_recv_buf_size(int fd, int size);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_get_recv_buf_size")]
-        private static extern int zts_get_recv_buf_size(int fd);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_get_recv_buf_size")]
+    private static extern int zts_get_recv_buf_size(int fd);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_set_ttl")]
-        private static extern int zts_set_ttl(int fd, int ttl);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_set_ttl")]
+    private static extern int zts_set_ttl(int fd, int ttl);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_get_ttl")]
-        private static extern int zts_get_ttl(int fd);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_get_ttl")]
+    private static extern int zts_get_ttl(int fd);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_set_blocking")]
-        private static extern int zts_set_blocking(int fd, int enabled);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_set_blocking")]
+    private static extern int zts_set_blocking(int fd, int enabled);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_get_blocking")]
-        private static extern int zts_get_blocking(int fd);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_get_blocking")]
+    private static extern int zts_get_blocking(int fd);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_set_keepalive")]
-        private static extern int zts_set_keepalive(int fd, int enabled);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_set_keepalive")]
+    private static extern int zts_set_keepalive(int fd, int enabled);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_get_keepalive")]
-        private static extern int zts_get_keepalive(int fd);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_get_keepalive")]
+    private static extern int zts_get_keepalive(int fd);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_add_dns_nameserver")]
-        private static extern int zts_add_dns_nameserver(IntPtr arg1);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_add_dns_nameserver")]
+    private static extern int zts_add_dns_nameserver(IntPtr arg1);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_del_dns_nameserver")]
-        private static extern int zts_del_dns_nameserver(IntPtr arg1);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_del_dns_nameserver")]
+    private static extern int zts_del_dns_nameserver(IntPtr arg1);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_errno_get")]
-        private static extern int zts_errno_get();
+    [DllImport("libzt", EntryPoint = "CSharp_zts_errno_get")]
+    private static extern int zts_errno_get();
 
-        [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_accept")]
-        private static extern int zts_accept(int jarg1, IntPtr jarg2, int jarg3, ref int jarg4);
+    [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_accept")]
+    private static extern int zts_accept(int jarg1, IntPtr jarg2, int jarg3, ref int jarg4);
 
-        [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_tcp_client")]
-        private static extern int zts_tcp_client(string jarg1, int jarg2);
+    [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_tcp_client")]
+    private static extern int zts_tcp_client(string jarg1, int jarg2);
 
-        [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_tcp_server")]
-        private static extern int zts_tcp_server(string jarg1, int jarg2, string jarg3, int jarg4, IntPtr jarg5);
+    [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_tcp_server")]
+    private static extern int zts_tcp_server(string jarg1, int jarg2, string jarg3, int jarg4, IntPtr jarg5);
 
-        [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_udp_server")]
-        private static extern int zts_udp_server(string jarg1, int jarg2);
+    [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_udp_server")]
+    private static extern int zts_udp_server(string jarg1, int jarg2);
 
-        [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_udp_client")]
-        private static extern int zts_udp_client(string jarg1);
+    [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_udp_client")]
+    private static extern int zts_udp_client(string jarg1);
 
-        [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_bind")]
-        private static extern int zts_bind(int jarg1, string jarg2, int jarg3);
+    [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_bind")]
+    private static extern int zts_bind(int jarg1, string jarg2, int jarg3);
 
-        [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_connect")]
-        private static extern int zts_connect(int jarg1, string jarg2, int jarg3, int jarg4);
+    [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_connect")]
+    private static extern int zts_connect(int jarg1, string jarg2, int jarg3, int jarg4);
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_stats_get_all")]
-        private static extern int zts_stats_get_all(IntPtr jarg1);
-        /*
-                [DllImport("libzt", EntryPoint = "CSharp_zts_set_no_delay")]
-                static extern int zts_set_no_delay(int jarg1, int jarg2);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_stats_get_all")]
+    private static extern int zts_stats_get_all(IntPtr jarg1);
+    /*
+            [DllImport("libzt", EntryPoint = "CSharp_zts_set_no_delay")]
+            static extern int zts_set_no_delay(int jarg1, int jarg2);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_get_no_delay")]
-                static extern int zts_get_no_delay(int jarg1);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_get_no_delay")]
+            static extern int zts_get_no_delay(int jarg1);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_set_linger")]
-                static extern int zts_set_linger(int jarg1, int jarg2, int jarg3);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_set_linger")]
+            static extern int zts_set_linger(int jarg1, int jarg2, int jarg3);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_get_linger_enabled")]
-                static extern int zts_get_linger_enabled(int jarg1);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_get_linger_enabled")]
+            static extern int zts_get_linger_enabled(int jarg1);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_get_linger_value")]
-                static extern int zts_get_linger_value(int jarg1);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_get_linger_value")]
+            static extern int zts_get_linger_value(int jarg1);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_set_reuse_addr")]
-                static extern int zts_set_reuse_addr(int jarg1, int jarg2);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_set_reuse_addr")]
+            static extern int zts_set_reuse_addr(int jarg1, int jarg2);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_get_reuse_addr")]
-                static extern int zts_get_reuse_addr(int jarg1);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_get_reuse_addr")]
+            static extern int zts_get_reuse_addr(int jarg1);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_set_recv_timeout")]
-                static extern int zts_set_recv_timeout(int jarg1, int jarg2, int jarg3);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_set_recv_timeout")]
+            static extern int zts_set_recv_timeout(int jarg1, int jarg2, int jarg3);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_get_recv_timeout")]
-                static extern int zts_get_recv_timeout(int jarg1);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_get_recv_timeout")]
+            static extern int zts_get_recv_timeout(int jarg1);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_set_send_timeout")]
-                static extern int zts_set_send_timeout(int jarg1, int jarg2, int jarg3);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_set_send_timeout")]
+            static extern int zts_set_send_timeout(int jarg1, int jarg2, int jarg3);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_get_send_timeout")]
-                static extern int zts_get_send_timeout(int jarg1);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_get_send_timeout")]
+            static extern int zts_get_send_timeout(int jarg1);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_set_send_buf_size")]
-                static extern int zts_set_send_buf_size(int jarg1, int jarg2);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_set_send_buf_size")]
+            static extern int zts_set_send_buf_size(int jarg1, int jarg2);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_get_send_buf_size")]
-                static extern int zts_get_send_buf_size(int jarg1);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_get_send_buf_size")]
+            static extern int zts_get_send_buf_size(int jarg1);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_set_recv_buf_size")]
-                static extern int zts_set_recv_buf_size(int jarg1, int jarg2);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_set_recv_buf_size")]
+            static extern int zts_set_recv_buf_size(int jarg1, int jarg2);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_get_recv_buf_size")]
-                static extern int zts_get_recv_buf_size(int jarg1);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_get_recv_buf_size")]
+            static extern int zts_get_recv_buf_size(int jarg1);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_set_ttl")]
-                static extern int zts_set_ttl(int jarg1, int jarg2);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_set_ttl")]
+            static extern int zts_set_ttl(int jarg1, int jarg2);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_get_ttl")]
-                static extern int zts_get_ttl(int jarg1);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_get_ttl")]
+            static extern int zts_get_ttl(int jarg1);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_set_blocking")]
-                static extern int zts_set_blocking(int jarg1, int jarg2);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_set_blocking")]
+            static extern int zts_set_blocking(int jarg1, int jarg2);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_get_blocking")]
-                static extern int zts_get_blocking(int jarg1);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_get_blocking")]
+            static extern int zts_get_blocking(int jarg1);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_set_keepalive")]
-                static extern int zts_set_keepalive(int jarg1, int jarg2);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_set_keepalive")]
+            static extern int zts_set_keepalive(int jarg1, int jarg2);
 
-                [DllImport("libzt", EntryPoint = "CSharp_zts_get_keepalive")]
-                static extern int zts_get_keepalive(int jarg1);
+            [DllImport("libzt", EntryPoint = "CSharp_zts_get_keepalive")]
+            static extern int zts_get_keepalive(int jarg1);
 
 
 
-        */
+    */
 
-        [DllImport("libzt", EntryPoint = "CSharp_zts_util_delay")]
-        public static extern void zts_util_delay(int jarg1);
+    [DllImport("libzt", EntryPoint = "CSharp_zts_util_delay")]
+    public static extern void zts_util_delay(int jarg1);
 
-        [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_util_get_ip_family")]
-        private static extern int zts_util_get_ip_family(string jarg1);
+    [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_util_get_ip_family")]
+    private static extern int zts_util_get_ip_family(string jarg1);
 
-        [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_util_ipstr_to_saddr")]
-        private static extern int zts_util_ipstr_to_saddr(string jarg1, int jarg2, IntPtr jarg3, IntPtr jarg4);
+    [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_util_ipstr_to_saddr")]
+    private static extern int zts_util_ipstr_to_saddr(string jarg1, int jarg2, IntPtr jarg3, IntPtr jarg4);
 
-        /// <value>The value of errno for the low-level socket layer</value>
-        public static int ErrNo => zts_errno_get();
+    /// <value>The value of errno for the low-level socket layer</value>
+    public static int ErrNo => zts_errno_get();
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct zts_sockaddr
-        {
-            public byte sa_len;
-            public byte sa_family;
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 14)]
-            public byte[] sa_data;
-        }
+    [StructLayout(LayoutKind.Sequential)]
+    private struct zts_sockaddr
+    {
+        public byte sa_len;
+        public byte sa_family;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 14)]
+        public byte[] sa_data;
+    }
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct zts_in_addr
-        {
-            public uint s_addr;
-        }
+    [StructLayout(LayoutKind.Sequential)]
+    private struct zts_in_addr
+    {
+        public uint s_addr;
+    }
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct zts_sockaddr_in
-        {
-            public byte sin_len;
-            public byte sin_family;
-            public short sin_port;
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
-            public byte[] sin_addr;
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
-            public char[] sin_zero;   // SIN_ZERO_LEN
-        }
+    [StructLayout(LayoutKind.Sequential)]
+    private struct zts_sockaddr_in
+    {
+        public byte sin_len;
+        public byte sin_family;
+        public short sin_port;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+        public byte[] sin_addr;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 8)]
+        public char[] sin_zero; // SIN_ZERO_LEN
+    }
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct zts_pollfd
-        {
-            public int fd;
-            public short events;
-            public short revents;
-        }
+    [StructLayout(LayoutKind.Sequential)]
+    private struct zts_pollfd
+    {
+        public int fd;
+        public short events;
+        public short revents;
+    }
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct zts_timeval
-        {
-            public long tv_sec;
-            public long tv_usec;
-        }
+    [StructLayout(LayoutKind.Sequential)]
+    private struct zts_timeval
+    {
+        public long tv_sec;
+        public long tv_usec;
     }
 }

--- a/BardMusicPlayer.Jamboree/PartyNetworking/ZeroTier/ZeroTierExtendedSocket.cs
+++ b/BardMusicPlayer.Jamboree/PartyNetworking/ZeroTier/ZeroTierExtendedSocket.cs
@@ -22,18 +22,9 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
         /// <summary>Consider filing a bug report.</summary>
         public static readonly int ZTS_ERR_GENERAL = -5;
 
-        int _fd;
-        bool _isClosed;
-        bool _isListening;
-        bool _isBound;
-        bool _isConnected;
-
-        int _connectTimeout = 30000;
-
-        AddressFamily _socketFamily;
-        SocketType _socketType;
-        ProtocolType _socketProtocol;
-
+        private int _fd;
+        private bool _isClosed;
+        private bool _isListening;
         internal EndPoint _localEndPoint;
         internal EndPoint _remoteEndPoint;
 
@@ -45,50 +36,38 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
 
         public ZeroTierExtendedSocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
         {
-            int family = -1;
-            int type = -1;
-            int protocol = -1;
+            var family = -1;
+            var type = -1;
+            var protocol = -1;
             // Map .NET socket parameters to ZeroTier equivalents
-            switch (addressFamily)
+            family = addressFamily switch
             {
-                case AddressFamily.InterNetwork:
-                    family = Constants.AF_INET;
-                    break;
-                case AddressFamily.InterNetworkV6:
-                    family = Constants.AF_INET6;
-                    break;
-                case AddressFamily.Unknown:
-                    family = Constants.AF_UNSPEC;
-                    break;
-            }
-            switch (socketType)
+                AddressFamily.InterNetwork   => Constants.AF_INET,
+                AddressFamily.InterNetworkV6 => Constants.AF_INET6,
+                AddressFamily.Unknown        => Constants.AF_UNSPEC,
+                _                            => family
+            };
+            type = socketType switch
             {
-                case SocketType.Stream:
-                    type = Constants.SOCK_STREAM;
-                    break;
-                case SocketType.Dgram:
-                    type = Constants.SOCK_DGRAM;
-                    break;
-            }
-            switch (protocolType)
+                SocketType.Stream => Constants.SOCK_STREAM,
+                SocketType.Dgram  => Constants.SOCK_DGRAM,
+                _                 => type
+            };
+            protocol = protocolType switch
             {
-                case ProtocolType.Udp:
-                    protocol = Constants.IPPROTO_UDP;
-                    break;
-                case ProtocolType.Tcp:
-                    protocol = Constants.IPPROTO_TCP;
-                    break;
-                case ProtocolType.Unspecified:
-                    protocol = 0;   // ?
-                    break;
-            }
+                ProtocolType.Udp         => Constants.IPPROTO_UDP,
+                ProtocolType.Tcp         => Constants.IPPROTO_TCP,
+                ProtocolType.Unspecified => 0 // ?
+                ,
+                _ => protocol
+            };
             if ((_fd = zts_bsd_socket(family, type, protocol)) < 0)
             {
                 throw new SocketException(_fd);
             }
-            _socketFamily = addressFamily;
-            _socketType = socketType;
-            _socketProtocol = protocolType;
+            AddressFamily = addressFamily;
+            SocketType = socketType;
+            ProtocolType = protocolType;
             InitializeInternalFlags();
         }
 
@@ -100,9 +79,9 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
             EndPoint localEndPoint,
             EndPoint remoteEndPoint)
         {
-            _socketFamily = addressFamily;
-            _socketType = socketType;
-            _socketProtocol = protocolType;
+            AddressFamily = addressFamily;
+            SocketType = socketType;
+            ProtocolType = protocolType;
             _localEndPoint = localEndPoint;
             _remoteEndPoint = remoteEndPoint;
             _fd = fileDescriptor;
@@ -122,15 +101,15 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
             }
             if (remoteEndPoint == null)
             {
-                throw new ArgumentNullException("remoteEndPoint");
+                throw new ArgumentNullException(nameof(remoteEndPoint));
             }
-            int err = zts_connect(_fd, remoteEndPoint.Address.ToString(), (ushort)remoteEndPoint.Port, _connectTimeout);
+            var err = zts_connect(_fd, remoteEndPoint.Address.ToString(), (ushort)remoteEndPoint.Port, ConnectTimeout);
             if (err < 0)
             {
                 throw new SocketException(err, global::ZeroTier.Core.Node.ErrNo);
             }
             _remoteEndPoint = remoteEndPoint;
-            _isConnected = true;
+            Connected = true;
         }
 
         public void Bind(IPEndPoint localEndPoint)
@@ -146,24 +125,21 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
             }
             if (localEndPoint == null)
             {
-                throw new ArgumentNullException("localEndPoint");
+                throw new ArgumentNullException(nameof(localEndPoint));
             }
-            int err = Constants.ERR_OK;
-            if (localEndPoint.AddressFamily == AddressFamily.InterNetwork)
+
+            var err = localEndPoint.AddressFamily switch
             {
-                err = zts_bind(_fd, "0.0.0.0", (ushort)localEndPoint.Port);
-            }
-            if (localEndPoint.AddressFamily == AddressFamily.InterNetworkV6)
-            {
-                // Todo: detect IPAddress.IPv6Any
-                err = zts_bind(_fd, "::", (ushort)localEndPoint.Port);
-            }
+                AddressFamily.InterNetwork   => zts_bind(_fd, "0.0.0.0", (ushort)localEndPoint.Port),
+                AddressFamily.InterNetworkV6 => zts_bind(_fd, "::", (ushort)localEndPoint.Port),
+                _                            => Constants.ERR_OK
+            };
             if (err < 0)
             {
                 throw new SocketException(err);
             }
             _localEndPoint = localEndPoint;
-            _isBound = true;
+            IsBound = true;
         }
 
         /// <summary>
@@ -186,26 +162,28 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
             }
             if (localEndPoint == null)
             {
-                throw new ArgumentNullException("localEndPoint");
+                throw new ArgumentNullException(nameof(localEndPoint));
             }
             int err = Constants.ERR_OK;
-            zts_sockaddr_in broadcast = new zts_sockaddr_in();
-            broadcast.sin_family = (byte)Constants.AF_INET;
-            broadcast.sin_addr = BitConverter.GetBytes(BitConverter.ToInt32((localEndPoint.Address.GetAddressBytes()), 0));
-            broadcast.sin_port = (short)localEndPoint.Port;
+            var broadcast = new zts_sockaddr_in
+            {
+                sin_family = (byte)Constants.AF_INET,
+                sin_addr   = BitConverter.GetBytes(BitConverter.ToInt32(localEndPoint.Address.GetAddressBytes(), 0)),
+                sin_port   = (short)localEndPoint.Port
+            };
 
-            IntPtr bcPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(zts_sockaddr)));
+            var bcPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(zts_sockaddr)));
             Marshal.StructureToPtr(broadcast, bcPtr, false);
 
             err = zts_bsd_bind(_fd, bcPtr, (ushort)Marshal.SizeOf(typeof(zts_sockaddr)));
             if (err < 0)
             {
-                int t = ErrNo;
+                var t = ErrNo;
                 Console.WriteLine(t);
                 throw new SocketException(err);
             }
             _localEndPoint = localEndPoint;
-            _isBound = true;
+            IsBound = true;
             Marshal.FreeHGlobal(bcPtr);
         }
 
@@ -244,17 +222,17 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
             {
                 throw new InvalidOperationException("Socket is not in a listening state. Call Listen() first");
             }
-            IntPtr lpBuffer = Marshal.AllocHGlobal(Constants.INET6_ADDRSTRLEN);
-            int port = 0;
-            int accepted_fd = zts_accept(_fd, lpBuffer, Constants.INET6_ADDRSTRLEN, ref port);
+            var lpBuffer = Marshal.AllocHGlobal(Constants.INET6_ADDRSTRLEN);
+            var port = 0;
+            var accepted_fd = zts_accept(_fd, lpBuffer, Constants.INET6_ADDRSTRLEN, ref port);
             // Convert buffer to managed string
-            string str = Marshal.PtrToStringAnsi(lpBuffer);
+            var str = Marshal.PtrToStringAnsi(lpBuffer);
             Marshal.FreeHGlobal(lpBuffer);
             lpBuffer = IntPtr.Zero;
-            IPEndPoint clientEndPoint = new IPEndPoint(IPAddress.Parse(str ?? string.Empty), port);
+            var clientEndPoint = new IPEndPoint(IPAddress.Parse(str ?? string.Empty), port);
             // Create new socket by providing file descriptor returned from zts_bsd_accept call.
-            ZeroTierExtendedSocket clientSocket =
-                new ZeroTierExtendedSocket(accepted_fd, _socketFamily, _socketType, _socketProtocol, _localEndPoint, clientEndPoint);
+            var clientSocket =
+                new ZeroTierExtendedSocket(accepted_fd, AddressFamily, SocketType, ProtocolType, _localEndPoint, clientEndPoint);
             return clientSocket;
         }
 
@@ -264,28 +242,18 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
             {
                 throw new ObjectDisposedException("Socket has been closed");
             }
-            int ztHow = 0;
-            switch (how)
+
+            var ztHow = how switch
             {
-                case SocketShutdown.Receive:
-                    ztHow = Constants.O_RDONLY;
-                    break;
-                case SocketShutdown.Send:
-                    ztHow = Constants.O_WRONLY;
-                    break;
-                case SocketShutdown.Both:
-                    ztHow = Constants.O_RDWR;
-                    break;
-            }
+                SocketShutdown.Receive => Constants.O_RDONLY,
+                SocketShutdown.Send    => Constants.O_WRONLY,
+                SocketShutdown.Both    => Constants.O_RDWR,
+                _                      => 0
+            };
             zts_bsd_shutdown(_fd, ztHow);
         }
 
-        public void Close()
-        {
-            Close(0);
-        }
-
-        public void Close(int timeout)
+        public void Close(int timeout = 0)
         {
             // TODO: Timeout needs to be implemented
             if (_isClosed)
@@ -298,26 +266,14 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
 
         public bool Blocking
         {
-            get
-            {
-                return Convert.ToBoolean(zts_get_blocking(_fd));
-            }
-            set
-            {
-                zts_set_blocking(_fd, Convert.ToInt32(value));
-            }
+            get => Convert.ToBoolean(zts_get_blocking(_fd));
+            set => zts_set_blocking(_fd, Convert.ToInt32(value));
         }
 
         public bool reuse_addr
         {
-            get
-            {
-                return Convert.ToBoolean(zts_get_reuse_addr(_fd));
-            }
-            set
-            {
-                zts_set_reuse_addr(_fd, Convert.ToInt32(value));
-            }
+            get => Convert.ToBoolean(zts_get_reuse_addr(_fd));
+            set => zts_set_reuse_addr(_fd, Convert.ToInt32(value));
         }
 
         public bool Poll(int microSeconds, SelectMode mode)
@@ -326,24 +282,21 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
             {
                 throw new ObjectDisposedException("Socket has been closed");
             }
-            zts_pollfd poll_set = new zts_pollfd();
-            poll_set.fd = _fd;
-            if (mode == SelectMode.SelectRead)
+            var poll_set = new zts_pollfd
             {
-                poll_set.events = (byte)Constants.POLLIN;
-            }
-            if (mode == SelectMode.SelectWrite)
+                fd = _fd
+            };
+            poll_set.events = mode switch
             {
-                poll_set.events = (byte)Constants.POLLOUT;
-            }
-            if (mode == SelectMode.SelectError)
-            {
-                poll_set.events = (short)((byte)Constants.POLLERR | (byte)Constants.POLLNVAL);
-            }
-            IntPtr poll_fd_ptr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(zts_pollfd)));
+                SelectMode.SelectRead  => Constants.POLLIN,
+                SelectMode.SelectWrite => Constants.POLLOUT,
+                SelectMode.SelectError => (short)((byte)Constants.POLLERR | (byte)Constants.POLLNVAL),
+                _                      => poll_set.events
+            };
+            var poll_fd_ptr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(zts_pollfd)));
             Marshal.StructureToPtr(poll_set, poll_fd_ptr, false);
-            int result = 0;
-            int timeout_ms = (microSeconds / 1000);
+            var result = 0;
+            var timeout_ms = microSeconds / 1000;
             uint numfds = 1;
             if ((result = zts_bsd_poll(poll_fd_ptr, numfds, timeout_ms)) < 0)
             {
@@ -352,31 +305,25 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
             poll_set = (zts_pollfd)Marshal.PtrToStructure(poll_fd_ptr, typeof(zts_pollfd));
             if (result != 0)
             {
-                if (mode == SelectMode.SelectRead)
+                result = mode switch
                 {
-                    result = Convert.ToInt32(((byte)poll_set.revents & (byte)Constants.POLLIN) != 0);
-                }
-                if (mode == SelectMode.SelectWrite)
-                {
-                    result = Convert.ToInt32(((byte)poll_set.revents & (byte)Constants.POLLOUT) != 0);
-                }
-                if (mode == SelectMode.SelectError)
-                {
-                    result = Convert.ToInt32(
-                        ((poll_set.revents & (byte)Constants.POLLERR) != 0)
-                        || ((poll_set.revents & (byte)Constants.POLLNVAL) != 0));
-                }
+                    SelectMode.SelectRead  => Convert.ToInt32(((byte)poll_set.revents & (byte)Constants.POLLIN) != 0),
+                    SelectMode.SelectWrite => Convert.ToInt32(((byte)poll_set.revents & (byte)Constants.POLLOUT) != 0),
+                    SelectMode.SelectError => Convert.ToInt32((poll_set.revents & (byte)Constants.POLLERR) != 0 ||
+                                                              (poll_set.revents & (byte)Constants.POLLNVAL) != 0),
+                    _ => result
+                };
             }
             Marshal.FreeHGlobal(poll_fd_ptr);
             return result > 0;
         }
 
-        public Int32 Send(Byte[] buffer)
+        public int Send(byte[] buffer)
         {
-            return Send(buffer, 0, buffer != null ? buffer.Length : 0, SocketFlags.None);
+            return Send(buffer, 0, buffer?.Length ?? 0, SocketFlags.None);
         }
 
-        public Int32 Send(Byte[] buffer, int offset, int size, SocketFlags socketFlags)
+        public int Send(byte[] buffer, int offset, int size, SocketFlags socketFlags)
         {
             if (_isClosed)
             {
@@ -388,18 +335,18 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
             }
             if (buffer == null)
             {
-                throw new ArgumentNullException("buffer");
+                throw new ArgumentNullException(nameof(buffer));
             }
             if (size < 0 || size > buffer.Length - offset)
             {
-                throw new ArgumentOutOfRangeException("size");
+                throw new ArgumentOutOfRangeException(nameof(size));
             }
             if (offset < 0 || offset > buffer.Length)
             {
-                throw new ArgumentOutOfRangeException("offset");
+                throw new ArgumentOutOfRangeException(nameof(offset));
             }
-            int flags = 0;
-            IntPtr bufferPtr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
+            const int flags = 0;
+            var bufferPtr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
             return zts_bsd_send(_fd, bufferPtr + offset, (uint)Buffer.ByteLength(buffer), flags);
         }
 
@@ -409,9 +356,9 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
         /// <param name="localEndPoint"></param>
         /// <param name="buffer"></param>
         /// <returns></returns>
-        public Int32 SendTo(IPEndPoint localEndPoint, Byte[] buffer)
+        public int SendTo(IPEndPoint localEndPoint, byte[] buffer)
         {
-            return SendTo(localEndPoint, buffer, 0, buffer != null ? buffer.Length : 0, SocketFlags.None);
+            return SendTo(localEndPoint, buffer, 0, buffer?.Length ?? 0, SocketFlags.None);
         }
 
         /// <summary>
@@ -427,7 +374,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
         /// <exception cref="SocketException"></exception>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentOutOfRangeException"></exception>
-        public Int32 SendTo(IPEndPoint localEndPoint, Byte[] buffer, int offset, int size, SocketFlags socketFlags)
+        public int SendTo(IPEndPoint localEndPoint, byte[] buffer, int offset, int size, SocketFlags socketFlags)
         {
             if (_isClosed)
             {
@@ -439,45 +386,41 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
             }
             if (buffer == null)
             {
-                throw new ArgumentNullException("buffer");
+                throw new ArgumentNullException(nameof(buffer));
             }
             if (size < 0 || size > buffer.Length - offset)
             {
-                throw new ArgumentOutOfRangeException("size");
+                throw new ArgumentOutOfRangeException(nameof(size));
             }
             if (offset < 0 || offset > buffer.Length)
             {
-                throw new ArgumentOutOfRangeException("offset");
+                throw new ArgumentOutOfRangeException(nameof(offset));
             }
-            zts_sockaddr_in broadcast = new zts_sockaddr_in();
-            broadcast.sin_family = (byte)Constants.AF_INET;
-            broadcast.sin_addr = BitConverter.GetBytes(BitConverter.ToInt32((localEndPoint.Address.GetAddressBytes()), 0));
-            broadcast.sin_port = (short)localEndPoint.Port;
+            var broadcast = new zts_sockaddr_in
+            {
+                sin_family = (byte)Constants.AF_INET,
+                sin_addr   = BitConverter.GetBytes(BitConverter.ToInt32(localEndPoint.Address.GetAddressBytes(), 0)),
+                sin_port   = (short)localEndPoint.Port
+            };
 
-            IntPtr bcPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(zts_sockaddr)));
+            var bcPtr = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(zts_sockaddr)));
             Marshal.StructureToPtr(broadcast, bcPtr, false);
 
-            int flags = 0;
-            IntPtr bufferPtr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
+            const int flags = 0;
+            var bufferPtr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
             var er = zts_bsd_sendto(_fd, bufferPtr + offset, (uint)Buffer.ByteLength(buffer), flags, bcPtr, (ushort)Marshal.SizeOf(typeof(zts_sockaddr)));
             Marshal.FreeHGlobal(bcPtr);
             return er;
         }
 
-        public int Available
+        public int Available => zts_get_data_available(_fd);
+
+        public int Receive(byte[] buffer)
         {
-            get
-            {
-                return zts_get_data_available(_fd);
-            }
+            return Receive(buffer, 0, buffer?.Length ?? 0, SocketFlags.None);
         }
 
-        public Int32 Receive(Byte[] buffer)
-        {
-            return Receive(buffer, 0, buffer != null ? buffer.Length : 0, SocketFlags.None);
-        }
-
-        public Int32 Receive(byte[] buffer, int offset, int size, SocketFlags socketFlags)
+        public int Receive(byte[] buffer, int offset, int size, SocketFlags socketFlags)
         {
             if (_isClosed)
             {
@@ -489,28 +432,28 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
             }
             if (buffer == null)
             {
-                throw new ArgumentNullException("buffer");
+                throw new ArgumentNullException(nameof(buffer));
             }
             if (size < 0 || size > buffer.Length - offset)
             {
-                throw new ArgumentOutOfRangeException("size");
+                throw new ArgumentOutOfRangeException(nameof(size));
             }
             if (offset < 0 || offset > buffer.Length)
             {
-                throw new ArgumentOutOfRangeException("offset");
+                throw new ArgumentOutOfRangeException(nameof(offset));
             }
-            int flags = 0;
-            IntPtr bufferPtr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
+            const int flags = 0;
+            var bufferPtr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
             var er = zts_bsd_recv(_fd, bufferPtr + offset, (uint)Buffer.ByteLength(buffer), flags);
             return er;
         }
 
-        public Int32 ReceiveFrom(Byte[] buffer)
+        public int ReceiveFrom(byte[] buffer)
         {
-            return ReceiveFrom(buffer, buffer != null ? buffer.Length : 0);
+            return ReceiveFrom(buffer, buffer?.Length ?? 0);
         }
 
-        public Int32 ReceiveFrom(byte[] buffer, int size)
+        public int ReceiveFrom(byte[] buffer, int size)
         {
             if (_isClosed)
             {
@@ -522,15 +465,15 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
             }
             if (buffer == null)
             {
-                throw new ArgumentNullException("buffer");
+                throw new ArgumentNullException(nameof(buffer));
             }
             if (size < 0 || size > buffer.Length)
             {
-                throw new ArgumentOutOfRangeException("size");
+                throw new ArgumentOutOfRangeException(nameof(size));
             }
-            int broadcast = 0;
-            IntPtr lpBuffer = Marshal.AllocHGlobal(broadcast);
-            IntPtr bufferPtr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
+            const int broadcast = 0;
+            var lpBuffer = Marshal.AllocHGlobal(broadcast);
+            var bufferPtr = Marshal.UnsafeAddrOfPinnedArrayElement(buffer, 0);
             var er = zts_bsd_recvfrom(_fd, bufferPtr, (uint)Buffer.ByteLength(buffer)-1, 0, IntPtr.Zero, lpBuffer);
             Marshal.FreeHGlobal(lpBuffer);
             return er;
@@ -538,197 +481,88 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
 
         public int ReceiveTimeout
         {
-            get
-            {
-                return zts_get_recv_timeout(_fd);
-            }
+            get => zts_get_recv_timeout(_fd);
             // TODO: microseconds
-            set
-            {
-                zts_set_recv_timeout(_fd, value, 0);
-            }
+            set => zts_set_recv_timeout(_fd, value, 0);
         }
 
         public int SendTimeout
         {
-            get
-            {
-                return zts_get_send_timeout(_fd);
-            }
+            get => zts_get_send_timeout(_fd);
             // TODO: microseconds
-            set
-            {
-                zts_set_send_timeout(_fd, value, 0);
-            }
+            set => zts_set_send_timeout(_fd, value, 0);
         }
 
-        public int ConnectTimeout
-        {
-            get
-            {
-                return _connectTimeout;
-            }
-            set
-            {
-                _connectTimeout = value;
-            }
-        }
+        public int ConnectTimeout { get; set; } = 30000;
 
         public int ReceiveBufferSize
         {
-            get
-            {
-                return zts_get_recv_buf_size(_fd);
-            }
-            set
-            {
-                zts_set_recv_buf_size(_fd, value);
-            }
+            get => zts_get_recv_buf_size(_fd);
+            set => zts_set_recv_buf_size(_fd, value);
         }
 
         public int SendBufferSize
         {
-            get
-            {
-                return zts_get_send_buf_size(_fd);
-            }
-            set
-            {
-                zts_set_send_buf_size(_fd, value);
-            }
+            get => zts_get_send_buf_size(_fd);
+            set => zts_set_send_buf_size(_fd, value);
         }
 
         public int SetBroadcast()
         {
-            int broadcast = 1;
-            IntPtr lpBuffer = Marshal.AllocHGlobal(broadcast);
+            const int broadcast = 1;
+            var lpBuffer = Marshal.AllocHGlobal(broadcast);
 
             return zts_bsd_setsockopt(_fd, Constants.SOL_SOCKET, Constants.SO_BROADCAST, lpBuffer, sizeof(int));
         }
 
         public short Ttl
         {
-            get
-            {
-                return Convert.ToInt16(zts_get_ttl(_fd));
-            }
-            set
-            {
-                zts_set_ttl(_fd, value);
-            }
+            get => Convert.ToInt16(zts_get_ttl(_fd));
+            set => zts_set_ttl(_fd, value);
         }
 
         public LingerOption LingerState
         {
             get
             {
-                LingerOption lo =
+                var lo =
                     new LingerOption(Convert.ToBoolean(zts_get_linger_enabled(_fd)), zts_get_linger_value(_fd));
                 return lo;
             }
-            set
-            {
-                zts_set_linger(_fd, Convert.ToInt32(value.Enabled), value.LingerTime);
-            }
+            set => zts_set_linger(_fd, Convert.ToInt32(value.Enabled), value.LingerTime);
         }
 
         public bool NoDelay
         {
-            get
-            {
-                return Convert.ToBoolean(zts_get_no_delay(_fd));
-            }
-            set
-            {
-                zts_set_no_delay(_fd, Convert.ToInt32(value));
-            }
+            get => Convert.ToBoolean(zts_get_no_delay(_fd));
+            set => zts_set_no_delay(_fd, Convert.ToInt32(value));
         }
 
         public bool KeepAlive
         {
-            get
-            {
-                return Convert.ToBoolean(zts_get_keepalive(_fd));
-            }
-            set
-            {
-                zts_set_keepalive(_fd, Convert.ToInt32(value));
-            }
+            get => Convert.ToBoolean(zts_get_keepalive(_fd));
+            set => zts_set_keepalive(_fd, Convert.ToInt32(value));
         }
 
-        public bool Connected
-        {
-            get
-            {
-                return _isConnected;
-            }
-        }
+        public bool Connected { get; private set; }
 
-        public bool IsBound
-        {
-            get
-            {
-                return _isBound;
-            }
-        }
+        public bool IsBound { get; private set; }
 
-        public AddressFamily AddressFamily
-        {
-            get
-            {
-                return _socketFamily;
-            }
-        }
+        public AddressFamily AddressFamily { get; }
 
-        public SocketType SocketType
-        {
-            get
-            {
-                return _socketType;
-            }
-        }
+        public SocketType SocketType { get; }
 
-        public ProtocolType ProtocolType
-        {
-            get
-            {
-                return _socketProtocol;
-            }
-        }
+        public ProtocolType ProtocolType { get; }
 
         /* .NET has moved to OSSupportsIPv* but libzt isn't an OS so we keep this old convention */
-        public static bool SupportsIPv4
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public static bool SupportsIPv4 => true;
 
         /* .NET has moved to OSSupportsIPv* but libzt isn't an OS so we keep this old convention */
-        public static bool SupportsIPv6
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public static bool SupportsIPv6 => true;
 
-        public EndPoint RemoteEndPoint
-        {
-            get
-            {
-                return _remoteEndPoint;
-            }
-        }
+        public EndPoint RemoteEndPoint => _remoteEndPoint;
 
-        public EndPoint LocalEndPoint
-        {
-            get
-            {
-                return _localEndPoint;
-            }
-        }
+        public EndPoint LocalEndPoint => _localEndPoint;
 
         /* Structures and functions used internally to communicate with
         lower-level C API defined in include/ZeroTierSockets.h */
@@ -741,193 +575,193 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
         zts_bsd_gethostbyname(string jarg1);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_select")]
-        static extern int zts_bsd_select(int jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, IntPtr jarg5);
+        private static extern int zts_bsd_select(int jarg1, IntPtr jarg2, IntPtr jarg3, IntPtr jarg4, IntPtr jarg5);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_get_all_stats")]
-        static extern int zts_get_all_stats(IntPtr arg1);
+        private static extern int zts_get_all_stats(IntPtr arg1);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_get_protocol_stats")]
-        static extern int zts_get_protocol_stats(int arg1, IntPtr arg2);
+        private static extern int zts_get_protocol_stats(int arg1, IntPtr arg2);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_socket")]
-        static extern int zts_bsd_socket(int arg1, int arg2, int arg3);
+        private static extern int zts_bsd_socket(int arg1, int arg2, int arg3);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_connect")]
-        static extern int zts_bsd_connect(int arg1, IntPtr arg2, ushort arg3);
+        private static extern int zts_bsd_connect(int arg1, IntPtr arg2, ushort arg3);
 
         [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_bsd_connect_easy")]
-        static extern int zts_bsd_connect_easy(int arg1, int arg2, string arg3, ushort arg4, int arg5);
+        private static extern int zts_bsd_connect_easy(int arg1, int arg2, string arg3, ushort arg4, int arg5);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_bind")]
-        static extern int zts_bsd_bind(int arg1, IntPtr arg2, ushort arg3);
+        private static extern int zts_bsd_bind(int arg1, IntPtr arg2, ushort arg3);
 
         [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_bsd_bind_easy")]
-        static extern int zts_bsd_bind_easy(int arg1, int arg2, string arg3, ushort arg4);
+        private static extern int zts_bsd_bind_easy(int arg1, int arg2, string arg3, ushort arg4);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_listen")]
-        static extern int zts_bsd_listen(int arg1, int arg2);
+        private static extern int zts_bsd_listen(int arg1, int arg2);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_accept")]
-        static extern int zts_bsd_accept(int arg1, IntPtr arg2, IntPtr arg3);
+        private static extern int zts_bsd_accept(int arg1, IntPtr arg2, IntPtr arg3);
 
         [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_bsd_accept_easy")]
-        static extern int zts_bsd_accept_easy(int arg1, IntPtr remoteAddrStr, int arg2, ref int arg3);
+        private static extern int zts_bsd_accept_easy(int arg1, IntPtr remoteAddrStr, int arg2, ref int arg3);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_setsockopt")]
-        static extern int zts_bsd_setsockopt(int arg1, int arg2, int arg3, IntPtr arg4, ushort arg5);
+        private static extern int zts_bsd_setsockopt(int arg1, int arg2, int arg3, IntPtr arg4, ushort arg5);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_getsockopt")]
-        static extern int zts_bsd_getsockopt(int arg1, int arg2, int arg3, IntPtr arg4, IntPtr arg5);
+        private static extern int zts_bsd_getsockopt(int arg1, int arg2, int arg3, IntPtr arg4, IntPtr arg5);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_getsockname")]
-        static extern int zts_bsd_getsockname(int arg1, IntPtr arg2, IntPtr arg3);
+        private static extern int zts_bsd_getsockname(int arg1, IntPtr arg2, IntPtr arg3);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_getpeername")]
-        static extern int zts_bsd_getpeername(int arg1, IntPtr arg2, IntPtr arg3);
+        private static extern int zts_bsd_getpeername(int arg1, IntPtr arg2, IntPtr arg3);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_close")]
-        static extern int zts_bsd_close(int arg1);
+        private static extern int zts_bsd_close(int arg1);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_fcntl")]
-        static extern int zts_bsd_fcntl(int arg1, int arg2, int arg3);
+        private static extern int zts_bsd_fcntl(int arg1, int arg2, int arg3);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_poll")]
-        static extern int zts_bsd_poll(IntPtr arg1, uint arg2, int arg3);
+        private static extern int zts_bsd_poll(IntPtr arg1, uint arg2, int arg3);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_ioctl")]
-        static extern int zts_bsd_ioctl(int arg1, uint arg2, IntPtr arg3);
+        private static extern int zts_bsd_ioctl(int arg1, uint arg2, IntPtr arg3);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_send")]
-        static extern int zts_bsd_send(int arg1, IntPtr arg2, uint arg3, int arg4);
+        private static extern int zts_bsd_send(int arg1, IntPtr arg2, uint arg3, int arg4);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_sendto")]
-        static extern int zts_bsd_sendto(int arg1, IntPtr arg2, uint arg3, int arg4, IntPtr arg5, ushort arg6);
+        private static extern int zts_bsd_sendto(int arg1, IntPtr arg2, uint arg3, int arg4, IntPtr arg5, ushort arg6);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_sendmsg")]
-        static extern int zts_bsd_sendmsg(int arg1, IntPtr arg2, int arg3);
+        private static extern int zts_bsd_sendmsg(int arg1, IntPtr arg2, int arg3);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_recv")]
-        static extern int zts_bsd_recv(int arg1, IntPtr arg2, uint arg3, int arg4);
+        private static extern int zts_bsd_recv(int arg1, IntPtr arg2, uint arg3, int arg4);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_recvfrom")]
-        static extern int zts_bsd_recvfrom(int arg1, IntPtr arg2, uint arg3, int arg4, IntPtr arg5, IntPtr arg6);
+        private static extern int zts_bsd_recvfrom(int arg1, IntPtr arg2, uint arg3, int arg4, IntPtr arg5, IntPtr arg6);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_recvmsg")]
-        static extern int zts_bsd_recvmsg(int arg1, IntPtr arg2, int arg3);
+        private static extern int zts_bsd_recvmsg(int arg1, IntPtr arg2, int arg3);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_read")]
-        static extern int zts_bsd_read(int arg1, IntPtr arg2, uint arg3);
+        private static extern int zts_bsd_read(int arg1, IntPtr arg2, uint arg3);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_readv")]
-        static extern int zts_bsd_readv(int arg1, IntPtr arg2, int arg3);
+        private static extern int zts_bsd_readv(int arg1, IntPtr arg2, int arg3);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_write")]
-        static extern int zts_bsd_write(int arg1, IntPtr arg2, uint arg3);
+        private static extern int zts_bsd_write(int arg1, IntPtr arg2, uint arg3);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_writev")]
-        static extern int zts_bsd_writev(int arg1, IntPtr arg2, int arg3);
+        private static extern int zts_bsd_writev(int arg1, IntPtr arg2, int arg3);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_bsd_shutdown")]
-        static extern int zts_bsd_shutdown(int arg1, int arg2);
+        private static extern int zts_bsd_shutdown(int arg1, int arg2);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_get_data_available")]
-        static extern int zts_get_data_available(int fd);
+        private static extern int zts_get_data_available(int fd);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_set_no_delay")]
-        static extern int zts_set_no_delay(int fd, int enabled);
+        private static extern int zts_set_no_delay(int fd, int enabled);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_get_no_delay")]
-        static extern int zts_get_no_delay(int fd);
+        private static extern int zts_get_no_delay(int fd);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_set_linger")]
-        static extern int zts_set_linger(int fd, int enabled, int value);
+        private static extern int zts_set_linger(int fd, int enabled, int value);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_get_linger_enabled")]
-        static extern int zts_get_linger_enabled(int fd);
+        private static extern int zts_get_linger_enabled(int fd);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_get_linger_value")]
-        static extern int zts_get_linger_value(int fd);
+        private static extern int zts_get_linger_value(int fd);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_set_reuse_addr")]
-        static extern int zts_set_reuse_addr(int fd, int enabled);
+        private static extern int zts_set_reuse_addr(int fd, int enabled);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_get_reuse_addr")]
-        static extern int zts_get_reuse_addr(int fd);
+        private static extern int zts_get_reuse_addr(int fd);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_set_recv_timeout")]
-        static extern int zts_set_recv_timeout(int fd, int seconds, int microseconds);
+        private static extern int zts_set_recv_timeout(int fd, int seconds, int microseconds);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_get_recv_timeout")]
-        static extern int zts_get_recv_timeout(int fd);
+        private static extern int zts_get_recv_timeout(int fd);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_set_send_timeout")]
-        static extern int zts_set_send_timeout(int fd, int seconds, int microseconds);
+        private static extern int zts_set_send_timeout(int fd, int seconds, int microseconds);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_get_send_timeout")]
-        static extern int zts_get_send_timeout(int fd);
+        private static extern int zts_get_send_timeout(int fd);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_set_send_buf_size")]
-        static extern int zts_set_send_buf_size(int fd, int size);
+        private static extern int zts_set_send_buf_size(int fd, int size);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_get_send_buf_size")]
-        static extern int zts_get_send_buf_size(int fd);
+        private static extern int zts_get_send_buf_size(int fd);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_set_recv_buf_size")]
-        static extern int zts_set_recv_buf_size(int fd, int size);
+        private static extern int zts_set_recv_buf_size(int fd, int size);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_get_recv_buf_size")]
-        static extern int zts_get_recv_buf_size(int fd);
+        private static extern int zts_get_recv_buf_size(int fd);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_set_ttl")]
-        static extern int zts_set_ttl(int fd, int ttl);
+        private static extern int zts_set_ttl(int fd, int ttl);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_get_ttl")]
-        static extern int zts_get_ttl(int fd);
+        private static extern int zts_get_ttl(int fd);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_set_blocking")]
-        static extern int zts_set_blocking(int fd, int enabled);
+        private static extern int zts_set_blocking(int fd, int enabled);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_get_blocking")]
-        static extern int zts_get_blocking(int fd);
+        private static extern int zts_get_blocking(int fd);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_set_keepalive")]
-        static extern int zts_set_keepalive(int fd, int enabled);
+        private static extern int zts_set_keepalive(int fd, int enabled);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_get_keepalive")]
-        static extern int zts_get_keepalive(int fd);
+        private static extern int zts_get_keepalive(int fd);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_add_dns_nameserver")]
-        static extern int zts_add_dns_nameserver(IntPtr arg1);
+        private static extern int zts_add_dns_nameserver(IntPtr arg1);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_del_dns_nameserver")]
-        static extern int zts_del_dns_nameserver(IntPtr arg1);
+        private static extern int zts_del_dns_nameserver(IntPtr arg1);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_errno_get")]
-        static extern int zts_errno_get();
+        private static extern int zts_errno_get();
 
         [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_accept")]
-        static extern int zts_accept(int jarg1, IntPtr jarg2, int jarg3, ref int jarg4);
+        private static extern int zts_accept(int jarg1, IntPtr jarg2, int jarg3, ref int jarg4);
 
         [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_tcp_client")]
-        static extern int zts_tcp_client(string jarg1, int jarg2);
+        private static extern int zts_tcp_client(string jarg1, int jarg2);
 
         [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_tcp_server")]
-        static extern int zts_tcp_server(string jarg1, int jarg2, string jarg3, int jarg4, IntPtr jarg5);
+        private static extern int zts_tcp_server(string jarg1, int jarg2, string jarg3, int jarg4, IntPtr jarg5);
 
         [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_udp_server")]
-        static extern int zts_udp_server(string jarg1, int jarg2);
+        private static extern int zts_udp_server(string jarg1, int jarg2);
 
         [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_udp_client")]
-        static extern int zts_udp_client(string jarg1);
+        private static extern int zts_udp_client(string jarg1);
 
         [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_bind")]
-        static extern int zts_bind(int jarg1, string jarg2, int jarg3);
+        private static extern int zts_bind(int jarg1, string jarg2, int jarg3);
 
         [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_connect")]
-        static extern int zts_connect(int jarg1, string jarg2, int jarg3, int jarg4);
+        private static extern int zts_connect(int jarg1, string jarg2, int jarg3, int jarg4);
 
         [DllImport("libzt", EntryPoint = "CSharp_zts_stats_get_all")]
-        static extern int zts_stats_get_all(IntPtr jarg1);
+        private static extern int zts_stats_get_all(IntPtr jarg1);
         /*
                 [DllImport("libzt", EntryPoint = "CSharp_zts_set_no_delay")]
                 static extern int zts_set_no_delay(int jarg1, int jarg2);
@@ -1000,22 +834,16 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
         public static extern void zts_util_delay(int jarg1);
 
         [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_util_get_ip_family")]
-        static extern int zts_util_get_ip_family(string jarg1);
+        private static extern int zts_util_get_ip_family(string jarg1);
 
         [DllImport("libzt", CharSet = CharSet.Ansi, EntryPoint = "CSharp_zts_util_ipstr_to_saddr")]
-        static extern int zts_util_ipstr_to_saddr(string jarg1, int jarg2, IntPtr jarg3, IntPtr jarg4);
+        private static extern int zts_util_ipstr_to_saddr(string jarg1, int jarg2, IntPtr jarg3, IntPtr jarg4);
 
         /// <value>The value of errno for the low-level socket layer</value>
-        public static int ErrNo
-        {
-            get
-            {
-                return zts_errno_get();
-            }
-        }
+        public static int ErrNo => zts_errno_get();
 
         [StructLayout(LayoutKind.Sequential)]
-        struct zts_sockaddr
+        private struct zts_sockaddr
         {
             public byte sa_len;
             public byte sa_family;
@@ -1024,13 +852,13 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        struct zts_in_addr
+        private struct zts_in_addr
         {
             public uint s_addr;
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        struct zts_sockaddr_in
+        private struct zts_sockaddr_in
         {
             public byte sin_len;
             public byte sin_family;
@@ -1042,7 +870,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        struct zts_pollfd
+        private struct zts_pollfd
         {
             public int fd;
             public short events;
@@ -1050,7 +878,7 @@ namespace BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        struct zts_timeval
+        private struct zts_timeval
         {
             public long tv_sec;
             public long tv_usec;

--- a/BardMusicPlayer.Jamboree/Pydna.cs
+++ b/BardMusicPlayer.Jamboree/Pydna.cs
@@ -31,7 +31,7 @@ namespace BardMusicPlayer.Jamboree
             FoundClients.Instance.Type = type;
             
             zeroTierConnector = new ZeroTierConnector();
-            string data = zeroTierConnector.ZeroTierConnect(networkId).Result;
+            var data = zeroTierConnector.ZeroTierConnect(networkId).Result;
 
             Autodiscover.Instance.StartAutodiscover(data, "0.1.0");
             NetworkPartyServer.Instance.StartServer(new IPEndPoint(IPAddress.Parse(data), 12345), type, name);
@@ -51,7 +51,7 @@ namespace BardMusicPlayer.Jamboree
         }
 
 #region NetworkSendFunctions
-        public void SendPerformanceStart()
+        public static void SendPerformanceStart()
         {
             FoundClients.Instance.SendToAll(ZeroTierPacketBuilder.PerformanceStart());
         }

--- a/BardMusicPlayer.Jamboree/Pydna.cs
+++ b/BardMusicPlayer.Jamboree/Pydna.cs
@@ -1,14 +1,8 @@
 using BardMusicPlayer.Jamboree.Events;
-using BardMusicPlayer.Jamboree.PartyNetworking;
-using ZeroTier;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
 using BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover;
 using BardMusicPlayer.Jamboree.PartyNetworking.Server_Client;
+using BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier;
 
 namespace BardMusicPlayer.Jamboree
 {
@@ -25,9 +19,9 @@ namespace BardMusicPlayer.Jamboree
     /// - handshake complete
     public class Pydna
     {
-        private bool _online { get; set; } = false;
+        private bool _online { get; set; }
 
-        private ZeroTierConnector zeroTierConnector = null;
+        private ZeroTierConnector zeroTierConnector;
 
         public void JoinParty(string networkId, byte type, string name)
         {
@@ -43,7 +37,6 @@ namespace BardMusicPlayer.Jamboree
             NetworkPartyServer.Instance.StartServer(new IPEndPoint(IPAddress.Parse(data), 12345), type, name);
             _online = true;
             BmpJamboree.Instance.PublishEvent(new PartyCreatedEvent("Connected...\r\n"));
-            return;
         }
 
         public void LeaveParty()

--- a/BardMusicPlayer.Jamboree/Pydna.cs
+++ b/BardMusicPlayer.Jamboree/Pydna.cs
@@ -4,90 +4,89 @@ using BardMusicPlayer.Jamboree.PartyNetworking.Autodiscover;
 using BardMusicPlayer.Jamboree.PartyNetworking.Server_Client;
 using BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier;
 
-namespace BardMusicPlayer.Jamboree
+namespace BardMusicPlayer.Jamboree;
+
+/// <summary>
+/// The manager class for the festival
+/// </summary>
+/// We are creating a mesh network
+/// - fire up the ZeroTier
+/// - start the autodiscover to tell we are here
+/// - start the TCP listener
+/// - add the clients we found to the manager
+/// - create a Session and connect to the listenserver
+/// - add the listensocket from the listenserver to our session
+/// - handshake complete
+public class Pydna
 {
-    /// <summary>
-    /// The manager class for the festival
-    /// </summary>
-    /// We are creating a mesh network
-    /// - fire up the ZeroTier
-    /// - start the autodiscover to tell we are here
-    /// - start the TCP listener
-    /// - add the clients we found to the manager
-    /// - create a Session and connect to the listenserver
-    /// - add the listensocket from the listenserver to our session
-    /// - handshake complete
-    public class Pydna
+    private bool _online { get; set; }
+
+    private ZeroTierConnector zeroTierConnector;
+
+    public void JoinParty(string networkId, byte type, string name)
     {
-        private bool _online { get; set; }
-
-        private ZeroTierConnector zeroTierConnector;
-
-        public void JoinParty(string networkId, byte type, string name)
-        {
-            if (zeroTierConnector != null)
-                return;
-            FoundClients.Instance.OwnName = name;
-            FoundClients.Instance.Type = type;
+        if (zeroTierConnector != null)
+            return;
+        FoundClients.Instance.OwnName = name;
+        FoundClients.Instance.Type    = type;
             
-            zeroTierConnector = new ZeroTierConnector();
-            var data = zeroTierConnector.ZeroTierConnect(networkId).Result;
+        zeroTierConnector = new ZeroTierConnector();
+        var data = zeroTierConnector.ZeroTierConnect(networkId).Result;
 
-            Autodiscover.Instance.StartAutodiscover(data, "0.1.0");
-            NetworkPartyServer.Instance.StartServer(new IPEndPoint(IPAddress.Parse(data), 12345), type, name);
-            _online = true;
-            BmpJamboree.Instance.PublishEvent(new PartyCreatedEvent("Connected...\r\n"));
-        }
-
-        public void LeaveParty()
-        {
-            _online = false;
-            //Stop the autodiscover
-            Autodiscover.Instance.Stop();
-            NetworkPartyServer.Instance.Stop();
-            FoundClients.Instance.Clear();
-            zeroTierConnector.ZeroTierDisconnect(true);
-            BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("[Pydna]: Stopped\r\n"));
-        }
-
-#region NetworkSendFunctions
-        public static void SendPerformanceStart()
-        {
-            FoundClients.Instance.SendToAll(ZeroTierPacketBuilder.PerformanceStart());
-        }
-
-        /// <summary>
-        /// Send we joined the party
-        /// | type 0 = bard
-        /// | type 1 = dancer
-        /// </summary>
-        /// <param name="type"></param>
-        /// <param name="performer_name"></param>
-        public void SendPerformerJoin(byte type, string performername)
-        {
-            if (!_online)
-                return;
-            /*if (!_servermode)
-            {
-                client.SetPlayerData(type, performername);
-                client.SendPacket(ZeroTierPacketBuilder.CMSG_JOIN_PARTY(type, performername));
-            }*/
-        }
-
-        public void SendClientPacket(byte [] packet)
-        {
-            //if (!_servermode)
-            //    client.SendPacket(packet);
-        }
-
-        public void SendServerPacket(byte[] packet)
-        {
-            if (!_online)
-                return;
-            FoundClients.Instance.SendToAll(packet);
-        }
-
-        #endregion
-
+        Autodiscover.Instance.StartAutodiscover(data, "0.1.0");
+        NetworkPartyServer.Instance.StartServer(new IPEndPoint(IPAddress.Parse(data), 12345), type, name);
+        _online = true;
+        BmpJamboree.Instance.PublishEvent(new PartyCreatedEvent("Connected...\r\n"));
     }
+
+    public void LeaveParty()
+    {
+        _online = false;
+        //Stop the autodiscover
+        Autodiscover.Instance.Stop();
+        NetworkPartyServer.Instance.Stop();
+        FoundClients.Instance.Clear();
+        zeroTierConnector.ZeroTierDisconnect(true);
+        BmpJamboree.Instance.PublishEvent(new PartyDebugLogEvent("[Pydna]: Stopped\r\n"));
+    }
+
+    #region NetworkSendFunctions
+    public static void SendPerformanceStart()
+    {
+        FoundClients.Instance.SendToAll(ZeroTierPacketBuilder.PerformanceStart());
+    }
+
+    /// <summary>
+    /// Send we joined the party
+    /// | type 0 = bard
+    /// | type 1 = dancer
+    /// </summary>
+    /// <param name="type"></param>
+    /// <param name="performer_name"></param>
+    public void SendPerformerJoin(byte type, string performername)
+    {
+        if (!_online)
+            return;
+        /*if (!_servermode)
+        {
+            client.SetPlayerData(type, performername);
+            client.SendPacket(ZeroTierPacketBuilder.CMSG_JOIN_PARTY(type, performername));
+        }*/
+    }
+
+    public void SendClientPacket(byte [] packet)
+    {
+        //if (!_servermode)
+        //    client.SendPacket(packet);
+    }
+
+    public void SendServerPacket(byte[] packet)
+    {
+        if (!_online)
+            return;
+        FoundClients.Instance.SendToAll(packet);
+    }
+
+    #endregion
+
 }


### PR DESCRIPTION
WARNING
- Potential Code Quality Issues
  * Empty general catch clause
      Empty general catch clause suppresses any errors (2)
  * Possible 'Sstem.NullReferenceException'
      Possible 'Sstem.NullReferenceException' (2)
  * Inconsistent synchronization on field
      The field is sometimes used inside synchronized block and sometimes used without synchronization (5)
- Redundancies in Code
  * Redundant control flow jump statement
      Redundant control flow jump statement (4)
  * Redundant using directive
      Using directive is not required by the code and can be safely removed (47)
  * Redundant name qualifier
      Qualifier is redundant (33)
  * Redundant cast
      Type cast is redundant (18)
  * Explicit delegate creation expression is redundant
      Redundant explicit delegate creation (4)
  * Redundant empty switch section
      Redundant empty switch section (1)
  * Redundant argument with default value
      The parameter 'dedupeThreshold' has the same default value (6)
	  The parameter 'highPriority' has the same default value (6)
  * Redundant 'object.ToString()' call
      Redundant 'object.ToString()' call (2)
  * Private field can be converted into local variable
      The field is always assigned before being used and can be converted into a local variable (2)
- Constraints Violations
  * Namespace does not correspond to file location
      Namespace does not correspond to file location, must be: 'BardMusicPlayer.Jamboree.PartyNetworking.ZeroTier' (2)
  * Possible 'null' assignment to non-nullable entity
      Possible 'null' assignment to non-nullable entity (1)
- Common Practices and Code Improvements
  * Empty statement is redundant
      Empty statement is redundant (2)
- Redundancies in Symbol Declarations
  * Redundant member initializer
      Initializing property by default value is redundant (9)
	  Initializing field by default value is redundant (10)
  * Empty constructor
      Empty constructor is redundant. The compiler generates the same as default. (1)
  * Underlying type of enum is 'int'
      'int' is default enum governing type
      
SUGGESTION
- Spelling Issues
  * Typo in comment
      Typo (1)
  * Typo in identifier
      Typo (2)
- Syntax Style
  * Use preferred body style
      Inconsistent body style: use expression body (35)
  * Use preferred style of 'new' expression when created type is evident
      Redundant type specified (11)
- Common Practices and Code Improvements
  * Method supports cancellation
      Method has overload with cancellation support (1)
  * Local variable has too wide declaration scope
      Local variable 'byteRec' can be declared in inner scope
- Language Usage Opportunities
  * 'if' statement can be rewritten as '??=' assignment
      Convert into '??=' (4)
  * Merge conditional ?: expression into conditional access
      Merge conditional expression (4)
  * Use 'nameof' expression to reference name
      Use 'nameof' expression to reference parameter (14)
  * Use object or collection initializer when possible
      Use object initializer (3)
  * Inline 'out' variable declaration
      Inline 'out' variable declaration (2)
  * Convert property into auto-property
      Convert into auto-property (1)
  * Introduce optional parameters
      Introduce optional parameter (s) for method 'void Close(int)'

HINT
- Syntax Style
  * Use preferred 'var' style (84)
      Use 'var' (elsewhere)
      Use 'var' (simple types)
      Use 'var' (built-in types)
  * Use explicit or implicit modifier definition for type members
      Inconsistent modifiers style: missing 'private' modifier (56)
  * Use preferred namespace body style
      Convert to file-scoped namespace (21)
  * Replace built-in type reference with a CLR type name or a keyword
      Built-in type reference is inconsistent with code style settings (14)
  * Remove redundant parentheses
      Redundant parentheses (7)
- Language Usage Opportunities
  * Replace if statement with null-propagating code
      Use null propagation (10)
  * Replace 'switch' statement with 'switch' expression
      Convert 'switch' statement to 'switch' expression (4)
  * Convert 'if' statement into 'switch'
      Convert 'if' statement into 'switch' (3)
  * Convert property into auto-property with private setter
      Convert into auto-property with private setter (2)
  * Convert property into auto-property (when possible)
      Convert into auto-property (5)
  * Part of foreach loop can be converted into LINQ-expression but another 'GetEnumerator' method will be used
      Part of foreach loop can be converted into LINQ-expression but another 'GetEnumerator' method will be used (1)
  * 'if-return' statement can be rewritten as 'return' statement
      Convert into 'return' statement (2)
  * Foreach loop can be converted into LINQ-expression but another 'GetEnumerator' method will be used
      Loop can be converted into LINQ-expression but another 'GetEnumerator' method will be used (1)
- Common Practices and Code Improvements
  * Convert local variable or field into constant
      Convert into constant (5)
  * Member can be made static (shared)
      Method can be made static (3)
- Redundancies in Code
  * Redundant 'else' keyword
      Redundant 'else' keyword (1)