### PR TITLE
Run as Admin

### DIFF
--- a/BardMusicPlayer/BardMusicPlayer.csproj
+++ b/BardMusicPlayer/BardMusicPlayer.csproj
@@ -7,6 +7,7 @@
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>bmp.ico</ApplicationIcon>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
     <PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
     <PackageProjectUrl>https://bardmusicplayer.com</PackageProjectUrl>
     <RepositoryUrl>https://github.com/BardMusicPlayer/BardMusicPlayer</RepositoryUrl>

--- a/BardMusicPlayer/app.manifest
+++ b/BardMusicPlayer/app.manifest
@@ -1,0 +1,9 @@
+﻿<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+          <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>


### PR DESCRIPTION
* Re-added app.manifest to run BMP as admin by default. Fixes issues with ensemble button not accepting if you don't force admin.