### PR TITLE
Modernize & Optimize Siren

### DIFF
--- a/BardMusicPlayer.Siren/AlphaTab/AlphaSynthWorkerApiBase.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/AlphaSynthWorkerApiBase.cs
@@ -42,10 +42,10 @@ namespace BardMusicPlayer.Siren.AlphaTab
             DispatchOnUiThread(OnReady);
         }
 
-        public bool IsReady => Player != null && Player.IsReady;
-        public bool IsReadyForPlayback => Player != null && Player.IsReadyForPlayback;
+        public bool IsReady => Player is { IsReady: true };
+        public bool IsReadyForPlayback => Player is { IsReadyForPlayback: true };
 
-        public PlayerState State => Player == null ? PlayerState.Paused : Player.State;
+        public PlayerState State => Player?.State ?? PlayerState.Paused;
 
         public LogLevel LogLevel
         {
@@ -163,47 +163,47 @@ namespace BardMusicPlayer.Siren.AlphaTab
         public event Action<PlayerStateChangedEventArgs> StateChanged;
         public event Action<PositionChangedEventArgs> PositionChanged;
 
-        protected virtual void OnReady()
+        private void OnReady()
         {
             DispatchOnUiThread(() => Ready?.Invoke());
         }
 
-        protected virtual void OnReadyForPlayback()
+        private void OnReadyForPlayback()
         {
             DispatchOnUiThread(() => ReadyForPlayback?.Invoke());
         }
 
-        protected virtual void OnFinished()
+        private void OnFinished()
         {
             DispatchOnUiThread(() => Finished?.Invoke());
         }
 
-        protected virtual void OnSoundFontLoaded()
+        private void OnSoundFontLoaded()
         {
             DispatchOnUiThread(() => SoundFontLoaded?.Invoke());
         }
 
-        protected virtual void OnSoundFontLoadFailed(Exception e)
+        private void OnSoundFontLoadFailed(Exception e)
         {
             DispatchOnUiThread(() => SoundFontLoadFailed?.Invoke(e));
         }
 
-        protected virtual void OnMidiLoaded()
+        private void OnMidiLoaded()
         {
             DispatchOnUiThread(() => MidiLoaded?.Invoke());
         }
 
-        protected virtual void OnMidiLoadFailed(Exception e)
+        private void OnMidiLoadFailed(Exception e)
         {
             DispatchOnUiThread(() => MidiLoadFailed?.Invoke(e));
         }
 
-        protected virtual void OnStateChanged(PlayerStateChangedEventArgs obj)
+        private void OnStateChanged(PlayerStateChangedEventArgs obj)
         {
             DispatchOnUiThread(() => StateChanged?.Invoke(obj));
         }
 
-        protected virtual void OnPositionChanged(PositionChangedEventArgs obj)
+        private void OnPositionChanged(PositionChangedEventArgs obj)
         {
             DispatchOnUiThread(() => PositionChanged?.Invoke(obj));
         }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Generator/AlphaSynthMidiFileHandler.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Generator/AlphaSynthMidiFileHandler.cs
@@ -8,145 +8,144 @@ using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi;
 using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.Event;
 using BardMusicPlayer.Siren.AlphaTab.Model;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Generator
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Generator;
+
+/// <summary>
+/// This implementation of the <see cref="IMidiFileHandler"/> generates a <see cref="MidiFile"/>
+/// object which can be used in AlphaSynth for playback. 
+/// </summary>
+internal class AlphaSynthMidiFileHandler : IMidiFileHandler
 {
+    private readonly MidiFile _midiFile;
+
     /// <summary>
-    /// This implementation of the <see cref="IMidiFileHandler"/> generates a <see cref="MidiFile"/>
-    /// object which can be used in AlphaSynth for playback. 
+    /// Initializes a new instance of the <see cref="AlphaSynthMidiFileHandler"/> class.
     /// </summary>
-    internal class AlphaSynthMidiFileHandler : IMidiFileHandler
+    /// <param name="midiFile">The midi file.</param>
+    public AlphaSynthMidiFileHandler(MidiFile midiFile)
     {
-        private readonly MidiFile _midiFile;
+        _midiFile = midiFile;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AlphaSynthMidiFileHandler"/> class.
-        /// </summary>
-        /// <param name="midiFile">The midi file.</param>
-        public AlphaSynthMidiFileHandler(MidiFile midiFile)
+    /// <inheritdoc />
+    public void AddTimeSignature(int tick, int timeSignatureNumerator, int timeSignatureDenominator)
+    {
+        var denominatorIndex = 0;
+        while ((timeSignatureDenominator >>= 1) > 0)
         {
-            _midiFile = midiFile;
+            denominatorIndex++;
         }
 
-        /// <inheritdoc />
-        public void AddTimeSignature(int tick, int timeSignatureNumerator, int timeSignatureDenominator)
-        {
-            var denominatorIndex = 0;
-            while ((timeSignatureDenominator >>= 1) > 0)
+        var message = new MetaDataEvent(tick,
+            0xFF,
+            (byte)MetaEventTypeEnum.TimeSignature,
+            new byte[]
             {
-                denominatorIndex++;
-            }
+                (byte)(timeSignatureNumerator & 0xFF), (byte)(denominatorIndex & 0xFF), 48, 8
+            });
+        _midiFile.AddEvent(message);
+    }
 
-            var message = new MetaDataEvent(tick,
-                0xFF,
-                (byte)MetaEventTypeEnum.TimeSignature,
-                new byte[]
-                {
-                    (byte)(timeSignatureNumerator & 0xFF), (byte)(denominatorIndex & 0xFF), 48, 8
-                });
-            _midiFile.AddEvent(message);
-        }
-
-        /// <inheritdoc />
-        public void AddRest(int track, int tick, int channel)
-        {
-            var message = new SystemExclusiveEvent(tick,
-                (byte)SystemCommonTypeEnum.SystemExclusive,
-                0,
-                new byte[]
-                {
-                    0xFF
-                });
-            _midiFile.AddEvent(message);
-        }
-
-        /// <inheritdoc />
-        public void AddNote(int track, int start, int length, byte key, DynamicValue dynamicValue, byte channel)
-        {
-            var velocity = MidiUtils.DynamicToVelocity(dynamicValue);
-
-            var noteOn = new MidiEvent(start,
-                MakeCommand((byte)MidiEventType.NoteOn, channel),
-                FixValue(key),
-                FixValue((byte)velocity),
-                true,
-                channel);
-            _midiFile.AddEvent(noteOn);
-
-            var noteOff = new MidiEvent(start + length,
-                MakeCommand((byte)MidiEventType.NoteOff, channel),
-                FixValue(key),
-                FixValue((byte)velocity),
-                true,
-                channel);
-            _midiFile.AddEvent(noteOff);
-        }
-
-        private static byte MakeCommand(byte command, byte channel)
-        {
-            return (byte)((command & 0xF0) | (channel & 0x0F));
-        }
-
-        private static byte FixValue(int value)
-        {
-            return value switch
+    /// <inheritdoc />
+    public void AddRest(int track, int tick, int channel)
+    {
+        var message = new SystemExclusiveEvent(tick,
+            (byte)SystemCommonTypeEnum.SystemExclusive,
+            0,
+            new byte[]
             {
-                > 127 => 127,
-                < 0   => 0,
-                _     => (byte)value
-            };
-        }
+                0xFF
+            });
+        _midiFile.AddEvent(message);
+    }
 
-        /// <inheritdoc />
-        public void AddControlChange(int track, int tick, byte channel, byte controller, byte value)
+    /// <inheritdoc />
+    public void AddNote(int track, int start, int length, byte key, DynamicValue dynamicValue, byte channel)
+    {
+        var velocity = MidiUtils.DynamicToVelocity(dynamicValue);
+
+        var noteOn = new MidiEvent(start,
+            MakeCommand((byte)MidiEventType.NoteOn, channel),
+            FixValue(key),
+            FixValue((byte)velocity),
+            true,
+            channel);
+        _midiFile.AddEvent(noteOn);
+
+        var noteOff = new MidiEvent(start + length,
+            MakeCommand((byte)MidiEventType.NoteOff, channel),
+            FixValue(key),
+            FixValue((byte)velocity),
+            true,
+            channel);
+        _midiFile.AddEvent(noteOff);
+    }
+
+    private static byte MakeCommand(byte command, byte channel)
+    {
+        return (byte)((command & 0xF0) | (channel & 0x0F));
+    }
+
+    private static byte FixValue(int value)
+    {
+        return value switch
         {
-            var message = new MidiEvent(tick,
-                MakeCommand((byte)MidiEventType.Controller, channel),
-                FixValue(controller),
-                FixValue(value));
-            _midiFile.AddEvent(message);
-        }
+            > 127 => 127,
+            < 0   => 0,
+            _     => (byte)value
+        };
+    }
 
-        /// <inheritdoc />
-        public void AddProgramChange(int track, int tick, byte channel, byte program)
-        {
-            var message = new MidiEvent(tick,
-                MakeCommand((byte)MidiEventType.ProgramChange, channel),
-                FixValue(program),
-                0,
-                true,
-                channel);
-            _midiFile.AddEvent(message);
-        }
+    /// <inheritdoc />
+    public void AddControlChange(int track, int tick, byte channel, byte controller, byte value)
+    {
+        var message = new MidiEvent(tick,
+            MakeCommand((byte)MidiEventType.Controller, channel),
+            FixValue(controller),
+            FixValue(value));
+        _midiFile.AddEvent(message);
+    }
 
-        /// <inheritdoc />
-        public void AddTempo(int tick, int tempo)
-        {
-            // bpm -> microsecond per quarter note
-            var tempoInUsq = 60000000 / tempo;
+    /// <inheritdoc />
+    public void AddProgramChange(int track, int tick, byte channel, byte program)
+    {
+        var message = new MidiEvent(tick,
+            MakeCommand((byte)MidiEventType.ProgramChange, channel),
+            FixValue(program),
+            0,
+            true,
+            channel);
+        _midiFile.AddEvent(message);
+    }
 
-            var message = new MetaNumberEvent(tick,
-                0xFF,
-                (byte)MetaEventTypeEnum.Tempo,
-                tempoInUsq);
-            _midiFile.AddEvent(message);
-        }
+    /// <inheritdoc />
+    public void AddTempo(int tick, int tempo)
+    {
+        // bpm -> microsecond per quarter note
+        var tempoInUsq = 60000000 / tempo;
 
-        /// <inheritdoc />
-        public void AddBend(int track, int tick, byte channel, int value)
-        {
-            var message = new MidiEvent(tick, MakeCommand((byte)MidiEventType.PitchBend, channel), 0, FixValue(value));
-            _midiFile.AddEvent(message);
-        }
+        var message = new MetaNumberEvent(tick,
+            0xFF,
+            (byte)MetaEventTypeEnum.Tempo,
+            tempoInUsq);
+        _midiFile.AddEvent(message);
+    }
 
-        /// <inheritdoc />
-        public void FinishTrack(int track, int tick)
-        {
-            var message = new MetaDataEvent(tick,
-                0xFF,
-                (byte)MetaEventTypeEnum.EndOfTrack,
-                Array.Empty<byte>());
-            _midiFile.AddEvent(message);
-            _midiFile.Sort();
-        }
+    /// <inheritdoc />
+    public void AddBend(int track, int tick, byte channel, int value)
+    {
+        var message = new MidiEvent(tick, MakeCommand((byte)MidiEventType.PitchBend, channel), 0, FixValue(value));
+        _midiFile.AddEvent(message);
+    }
+
+    /// <inheritdoc />
+    public void FinishTrack(int track, int tick)
+    {
+        var message = new MetaDataEvent(tick,
+            0xFF,
+            (byte)MetaEventTypeEnum.EndOfTrack,
+            Array.Empty<byte>());
+        _midiFile.AddEvent(message);
+        _midiFile.Sort();
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Generator/AlphaSynthMidiFileHandler.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Generator/AlphaSynthMidiFileHandler.cs
@@ -3,6 +3,7 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
+using System;
 using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi;
 using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.Event;
 using BardMusicPlayer.Siren.AlphaTab.Model;
@@ -30,7 +31,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Generator
         public void AddTimeSignature(int tick, int timeSignatureNumerator, int timeSignatureDenominator)
         {
             var denominatorIndex = 0;
-            while ((timeSignatureDenominator = timeSignatureDenominator >> 1) > 0)
+            while ((timeSignatureDenominator >>= 1) > 0)
             {
                 denominatorIndex++;
             }
@@ -80,24 +81,19 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Generator
             _midiFile.AddEvent(noteOff);
         }
 
-        private byte MakeCommand(byte command, byte channel)
+        private static byte MakeCommand(byte command, byte channel)
         {
             return (byte)((command & 0xF0) | (channel & 0x0F));
         }
 
         private static byte FixValue(int value)
         {
-            if (value > 127)
+            return value switch
             {
-                return 127;
-            }
-
-            if (value < 0)
-            {
-                return 0;
-            }
-
-            return (byte)value;
+                > 127 => 127,
+                < 0   => 0,
+                _     => (byte)value
+            };
         }
 
         /// <inheritdoc />
@@ -148,7 +144,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Generator
             var message = new MetaDataEvent(tick,
                 0xFF,
                 (byte)MetaEventTypeEnum.EndOfTrack,
-                new byte[0]);
+                Array.Empty<byte>());
             _midiFile.AddEvent(message);
             _midiFile.Sort();
         }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Generator/IMidiFileHandler.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Generator/IMidiFileHandler.cs
@@ -5,80 +5,79 @@
 
 using BardMusicPlayer.Siren.AlphaTab.Model;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Generator
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Generator;
+
+/// <summary>
+/// A handler is responsible for writing midi events to a custom structure
+/// </summary>
+internal interface IMidiFileHandler
 {
     /// <summary>
-    /// A handler is responsible for writing midi events to a custom structure
+    /// Adds a time signature to the generated midi file
     /// </summary>
-    internal interface IMidiFileHandler
-    {
-        /// <summary>
-        /// Adds a time signature to the generated midi file
-        /// </summary>
-        /// <param name="tick">The midi ticks when this event should be happening. </param>
-        /// <param name="timeSignatureNumerator">The time signature numerator</param>
-        /// <param name="timeSignatureDenominator">The time signature denominator</param>
-        void AddTimeSignature(int tick, int timeSignatureNumerator, int timeSignatureDenominator);
+    /// <param name="tick">The midi ticks when this event should be happening. </param>
+    /// <param name="timeSignatureNumerator">The time signature numerator</param>
+    /// <param name="timeSignatureDenominator">The time signature denominator</param>
+    void AddTimeSignature(int tick, int timeSignatureNumerator, int timeSignatureDenominator);
 
-        /// <summary>
-        /// Adds a rest to the generated midi file. 
-        /// </summary>
-        /// <param name="track">The midi track on which the rest should be "played".</param>
-        /// <param name="tick">The midi ticks when the rest is "playing". </param>
-        /// <param name="channel">The midi channel on which the rest should be "played".</param>
-        void AddRest(int track, int tick, int channel);
+    /// <summary>
+    /// Adds a rest to the generated midi file. 
+    /// </summary>
+    /// <param name="track">The midi track on which the rest should be "played".</param>
+    /// <param name="tick">The midi ticks when the rest is "playing". </param>
+    /// <param name="channel">The midi channel on which the rest should be "played".</param>
+    void AddRest(int track, int tick, int channel);
 
-        /// <summary>
-        /// Adds a note to the generated midi file
-        /// </summary>
-        /// <param name="track">The midi track on which the note should be played.</param>
-        /// <param name="start">The midi ticks when the note should start playing. </param>
-        /// <param name="length">The duration the note in midi ticks. </param>
-        /// <param name="key">The key of the note to play</param>
-        /// <param name="dynamicValue">The dynamic which should be applied to the note. </param>
-        /// <param name="channel">The midi channel on which the note should be played.</param>
-        void AddNote(int track, int start, int length, byte key, DynamicValue dynamicValue, byte channel);
+    /// <summary>
+    /// Adds a note to the generated midi file
+    /// </summary>
+    /// <param name="track">The midi track on which the note should be played.</param>
+    /// <param name="start">The midi ticks when the note should start playing. </param>
+    /// <param name="length">The duration the note in midi ticks. </param>
+    /// <param name="key">The key of the note to play</param>
+    /// <param name="dynamicValue">The dynamic which should be applied to the note. </param>
+    /// <param name="channel">The midi channel on which the note should be played.</param>
+    void AddNote(int track, int start, int length, byte key, DynamicValue dynamicValue, byte channel);
 
-        /// <summary>
-        /// Adds a control change to the generated midi file. 
-        /// </summary>
-        /// <param name="track">The midi track on which the controller should change.</param>
-        /// <param name="tick">The midi ticks when the controller should change.</param>
-        /// <param name="channel">The midi channel on which the controller should change.</param>
-        /// <param name="controller">The midi controller that should change.</param>
-        /// <param name="value">The value to which the midi controller should change</param>
-        void AddControlChange(int track, int tick, byte channel, byte controller, byte value);
+    /// <summary>
+    /// Adds a control change to the generated midi file. 
+    /// </summary>
+    /// <param name="track">The midi track on which the controller should change.</param>
+    /// <param name="tick">The midi ticks when the controller should change.</param>
+    /// <param name="channel">The midi channel on which the controller should change.</param>
+    /// <param name="controller">The midi controller that should change.</param>
+    /// <param name="value">The value to which the midi controller should change</param>
+    void AddControlChange(int track, int tick, byte channel, byte controller, byte value);
 
-        /// <summary>
-        /// Add a program change to the generated midi file
-        /// </summary>
-        /// <param name="track">The midi track on which the program should change.</param>
-        /// <param name="tick">The midi ticks when the program should change.</param>
-        /// <param name="channel">The midi channel on which the program should change.</param>
-        /// <param name="program">The new program for the selected track and channel.</param>
-        void AddProgramChange(int track, int tick, byte channel, byte program);
+    /// <summary>
+    /// Add a program change to the generated midi file
+    /// </summary>
+    /// <param name="track">The midi track on which the program should change.</param>
+    /// <param name="tick">The midi ticks when the program should change.</param>
+    /// <param name="channel">The midi channel on which the program should change.</param>
+    /// <param name="program">The new program for the selected track and channel.</param>
+    void AddProgramChange(int track, int tick, byte channel, byte program);
 
-        /// <summary>
-        /// Add a tempo change to the generated midi file. 
-        /// </summary>
-        /// <param name="tick">The midi ticks when the tempo should change change.</param>
-        /// <param name="tempo">The tempo as BPM</param>
-        void AddTempo(int tick, int tempo);
+    /// <summary>
+    /// Add a tempo change to the generated midi file. 
+    /// </summary>
+    /// <param name="tick">The midi ticks when the tempo should change change.</param>
+    /// <param name="tempo">The tempo as BPM</param>
+    void AddTempo(int tick, int tempo);
 
-        /// <summary>
-        /// Add a bend to the generated midi file. 
-        /// </summary>
-        /// <param name="track">The midi track on which the bend should change.</param>
-        /// <param name="tick">The midi ticks when the bend should change.</param>
-        /// <param name="channel">The midi channel on which the bend should change.</param>
-        /// <param name="value">The new bend for the selected track and channel.</param>
-        void AddBend(int track, int tick, byte channel, int value);
+    /// <summary>
+    /// Add a bend to the generated midi file. 
+    /// </summary>
+    /// <param name="track">The midi track on which the bend should change.</param>
+    /// <param name="tick">The midi ticks when the bend should change.</param>
+    /// <param name="channel">The midi channel on which the bend should change.</param>
+    /// <param name="value">The new bend for the selected track and channel.</param>
+    void AddBend(int track, int tick, byte channel, int value);
 
-        /// <summary>
-        /// Indicates that the track is finished on the given ticks.
-        /// </summary>
-        /// <param name="track">The track that was finished. </param>
-        /// <param name="tick">The end tick for this track.</param>
-        void FinishTrack(int track, int tick);
-    }
+    /// <summary>
+    /// Indicates that the track is finished on the given ticks.
+    /// </summary>
+    /// <param name="track">The track that was finished. </param>
+    /// <param name="tick">The end tick for this track.</param>
+    void FinishTrack(int track, int tick);
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/MidiUtils.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/MidiUtils.cs
@@ -57,13 +57,13 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio
         /// <returns></returns>
         public static int ValueToTicks(int duration)
         {
-            float denomninator = duration;
-            if (denomninator < 0)
+            float denominator = duration;
+            if (denominator < 0)
             {
-                denomninator = 1 / -denomninator;
+                denominator = 1 / -denominator;
             }
 
-            return (int)(QuarterTime * (4.0 / denomninator));
+            return (int)(QuarterTime * (4.0 / denominator));
         }
 
         public static int ApplyDot(int ticks, bool doubleDotted)

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/MidiUtils.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/MidiUtils.cs
@@ -5,90 +5,89 @@
 
 using BardMusicPlayer.Siren.AlphaTab.Model;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio
+namespace BardMusicPlayer.Siren.AlphaTab.Audio;
+
+internal static class MidiUtils
 {
-    internal static class MidiUtils
+    /// <summary>
+    /// The amount of ticks per quarter note used within this midi system.
+    /// (Pulses Per Quarter Note)
+    /// </summary>
+    public const int QuarterTime = 960;
+
+    private const int MinVelocity = 15;
+    private const int VelocityIncrement = 16;
+
+    /// <summary>
+    /// Converts the given midi tick duration into milliseconds. 
+    /// </summary>
+    /// <param name="ticks">The duration in midi ticks</param>
+    /// <param name="tempo">The current tempo in BPM.</param>
+    /// <returns>The converted duration in milliseconds. </returns>
+    public static int TicksToMillis(int ticks, int tempo)
     {
-        /// <summary>
-        /// The amount of ticks per quarter note used within this midi system.
-        /// (Pulses Per Quarter Note)
-        /// </summary>
-        public const int QuarterTime = 960;
+        return (int)(ticks * (60000.0 / (tempo * QuarterTime)));
+    }
 
-        private const int MinVelocity = 15;
-        private const int VelocityIncrement = 16;
+    /// <summary>
+    /// Converts the given midi tick duration into milliseconds. 
+    /// </summary>
+    /// <param name="millis">The duration in milliseconds</param>
+    /// <param name="tempo">The current tempo in BPM.</param>
+    /// <returns>The converted duration in midi ticks. </returns>
+    public static int MillisToTicks(int millis, int tempo)
+    {
+        return (int)(millis / (60000.0 / (tempo * QuarterTime)));
+    }
 
-        /// <summary>
-        /// Converts the given midi tick duration into milliseconds. 
-        /// </summary>
-        /// <param name="ticks">The duration in midi ticks</param>
-        /// <param name="tempo">The current tempo in BPM.</param>
-        /// <returns>The converted duration in milliseconds. </returns>
-        public static int TicksToMillis(int ticks, int tempo)
+    /// <summary>
+    /// Converts a duration value to its ticks equivalent.
+    /// </summary>
+    /// <param name="duration"></param>
+    /// <returns></returns>
+    public static int ToTicks(this Duration duration)
+    {
+        return ValueToTicks((int)duration);
+    }
+
+    /// <summary>
+    /// Converts a numerical value to its ticks equivalent.
+    /// </summary>
+    /// <param name="duration">the numerical proportion to convert. (i.E. timesignature denominator, note duration,...)</param>
+    /// <returns></returns>
+    public static int ValueToTicks(int duration)
+    {
+        float denominator = duration;
+        if (denominator < 0)
         {
-            return (int)(ticks * (60000.0 / (tempo * QuarterTime)));
+            denominator = 1 / -denominator;
         }
 
-        /// <summary>
-        /// Converts the given midi tick duration into milliseconds. 
-        /// </summary>
-        /// <param name="millis">The duration in milliseconds</param>
-        /// <param name="tempo">The current tempo in BPM.</param>
-        /// <returns>The converted duration in midi ticks. </returns>
-        public static int MillisToTicks(int millis, int tempo)
+        return (int)(QuarterTime * (4.0 / denominator));
+    }
+
+    public static int ApplyDot(int ticks, bool doubleDotted)
+    {
+        if (doubleDotted)
         {
-            return (int)(millis / (60000.0 / (tempo * QuarterTime)));
+            return ticks + ticks / 4 * 3;
         }
 
-        /// <summary>
-        /// Converts a duration value to its ticks equivalent.
-        /// </summary>
-        /// <param name="duration"></param>
-        /// <returns></returns>
-        public static int ToTicks(this Duration duration)
-        {
-            return ValueToTicks((int)duration);
-        }
+        return ticks + ticks / 2;
+    }
 
-        /// <summary>
-        /// Converts a numerical value to its ticks equivalent.
-        /// </summary>
-        /// <param name="duration">the numerical proportion to convert. (i.E. timesignature denominator, note duration,...)</param>
-        /// <returns></returns>
-        public static int ValueToTicks(int duration)
-        {
-            float denominator = duration;
-            if (denominator < 0)
-            {
-                denominator = 1 / -denominator;
-            }
+    public static int ApplyTuplet(int ticks, int numerator, int denominator)
+    {
+        return ticks * denominator / numerator;
+    }
 
-            return (int)(QuarterTime * (4.0 / denominator));
-        }
+    public static int RemoveTuplet(int ticks, int numerator, int denominator)
+    {
+        return ticks * numerator / denominator;
+    }
 
-        public static int ApplyDot(int ticks, bool doubleDotted)
-        {
-            if (doubleDotted)
-            {
-                return ticks + ticks / 4 * 3;
-            }
-
-            return ticks + ticks / 2;
-        }
-
-        public static int ApplyTuplet(int ticks, int numerator, int denominator)
-        {
-            return ticks * denominator / numerator;
-        }
-
-        public static int RemoveTuplet(int ticks, int numerator, int denominator)
-        {
-            return ticks * numerator / denominator;
-        }
-
-        public static int DynamicToVelocity(DynamicValue dyn)
-        {
-            return MinVelocity + (int)dyn * VelocityIncrement;
-        }
+    public static int DynamicToVelocity(DynamicValue dyn)
+    {
+        return MinVelocity + (int)dyn * VelocityIncrement;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/AlphaSynth.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/AlphaSynth.cs
@@ -11,527 +11,526 @@ using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Util;
 using BardMusicPlayer.Siren.AlphaTab.IO;
 using BardMusicPlayer.Siren.AlphaTab.Util;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth;
+
+/// <summary>
+/// This is the main synthesizer component which can be used to
+/// play a <see cref="MidiFile"/> via a <see cref="ISynthOutput"/>.
+/// </summary>
+internal class AlphaSynth : IAlphaSynth
 {
+    private readonly MidiFileSequencer _sequencer;
+    private readonly TinySoundFont _synthesizer;
+
+    private bool _isSoundFontLoaded;
+    private bool _isMidiLoaded;
+    private int _tickPosition;
+    private double _timePosition;
+
     /// <summary>
-    /// This is the main synthesizer component which can be used to
-    /// play a <see cref="MidiFile"/> via a <see cref="ISynthOutput"/>.
+    /// Gets the <see cref="ISynthOutput"/> used for playing the generated samples.
     /// </summary>
-    internal class AlphaSynth : IAlphaSynth
+    public ISynthOutput Output { get; }
+
+    /// <inheritdoc />
+    public bool IsReady { get; private set; }
+
+    /// <inheritdoc />
+    public bool IsReadyForPlayback => IsReady && _isSoundFontLoaded && _isMidiLoaded;
+
+    /// <inheritdoc />
+    public PlayerState State { get; private set; }
+
+    /// <inheritdoc />
+    public LogLevel LogLevel
     {
-        private readonly MidiFileSequencer _sequencer;
-        private readonly TinySoundFont _synthesizer;
+        get => Logger.LogLevel;
+        set => Logger.LogLevel = value;
+    }
 
-        private bool _isSoundFontLoaded;
-        private bool _isMidiLoaded;
-        private int _tickPosition;
-        private double _timePosition;
-
-        /// <summary>
-        /// Gets the <see cref="ISynthOutput"/> used for playing the generated samples.
-        /// </summary>
-        public ISynthOutput Output { get; }
-
-        /// <inheritdoc />
-        public bool IsReady { get; private set; }
-
-        /// <inheritdoc />
-        public bool IsReadyForPlayback => IsReady && _isSoundFontLoaded && _isMidiLoaded;
-
-        /// <inheritdoc />
-        public PlayerState State { get; private set; }
-
-        /// <inheritdoc />
-        public LogLevel LogLevel
+    /// <inheritdoc />
+    public float MasterVolume
+    {
+        get => _synthesizer.GlobalGainDb;
+        set
         {
-            get => Logger.LogLevel;
-            set => Logger.LogLevel = value;
+            value                     = SynthHelper.ClampF(value, SynthConstants.MinVolume, SynthConstants.MaxVolume);
+            _synthesizer.GlobalGainDb = value;
         }
+    }
 
-        /// <inheritdoc />
-        public float MasterVolume
+    /// <inheritdoc />
+    public double PlaybackSpeed
+    {
+        get => _sequencer.PlaybackSpeed;
+        set
         {
-            get => _synthesizer.GlobalGainDb;
-            set
+            value = SynthHelper.ClampD(value, SynthConstants.MinPlaybackSpeed, SynthConstants.MaxPlaybackSpeed);
+            var oldSpeed = _sequencer.PlaybackSpeed;
+            _sequencer.PlaybackSpeed = value;
+            UpdateTimePosition(_timePosition * (oldSpeed / value));
+        }
+    }
+
+    /// <inheritdoc />
+    public int TickPosition
+    {
+        get => _tickPosition;
+        set => TimePosition = _sequencer.TickPositionToTimePosition(value);
+    }
+
+    /// <inheritdoc />
+    public double TimePosition
+    {
+        get => _timePosition;
+        set
+        {
+            Logger.Debug("AlphaSynth", "Seeking to position " + value + "ms");
+
+            // tell the sequencer to jump to the given position
+            _sequencer.Seek(value);
+
+            // update the internal position
+            UpdateTimePosition(value);
+
+            // tell the output to reset the already synthesized buffers and request data again
+            Output.ResetSamples();
+        }
+    }
+
+    /// <inheritdoc />
+    public PlaybackRange PlaybackRange
+    {
+        get => _sequencer.PlaybackRange;
+        set
+        {
+            _sequencer.PlaybackRange = value;
+            if (value != null)
             {
-                value = SynthHelper.ClampF(value, SynthConstants.MinVolume, SynthConstants.MaxVolume);
-                _synthesizer.GlobalGainDb = value;
+                TickPosition = value.StartTick;
             }
         }
+    }
 
-        /// <inheritdoc />
-        public double PlaybackSpeed
+    /// <inheritdoc />
+    public bool IsLooping
+    {
+        get => _sequencer.IsLooping;
+        set => _sequencer.IsLooping = value;
+    }
+
+    /// <inheritdoc />
+    public void Destroy()
+    {
+        Logger.Debug("AlphaSynth", "Destroying player");
+        Stop();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AlphaSynth"/> class.
+    /// </summary>
+    /// <param name="output">The output to use for playing the generated samples.</param>
+    public AlphaSynth(ISynthOutput output)
+    {
+        Logger.Debug("AlphaSynth", "Initializing player");
+        State = PlayerState.Paused;
+
+        Logger.Debug("AlphaSynth", "Creating output");
+        Output = output;
+        Output.Ready += () =>
         {
-            get => _sequencer.PlaybackSpeed;
-            set
+            IsReady = true;
+            OnReady();
+            CheckReadyForPlayback();
+        };
+        Output.Finished += () =>
+        {
+            //The Ui will trigger Stop() to reduce the CPU load
+            //If stop is triggered here, there's no playback possible anymore
             {
-                value = SynthHelper.ClampD(value, SynthConstants.MinPlaybackSpeed, SynthConstants.MaxPlaybackSpeed);
-                var oldSpeed = _sequencer.PlaybackSpeed;
-                _sequencer.PlaybackSpeed = value;
-                UpdateTimePosition(_timePosition * (oldSpeed / value));
-            }
-        }
-
-        /// <inheritdoc />
-        public int TickPosition
-        {
-            get => _tickPosition;
-            set => TimePosition = _sequencer.TickPositionToTimePosition(value);
-        }
-
-        /// <inheritdoc />
-        public double TimePosition
-        {
-            get => _timePosition;
-            set
-            {
-                Logger.Debug("AlphaSynth", "Seeking to position " + value + "ms");
-
-                // tell the sequencer to jump to the given position
-                _sequencer.Seek(value);
-
-                // update the internal position
-                UpdateTimePosition(value);
-
-                // tell the output to reset the already synthesized buffers and request data again
-                Output.ResetSamples();
-            }
-        }
-
-        /// <inheritdoc />
-        public PlaybackRange PlaybackRange
-        {
-            get => _sequencer.PlaybackRange;
-            set
-            {
-                _sequencer.PlaybackRange = value;
-                if (value != null)
-                {
-                    TickPosition = value.StartTick;
-                }
-            }
-        }
-
-        /// <inheritdoc />
-        public bool IsLooping
-        {
-            get => _sequencer.IsLooping;
-            set => _sequencer.IsLooping = value;
-        }
-
-        /// <inheritdoc />
-        public void Destroy()
-        {
-            Logger.Debug("AlphaSynth", "Destroying player");
-            Stop();
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AlphaSynth"/> class.
-        /// </summary>
-        /// <param name="output">The output to use for playing the generated samples.</param>
-        public AlphaSynth(ISynthOutput output)
-        {
-            Logger.Debug("AlphaSynth", "Initializing player");
-            State = PlayerState.Paused;
-
-            Logger.Debug("AlphaSynth", "Creating output");
-            Output = output;
-            Output.Ready += () =>
-            {
-                IsReady = true;
-                OnReady();
-                CheckReadyForPlayback();
-            };
-            Output.Finished += () =>
-            {
-                //The Ui will trigger Stop() to reduce the CPU load
-                //If stop is triggered here, there's no playback possible anymore
-                {
-                    Output.Pause();
-                    State = PlayerState.Paused;
-                    OnStateChanged(new PlayerStateChangedEventArgs(State, false));
-                    _sequencer?.Stop();
-                    _synthesizer?.NoteOffAll(true);
-                    TickPosition = _sequencer?.PlaybackRange?.StartTick ?? 0;
-                }
-
-                Logger.Debug("AlphaSynth", "Finished playback");
-                OnFinished();
-                if (_sequencer is { IsLooping: true })
-                {
-                    Play();
-                }
-            };
-            Output.SampleRequest += () =>
-            {
-                // synthesize buffer
-                _sequencer?.FillMidiEventQueue();
-                var samples = _synthesizer?.Synthesize();
-                // send it to output
-                Output.AddSamples(samples);
-                // tell sequencer to check whether its work is done
-                _sequencer?.CheckForStop();
-            };
-            Output.SamplesPlayed += OnSamplesPlayed;
-
-            Logger.Debug("AlphaSynth", "Creating synthesizer");
-            _synthesizer = new TinySoundFont(Output.SampleRate);
-            _sequencer = new MidiFileSequencer(_synthesizer);
-            _sequencer.Finished += Output.SequencerFinished;
-
-            Logger.Debug("AlphaSynth", "Opening output");
-            Output.Open();
-        }
-
-        /// <inheritdoc />
-        public bool Play()
-        {
-            if (State == PlayerState.Playing || !IsReadyForPlayback)
-            {
-                return false;
+                Output.Pause();
+                State = PlayerState.Paused;
+                OnStateChanged(new PlayerStateChangedEventArgs(State, false));
+                _sequencer?.Stop();
+                _synthesizer?.NoteOffAll(true);
+                TickPosition = _sequencer?.PlaybackRange?.StartTick ?? 0;
             }
 
-            Output.Activate();
-
-            Logger.Debug("AlphaSynth", "Starting playback");
-            State = PlayerState.Playing;
-            OnStateChanged(new PlayerStateChangedEventArgs(State, false));
-            Output.Play();
-            return true;
-        }
-
-        /// <inheritdoc />
-        public void Pause()
-        {
-            if (State == PlayerState.Paused || !IsReadyForPlayback)
-            {
-                return;
-            }
-
-            Logger.Debug("AlphaSynth", "Pausing playback");
-            State = PlayerState.Paused;
-            OnStateChanged(new PlayerStateChangedEventArgs(State, false));
-            Output.Pause();
-            _synthesizer.NoteOffAll(false);
-        }
-
-        /// <inheritdoc />
-        public void PlayPause()
-        {
-            if (State == PlayerState.Playing || !IsReadyForPlayback)
-            {
-                Pause();
-            }
-            else
+            Logger.Debug("AlphaSynth", "Finished playback");
+            OnFinished();
+            if (_sequencer is { IsLooping: true })
             {
                 Play();
             }
-        }
-
-        /// <inheritdoc />
-        public void Stop()
+        };
+        Output.SampleRequest += () =>
         {
-            if (!IsReadyForPlayback)
-            {
-                return;
-            }
+            // synthesize buffer
+            _sequencer?.FillMidiEventQueue();
+            var samples = _synthesizer?.Synthesize();
+            // send it to output
+            Output.AddSamples(samples);
+            // tell sequencer to check whether its work is done
+            _sequencer?.CheckForStop();
+        };
+        Output.SamplesPlayed += OnSamplesPlayed;
 
-            Logger.Debug("AlphaSynth", "Stopping playback");
-            State = PlayerState.Paused;
-            Output.Stop();
-            _sequencer.Stop();
-            _synthesizer.NoteOffAll(true);
-            TickPosition = _sequencer.PlaybackRange?.StartTick ?? 0;
-            OnStateChanged(new PlayerStateChangedEventArgs(State, true));
+        Logger.Debug("AlphaSynth", "Creating synthesizer");
+        _synthesizer        =  new TinySoundFont(Output.SampleRate);
+        _sequencer          =  new MidiFileSequencer(_synthesizer);
+        _sequencer.Finished += Output.SequencerFinished;
+
+        Logger.Debug("AlphaSynth", "Opening output");
+        Output.Open();
+    }
+
+    /// <inheritdoc />
+    public bool Play()
+    {
+        if (State == PlayerState.Playing || !IsReadyForPlayback)
+        {
+            return false;
         }
 
-        /// <inheritdoc />
-        public void LoadSoundFont(byte[] data, bool append = false)
+        Output.Activate();
+
+        Logger.Debug("AlphaSynth", "Starting playback");
+        State = PlayerState.Playing;
+        OnStateChanged(new PlayerStateChangedEventArgs(State, false));
+        Output.Play();
+        return true;
+    }
+
+    /// <inheritdoc />
+    public void Pause()
+    {
+        if (State == PlayerState.Paused || !IsReadyForPlayback)
+        {
+            return;
+        }
+
+        Logger.Debug("AlphaSynth", "Pausing playback");
+        State = PlayerState.Paused;
+        OnStateChanged(new PlayerStateChangedEventArgs(State, false));
+        Output.Pause();
+        _synthesizer.NoteOffAll(false);
+    }
+
+    /// <inheritdoc />
+    public void PlayPause()
+    {
+        if (State == PlayerState.Playing || !IsReadyForPlayback)
         {
             Pause();
-
-            var input = ByteBuffer.FromBuffer(data);
-            try
-            {
-                Logger.Info("AlphaSynth", "Loading soundfont from bytes");
-                var soundFont = new Hydra();
-                soundFont.Load(input);
-                _synthesizer.LoadPresets(soundFont, append);
-                _isSoundFontLoaded = true;
-                OnSoundFontLoaded();
-
-                Logger.Info("AlphaSynth", "soundFont successfully loaded");
-                CheckReadyForPlayback();
-            }
-            catch (Exception e)
-            {
-                Logger.Error("AlphaSynth", "Could not load soundfont from bytes " + e);
-                OnSoundFontLoadFailed(e);
-            }
         }
-
-        private void CheckReadyForPlayback()
+        else
         {
-            if (IsReadyForPlayback)
-            {
-                OnReadyForPlayback();
-            }
+            Play();
         }
-
-        /// <summary>
-        /// Loads the given midi file for playback.
-        /// </summary>
-        /// <param name="midiFile">The midi file to load</param>
-        // ReSharper disable once UnusedMember.Global
-        public void LoadMidiFile(MidiFile midiFile)
-        {
-            Stop();
-
-            try
-            {
-                Logger.Info("AlphaSynth", "Loading midi from model");
-
-                _sequencer.LoadMidi(midiFile);
-                _isMidiLoaded = true;
-                OnMidiLoaded();
-                Logger.Info("AlphaSynth", "Midi successfully loaded");
-                CheckReadyForPlayback();
-
-                TickPosition = 0;
-            }
-            catch (Exception e)
-            {
-                Logger.Error("AlphaSynth", "Could not load midi from model " + e);
-                OnMidiLoadFailed(e);
-            }
-        }
-
-        /// <inheritdoc />
-        public void SetChannelMute(int channel, bool mute)
-        {
-            _synthesizer.ChannelSetMute(channel, mute);
-        }
-
-        /// <inheritdoc />
-        public void ResetChannelStates()
-        {
-            _synthesizer.ResetChannelStates();
-        }
-
-        /// <inheritdoc />
-        public void SetChannelSolo(int channel, bool solo)
-        {
-            _synthesizer.ChannelSetSolo(channel, solo);
-        }
-
-        /// <inheritdoc />
-        public void SetChannelVolume(int channel, float volume)
-        {
-            volume = SynthHelper.ClampF(volume, SynthConstants.MinVolume, SynthConstants.MaxVolume);
-            _synthesizer.ChannelSetMixVolume(channel, volume);
-        }
-
-        /// <inheritdoc />
-        public void SetChannelProgram(int channel, byte program)
-        {
-            program = SynthHelper.ClampB(program, SynthConstants.MinProgram, SynthConstants.MaxProgram);
-            _sequencer.SetChannelProgram(channel, program);
-            _synthesizer.ChannelSetPresetNumber(channel, program);
-        }
-
-        private void OnSamplesPlayed(int sampleCount)
-        {
-            var playedMillis = sampleCount / (double)_synthesizer.OutSampleRate * 1000;
-            UpdateTimePosition(_timePosition + playedMillis);
-        }
-
-        private void UpdateTimePosition(double timePosition)
-        {
-            // update the real positions
-            var currentTime = _timePosition = timePosition;
-            var currentTick = _tickPosition = _sequencer.TimePositionToTickPosition(currentTime);
-
-            var endTime = _sequencer.EndTime;
-            var endTick = _sequencer.EndTick;
-
-            Logger.Debug("AlphaSynth",
-                "Position changed: (time: " + currentTime + "/" + endTime + ", tick: " + currentTick + "/" + endTime +
-                ", Active Voices: " + _synthesizer.ActiveVoiceCount);
-            OnPositionChanged(new PositionChangedEventArgs(currentTime, endTime, currentTick, endTick, _synthesizer.ActiveVoiceCount));
-        }
-
-        #region Events
-
-        /// <inheritdoc />
-        public event Action Ready;
-
-        private void OnReady()
-        {
-            var handler = Ready;
-            handler?.Invoke();
-        }
-
-        /// <summary>
-        /// Occurs when the playback of the whole midi file finished.
-        /// </summary>
-        public event Action Finished;
-
-        private void OnFinished()
-        {
-            var handler = Finished;
-            handler?.Invoke();
-        }
-
-        /// <summary>
-        /// Occurs when the playback state changes.
-        /// </summary>
-        public event Action<PlayerStateChangedEventArgs> StateChanged;
-
-        private void OnStateChanged(PlayerStateChangedEventArgs e)
-        {
-            var handler = StateChanged;
-            handler?.Invoke(e);
-        }
-
-        /// <summary>
-        /// Occurs when the soundfont was successfully loaded.
-        /// </summary>
-        public event Action SoundFontLoaded;
-
-        private void OnSoundFontLoaded()
-        {
-            var handler = SoundFontLoaded;
-            handler?.Invoke();
-        }
-
-        /// <summary>
-        /// Occurs when AlphaSynth is ready to start the playback.
-        /// This is the case once the <see cref="ISynthOutput"/> is ready, a SoundFont was loaded and also a MidiFle is loaded.
-        /// </summary>
-        public event Action ReadyForPlayback;
-
-        private void OnReadyForPlayback()
-        {
-            var handler = ReadyForPlayback;
-            handler?.Invoke();
-        }
-
-        /// <summary>
-        /// Occurs when the soundfont failed to be loaded.
-        /// </summary>
-        public event Action<Exception> SoundFontLoadFailed;
-
-        private void OnSoundFontLoadFailed(Exception e)
-        {
-            var handler = SoundFontLoadFailed;
-            handler?.Invoke(e);
-        }
-
-        /// <summary>
-        /// Occurs when the midi file was successfully loaded.
-        /// </summary>
-        public event Action MidiLoaded;
-
-        private void OnMidiLoaded()
-        {
-            var handler = MidiLoaded;
-            handler?.Invoke();
-        }
-
-        /// <summary>
-        /// Occurs when the midi failed to be loaded.
-        /// </summary>
-        public event Action<Exception> MidiLoadFailed;
-
-        private void OnMidiLoadFailed(Exception e)
-        {
-            var handler = MidiLoadFailed;
-            handler?.Invoke(e);
-        }
-
-        /// <summary>
-        /// Occurs whenever the current time of the played audio changes.
-        /// </summary>
-        public event Action<PositionChangedEventArgs> PositionChanged;
-
-        private void OnPositionChanged(PositionChangedEventArgs e)
-        {
-            var handler = PositionChanged;
-            handler?.Invoke(e);
-        }
-
-        #endregion
     }
 
-    /// <summary>
-    /// Represents the info when the player state changes.
-    /// </summary>
-    internal class PlayerStateChangedEventArgs
+    /// <inheritdoc />
+    public void Stop()
     {
-        /// <summary>
-        /// The new state of the player.
-        /// </summary>
-        public PlayerState State { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the playback was stopped or only paused.
-        /// </summary>
-        /// <returns>true if the playback was stopped, false if the playback was started or paused</returns>
-        public bool Stopped { get; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PlayerStateChangedEventArgs"/> class.
-        /// </summary>
-        /// <param name="state">The state.</param>
-        public PlayerStateChangedEventArgs(PlayerState state, bool stopped)
+        if (!IsReadyForPlayback)
         {
-            State = state;
-            Stopped = stopped;
+            return;
+        }
+
+        Logger.Debug("AlphaSynth", "Stopping playback");
+        State = PlayerState.Paused;
+        Output.Stop();
+        _sequencer.Stop();
+        _synthesizer.NoteOffAll(true);
+        TickPosition = _sequencer.PlaybackRange?.StartTick ?? 0;
+        OnStateChanged(new PlayerStateChangedEventArgs(State, true));
+    }
+
+    /// <inheritdoc />
+    public void LoadSoundFont(byte[] data, bool append = false)
+    {
+        Pause();
+
+        var input = ByteBuffer.FromBuffer(data);
+        try
+        {
+            Logger.Info("AlphaSynth", "Loading soundfont from bytes");
+            var soundFont = new Hydra();
+            soundFont.Load(input);
+            _synthesizer.LoadPresets(soundFont, append);
+            _isSoundFontLoaded = true;
+            OnSoundFontLoaded();
+
+            Logger.Info("AlphaSynth", "soundFont successfully loaded");
+            CheckReadyForPlayback();
+        }
+        catch (Exception e)
+        {
+            Logger.Error("AlphaSynth", "Could not load soundfont from bytes " + e);
+            OnSoundFontLoadFailed(e);
+        }
+    }
+
+    private void CheckReadyForPlayback()
+    {
+        if (IsReadyForPlayback)
+        {
+            OnReadyForPlayback();
         }
     }
 
     /// <summary>
-    /// Represents the info when the time in the synthesizer changes.
+    /// Loads the given midi file for playback.
     /// </summary>
-    internal class PositionChangedEventArgs
+    /// <param name="midiFile">The midi file to load</param>
+    // ReSharper disable once UnusedMember.Global
+    public void LoadMidiFile(MidiFile midiFile)
     {
-        /// <summary>
-        /// Gets the current time in milliseconds.
-        /// </summary>
-        public double CurrentTime { get; }
+        Stop();
 
-        /// <summary>
-        /// Gets the length of the played song in milliseconds.
-        /// </summary>
-        public double EndTime { get; }
-
-        /// <summary>
-        /// Gets the current time in midi ticks.
-        /// </summary>
-        public int CurrentTick { get; }
-
-        /// <summary>
-        /// Gets the length of the played song in midi ticks.
-        /// </summary>
-        public int EndTick { get; }
-
-        public int ActiveVoices { get; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PositionChangedEventArgs"/> class.
-        /// </summary>
-        /// <param name="currentTime">The current time.</param>
-        /// <param name="endTime">The end time.</param>
-        /// <param name="currentTick">The current tick.</param>
-        /// <param name="endTick">The end tick.</param>
-        public PositionChangedEventArgs(double currentTime, double endTime, int currentTick, int endTick, int activeVoices)
+        try
         {
-            CurrentTime = currentTime;
-            EndTime = endTime;
-            CurrentTick = currentTick;
-            EndTick = endTick;
-            ActiveVoices = activeVoices;
+            Logger.Info("AlphaSynth", "Loading midi from model");
+
+            _sequencer.LoadMidi(midiFile);
+            _isMidiLoaded = true;
+            OnMidiLoaded();
+            Logger.Info("AlphaSynth", "Midi successfully loaded");
+            CheckReadyForPlayback();
+
+            TickPosition = 0;
         }
+        catch (Exception e)
+        {
+            Logger.Error("AlphaSynth", "Could not load midi from model " + e);
+            OnMidiLoadFailed(e);
+        }
+    }
+
+    /// <inheritdoc />
+    public void SetChannelMute(int channel, bool mute)
+    {
+        _synthesizer.ChannelSetMute(channel, mute);
+    }
+
+    /// <inheritdoc />
+    public void ResetChannelStates()
+    {
+        _synthesizer.ResetChannelStates();
+    }
+
+    /// <inheritdoc />
+    public void SetChannelSolo(int channel, bool solo)
+    {
+        _synthesizer.ChannelSetSolo(channel, solo);
+    }
+
+    /// <inheritdoc />
+    public void SetChannelVolume(int channel, float volume)
+    {
+        volume = SynthHelper.ClampF(volume, SynthConstants.MinVolume, SynthConstants.MaxVolume);
+        _synthesizer.ChannelSetMixVolume(channel, volume);
+    }
+
+    /// <inheritdoc />
+    public void SetChannelProgram(int channel, byte program)
+    {
+        program = SynthHelper.ClampB(program, SynthConstants.MinProgram, SynthConstants.MaxProgram);
+        _sequencer.SetChannelProgram(channel, program);
+        _synthesizer.ChannelSetPresetNumber(channel, program);
+    }
+
+    private void OnSamplesPlayed(int sampleCount)
+    {
+        var playedMillis = sampleCount / (double)_synthesizer.OutSampleRate * 1000;
+        UpdateTimePosition(_timePosition + playedMillis);
+    }
+
+    private void UpdateTimePosition(double timePosition)
+    {
+        // update the real positions
+        var currentTime = _timePosition = timePosition;
+        var currentTick = _tickPosition = _sequencer.TimePositionToTickPosition(currentTime);
+
+        var endTime = _sequencer.EndTime;
+        var endTick = _sequencer.EndTick;
+
+        Logger.Debug("AlphaSynth",
+            "Position changed: (time: " + currentTime + "/" + endTime + ", tick: " + currentTick + "/" + endTime +
+            ", Active Voices: " + _synthesizer.ActiveVoiceCount);
+        OnPositionChanged(new PositionChangedEventArgs(currentTime, endTime, currentTick, endTick, _synthesizer.ActiveVoiceCount));
+    }
+
+    #region Events
+
+    /// <inheritdoc />
+    public event Action Ready;
+
+    private void OnReady()
+    {
+        var handler = Ready;
+        handler?.Invoke();
+    }
+
+    /// <summary>
+    /// Occurs when the playback of the whole midi file finished.
+    /// </summary>
+    public event Action Finished;
+
+    private void OnFinished()
+    {
+        var handler = Finished;
+        handler?.Invoke();
+    }
+
+    /// <summary>
+    /// Occurs when the playback state changes.
+    /// </summary>
+    public event Action<PlayerStateChangedEventArgs> StateChanged;
+
+    private void OnStateChanged(PlayerStateChangedEventArgs e)
+    {
+        var handler = StateChanged;
+        handler?.Invoke(e);
+    }
+
+    /// <summary>
+    /// Occurs when the soundfont was successfully loaded.
+    /// </summary>
+    public event Action SoundFontLoaded;
+
+    private void OnSoundFontLoaded()
+    {
+        var handler = SoundFontLoaded;
+        handler?.Invoke();
+    }
+
+    /// <summary>
+    /// Occurs when AlphaSynth is ready to start the playback.
+    /// This is the case once the <see cref="ISynthOutput"/> is ready, a SoundFont was loaded and also a MidiFle is loaded.
+    /// </summary>
+    public event Action ReadyForPlayback;
+
+    private void OnReadyForPlayback()
+    {
+        var handler = ReadyForPlayback;
+        handler?.Invoke();
+    }
+
+    /// <summary>
+    /// Occurs when the soundfont failed to be loaded.
+    /// </summary>
+    public event Action<Exception> SoundFontLoadFailed;
+
+    private void OnSoundFontLoadFailed(Exception e)
+    {
+        var handler = SoundFontLoadFailed;
+        handler?.Invoke(e);
+    }
+
+    /// <summary>
+    /// Occurs when the midi file was successfully loaded.
+    /// </summary>
+    public event Action MidiLoaded;
+
+    private void OnMidiLoaded()
+    {
+        var handler = MidiLoaded;
+        handler?.Invoke();
+    }
+
+    /// <summary>
+    /// Occurs when the midi failed to be loaded.
+    /// </summary>
+    public event Action<Exception> MidiLoadFailed;
+
+    private void OnMidiLoadFailed(Exception e)
+    {
+        var handler = MidiLoadFailed;
+        handler?.Invoke(e);
+    }
+
+    /// <summary>
+    /// Occurs whenever the current time of the played audio changes.
+    /// </summary>
+    public event Action<PositionChangedEventArgs> PositionChanged;
+
+    private void OnPositionChanged(PositionChangedEventArgs e)
+    {
+        var handler = PositionChanged;
+        handler?.Invoke(e);
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Represents the info when the player state changes.
+/// </summary>
+internal class PlayerStateChangedEventArgs
+{
+    /// <summary>
+    /// The new state of the player.
+    /// </summary>
+    public PlayerState State { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the playback was stopped or only paused.
+    /// </summary>
+    /// <returns>true if the playback was stopped, false if the playback was started or paused</returns>
+    public bool Stopped { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlayerStateChangedEventArgs"/> class.
+    /// </summary>
+    /// <param name="state">The state.</param>
+    public PlayerStateChangedEventArgs(PlayerState state, bool stopped)
+    {
+        State   = state;
+        Stopped = stopped;
+    }
+}
+
+/// <summary>
+/// Represents the info when the time in the synthesizer changes.
+/// </summary>
+internal class PositionChangedEventArgs
+{
+    /// <summary>
+    /// Gets the current time in milliseconds.
+    /// </summary>
+    public double CurrentTime { get; }
+
+    /// <summary>
+    /// Gets the length of the played song in milliseconds.
+    /// </summary>
+    public double EndTime { get; }
+
+    /// <summary>
+    /// Gets the current time in midi ticks.
+    /// </summary>
+    public int CurrentTick { get; }
+
+    /// <summary>
+    /// Gets the length of the played song in midi ticks.
+    /// </summary>
+    public int EndTick { get; }
+
+    public int ActiveVoices { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PositionChangedEventArgs"/> class.
+    /// </summary>
+    /// <param name="currentTime">The current time.</param>
+    /// <param name="endTime">The end time.</param>
+    /// <param name="currentTick">The current tick.</param>
+    /// <param name="endTick">The end tick.</param>
+    public PositionChangedEventArgs(double currentTime, double endTime, int currentTick, int endTick, int activeVoices)
+    {
+        CurrentTime  = currentTime;
+        EndTime      = endTime;
+        CurrentTick  = currentTick;
+        EndTick      = endTick;
+        ActiveVoices = activeVoices;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/AlphaSynth.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/AlphaSynth.cs
@@ -151,14 +151,14 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
                     Output.Pause();
                     State = PlayerState.Paused;
                     OnStateChanged(new PlayerStateChangedEventArgs(State, false));
-                    _sequencer.Stop();
-                    _synthesizer.NoteOffAll(true);
-                    TickPosition = _sequencer.PlaybackRange != null ? _sequencer.PlaybackRange.StartTick : 0;
+                    _sequencer?.Stop();
+                    _synthesizer?.NoteOffAll(true);
+                    TickPosition = _sequencer?.PlaybackRange?.StartTick ?? 0;
                 }
 
                 Logger.Debug("AlphaSynth", "Finished playback");
                 OnFinished();
-                if (_sequencer.IsLooping)
+                if (_sequencer is { IsLooping: true })
                 {
                     Play();
                 }
@@ -166,12 +166,12 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
             Output.SampleRequest += () =>
             {
                 // synthesize buffer
-                _sequencer.FillMidiEventQueue();
-                var samples = _synthesizer.Synthesize();
+                _sequencer?.FillMidiEventQueue();
+                var samples = _synthesizer?.Synthesize();
                 // send it to output
                 Output.AddSamples(samples);
                 // tell sequencer to check whether its work is done
-                _sequencer.CheckForStop();
+                _sequencer?.CheckForStop();
             };
             Output.SamplesPlayed += OnSamplesPlayed;
 
@@ -242,7 +242,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
             Output.Stop();
             _sequencer.Stop();
             _synthesizer.NoteOffAll(true);
-            TickPosition = _sequencer.PlaybackRange != null ? _sequencer.PlaybackRange.StartTick : 0;
+            TickPosition = _sequencer.PlaybackRange?.StartTick ?? 0;
             OnStateChanged(new PlayerStateChangedEventArgs(State, true));
         }
 
@@ -369,10 +369,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
         private void OnReady()
         {
             var handler = Ready;
-            if (handler != null)
-            {
-                handler();
-            }
+            handler?.Invoke();
         }
 
         /// <summary>
@@ -383,10 +380,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
         private void OnFinished()
         {
             var handler = Finished;
-            if (handler != null)
-            {
-                handler();
-            }
+            handler?.Invoke();
         }
 
         /// <summary>
@@ -397,10 +391,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
         private void OnStateChanged(PlayerStateChangedEventArgs e)
         {
             var handler = StateChanged;
-            if (handler != null)
-            {
-                handler(e);
-            }
+            handler?.Invoke(e);
         }
 
         /// <summary>
@@ -411,10 +402,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
         private void OnSoundFontLoaded()
         {
             var handler = SoundFontLoaded;
-            if (handler != null)
-            {
-                handler();
-            }
+            handler?.Invoke();
         }
 
         /// <summary>
@@ -426,10 +414,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
         private void OnReadyForPlayback()
         {
             var handler = ReadyForPlayback;
-            if (handler != null)
-            {
-                handler();
-            }
+            handler?.Invoke();
         }
 
         /// <summary>
@@ -440,10 +425,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
         private void OnSoundFontLoadFailed(Exception e)
         {
             var handler = SoundFontLoadFailed;
-            if (handler != null)
-            {
-                handler(e);
-            }
+            handler?.Invoke(e);
         }
 
         /// <summary>
@@ -454,10 +436,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
         private void OnMidiLoaded()
         {
             var handler = MidiLoaded;
-            if (handler != null)
-            {
-                handler();
-            }
+            handler?.Invoke();
         }
 
         /// <summary>
@@ -468,10 +447,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
         private void OnMidiLoadFailed(Exception e)
         {
             var handler = MidiLoadFailed;
-            if (handler != null)
-            {
-                handler(e);
-            }
+            handler?.Invoke(e);
         }
 
         /// <summary>
@@ -482,10 +458,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
         private void OnPositionChanged(PositionChangedEventArgs e)
         {
             var handler = PositionChanged;
-            if (handler != null)
-            {
-                handler(e);
-            }
+            handler?.Invoke(e);
         }
 
         #endregion

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Ds/CircularSampleBuffer.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Ds/CircularSampleBuffer.cs
@@ -5,106 +5,105 @@
 
 using System;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Ds
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Ds;
+
+/// <summary>
+/// Represents a fixed size circular sample buffer that can be written to and read from.
+/// </summary>
+internal class CircularSampleBuffer
 {
+    private float[] _buffer;
+    private int _writePosition;
+    private int _readPosition;
+
     /// <summary>
-    /// Represents a fixed size circular sample buffer that can be written to and read from.
+    /// Initializes a new instance of the <see cref="CircularSampleBuffer"/> class.
     /// </summary>
-    internal class CircularSampleBuffer
+    /// <param name="size">The size.</param>
+    public CircularSampleBuffer(int size)
     {
-        private float[] _buffer;
-        private int _writePosition;
-        private int _readPosition;
+        _buffer        = new float[size];
+        _writePosition = 0;
+        _readPosition  = 0;
+        Count          = 0;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CircularSampleBuffer"/> class.
-        /// </summary>
-        /// <param name="size">The size.</param>
-        public CircularSampleBuffer(int size)
+    /// <summary>
+    /// Gets the number of samples written to the buffer.
+    /// </summary>
+    public int Count { get; private set; }
+
+    /// <summary>
+    /// Clears all samples written to this buffer.
+    /// </summary>
+    public void Clear()
+    {
+        _readPosition  = 0;
+        _writePosition = 0;
+        Count          = 0;
+        _buffer        = new float[_buffer.Length];
+    }
+
+    /// <summary>
+    /// Writes the given samples to this buffer.
+    /// </summary>
+    /// <param name="data">The sample array to read from. </param>
+    /// <param name="offset"></param>
+    /// <param name="count"></param>
+    /// <returns></returns>
+    public int Write(float[] data, int offset, int count)
+    {
+        var samplesWritten = 0;
+        if (count > _buffer.Length - Count)
         {
-            _buffer = new float[size];
-            _writePosition = 0;
-            _readPosition = 0;
-            Count = 0;
+            count = _buffer.Length - Count;
         }
 
-        /// <summary>
-        /// Gets the number of samples written to the buffer.
-        /// </summary>
-        public int Count { get; private set; }
-
-        /// <summary>
-        /// Clears all samples written to this buffer.
-        /// </summary>
-        public void Clear()
+        var writeToEnd = Math.Min(_buffer.Length - _writePosition, count);
+        Platform.ArrayCopy(data, offset, _buffer, _writePosition, writeToEnd);
+        _writePosition += writeToEnd;
+        _writePosition %= _buffer.Length;
+        samplesWritten += writeToEnd;
+        if (samplesWritten < count)
         {
-            _readPosition = 0;
-            _writePosition = 0;
-            Count = 0;
-            _buffer = new float[_buffer.Length];
+            Platform.ArrayCopy(data, offset + samplesWritten, _buffer, _writePosition, count - samplesWritten);
+            _writePosition += count - samplesWritten;
+            samplesWritten =  count;
         }
 
-        /// <summary>
-        /// Writes the given samples to this buffer.
-        /// </summary>
-        /// <param name="data">The sample array to read from. </param>
-        /// <param name="offset"></param>
-        /// <param name="count"></param>
-        /// <returns></returns>
-        public int Write(float[] data, int offset, int count)
+        Count += samplesWritten;
+        return samplesWritten;
+    }
+
+    /// <summary>
+    /// Reads the requested amount of samples from the buffer.
+    /// </summary>
+    /// <param name="data">The sample array to store the read elements.</param>
+    /// <param name="offset">The offset within the destination buffer to put the items at.</param>
+    /// <param name="count">The number of items to read from this buffer.</param>
+    /// <returns>The number of items actually read from the buffer.</returns>
+    public int Read(float[] data, int offset, int count)
+    {
+        if (count > Count)
         {
-            var samplesWritten = 0;
-            if (count > _buffer.Length - Count)
-            {
-                count = _buffer.Length - Count;
-            }
-
-            var writeToEnd = Math.Min(_buffer.Length - _writePosition, count);
-            Platform.ArrayCopy(data, offset, _buffer, _writePosition, writeToEnd);
-            _writePosition += writeToEnd;
-            _writePosition %= _buffer.Length;
-            samplesWritten += writeToEnd;
-            if (samplesWritten < count)
-            {
-                Platform.ArrayCopy(data, offset + samplesWritten, _buffer, _writePosition, count - samplesWritten);
-                _writePosition += count - samplesWritten;
-                samplesWritten = count;
-            }
-
-            Count += samplesWritten;
-            return samplesWritten;
+            count = Count;
         }
 
-        /// <summary>
-        /// Reads the requested amount of samples from the buffer.
-        /// </summary>
-        /// <param name="data">The sample array to store the read elements.</param>
-        /// <param name="offset">The offset within the destination buffer to put the items at.</param>
-        /// <param name="count">The number of items to read from this buffer.</param>
-        /// <returns>The number of items actually read from the buffer.</returns>
-        public int Read(float[] data, int offset, int count)
+        var samplesRead = 0;
+        var readToEnd = Math.Min(_buffer.Length - _readPosition, count);
+        Platform.ArrayCopy(_buffer, _readPosition, data, offset, readToEnd);
+        samplesRead   += readToEnd;
+        _readPosition += readToEnd;
+        _readPosition %= _buffer.Length;
+
+        if (samplesRead < count)
         {
-            if (count > Count)
-            {
-                count = Count;
-            }
-
-            var samplesRead = 0;
-            var readToEnd = Math.Min(_buffer.Length - _readPosition, count);
-            Platform.ArrayCopy(_buffer, _readPosition, data, offset, readToEnd);
-            samplesRead += readToEnd;
-            _readPosition += readToEnd;
-            _readPosition %= _buffer.Length;
-
-            if (samplesRead < count)
-            {
-                Platform.ArrayCopy(_buffer, _readPosition, data, offset + samplesRead, count - samplesRead);
-                _readPosition += count - samplesRead;
-                samplesRead = count;
-            }
-
-            Count -= samplesRead;
-            return samplesRead;
+            Platform.ArrayCopy(_buffer, _readPosition, data, offset + samplesRead, count - samplesRead);
+            _readPosition += count - samplesRead;
+            samplesRead   =  count;
         }
+
+        Count -= samplesRead;
+        return samplesRead;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Ds/LinkedList.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Ds/LinkedList.cs
@@ -18,8 +18,10 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Ds
 
         public void AddFirst(T value)
         {
-            var node = new LinkedListNode<T>();
-            node.Value = value;
+            var node = new LinkedListNode<T>
+            {
+                Value = value
+            };
             if (First == null)
             {
                 InsertNodeToEmptyList(node);
@@ -33,8 +35,10 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Ds
 
         public void AddLast(T value)
         {
-            var node = new LinkedListNode<T>();
-            node.Value = value;
+            var node = new LinkedListNode<T>
+            {
+                Value = value
+            };
             if (First == null)
             {
                 InsertNodeToEmptyList(node);
@@ -64,7 +68,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Ds
                 return null;
             }
 
-            var v = First.PrevInternal != null ? First.PrevInternal.Value : null;
+            var v = First.PrevInternal?.Value;
             Remove(First.PrevInternal);
             return v;
         }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Ds/LinkedList.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Ds/LinkedList.cs
@@ -3,133 +3,132 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Ds
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Ds;
+
+internal class LinkedList<T> where T : class
 {
-    internal class LinkedList<T> where T : class
+    public LinkedListNode<T> First { get; set; }
+
+    public int Length { get; private set; }
+
+    public LinkedList()
     {
-        public LinkedListNode<T> First { get; set; }
+        Length = 0;
+    }
 
-        public int Length { get; private set; }
-
-        public LinkedList()
+    public void AddFirst(T value)
+    {
+        var node = new LinkedListNode<T>
         {
-            Length = 0;
+            Value = value
+        };
+        if (First == null)
+        {
+            InsertNodeToEmptyList(node);
         }
-
-        public void AddFirst(T value)
+        else
         {
-            var node = new LinkedListNode<T>
-            {
-                Value = value
-            };
-            if (First == null)
-            {
-                InsertNodeToEmptyList(node);
-            }
-            else
-            {
-                InsertNodeBefore(First, node);
-                First = node;
-            }
-        }
-
-        public void AddLast(T value)
-        {
-            var node = new LinkedListNode<T>
-            {
-                Value = value
-            };
-            if (First == null)
-            {
-                InsertNodeToEmptyList(node);
-            }
-            else
-            {
-                InsertNodeBefore(First, node);
-            }
-        }
-
-        public T RemoveFirst()
-        {
-            if (First == null)
-            {
-                return null;
-            }
-
-            var v = First.Value;
-            Remove(First);
-            return v;
-        }
-
-        public T RemoveLast()
-        {
-            if (First == null)
-            {
-                return null;
-            }
-
-            var v = First.PrevInternal?.Value;
-            Remove(First.PrevInternal);
-            return v;
-        }
-
-        public void Remove(LinkedListNode<T> n)
-        {
-            if (n.NextInternal == n)
-            {
-                First = null;
-            }
-            else
-            {
-                n.NextInternal.PrevInternal = n.PrevInternal;
-                n.PrevInternal.NextInternal = n.NextInternal;
-                if (First == n)
-                {
-                    First = n.NextInternal;
-                }
-            }
-
-            n.Invalidate();
-            Length--;
-        }
-
-        private void InsertNodeBefore(LinkedListNode<T> node, LinkedListNode<T> newNode)
-        {
-            newNode.NextInternal = node;
-            newNode.PrevInternal = node.PrevInternal;
-            node.PrevInternal.NextInternal = newNode;
-            node.PrevInternal = newNode;
-            newNode.List = this;
-            Length++;
-        }
-
-        private void InsertNodeToEmptyList(LinkedListNode<T> node)
-        {
-            node.NextInternal = node;
-            node.PrevInternal = node;
-            node.List = this;
+            InsertNodeBefore(First, node);
             First = node;
-            Length++;
         }
     }
 
-    internal class LinkedListNode<T> where T : class
+    public void AddLast(T value)
     {
-        internal LinkedList<T> List;
-        internal LinkedListNode<T> NextInternal;
-        internal LinkedListNode<T> PrevInternal;
-
-        public T Value { get; set; }
-
-        public LinkedListNode<T> Next => NextInternal == null || List.First == NextInternal ? null : NextInternal;
-
-        public LinkedListNode<T> Prev => PrevInternal == null || this == List.First ? null : PrevInternal;
-
-        public void Invalidate()
+        var node = new LinkedListNode<T>
         {
-            List = null;
-            NextInternal = null;
-            PrevInternal = null;
+            Value = value
+        };
+        if (First == null)
+        {
+            InsertNodeToEmptyList(node);
         }
+        else
+        {
+            InsertNodeBefore(First, node);
+        }
+    }
+
+    public T RemoveFirst()
+    {
+        if (First == null)
+        {
+            return null;
+        }
+
+        var v = First.Value;
+        Remove(First);
+        return v;
+    }
+
+    public T RemoveLast()
+    {
+        if (First == null)
+        {
+            return null;
+        }
+
+        var v = First.PrevInternal?.Value;
+        Remove(First.PrevInternal);
+        return v;
+    }
+
+    public void Remove(LinkedListNode<T> n)
+    {
+        if (n.NextInternal == n)
+        {
+            First = null;
+        }
+        else
+        {
+            n.NextInternal.PrevInternal = n.PrevInternal;
+            n.PrevInternal.NextInternal = n.NextInternal;
+            if (First == n)
+            {
+                First = n.NextInternal;
+            }
+        }
+
+        n.Invalidate();
+        Length--;
+    }
+
+    private void InsertNodeBefore(LinkedListNode<T> node, LinkedListNode<T> newNode)
+    {
+        newNode.NextInternal           = node;
+        newNode.PrevInternal           = node.PrevInternal;
+        node.PrevInternal.NextInternal = newNode;
+        node.PrevInternal              = newNode;
+        newNode.List                   = this;
+        Length++;
+    }
+
+    private void InsertNodeToEmptyList(LinkedListNode<T> node)
+    {
+        node.NextInternal = node;
+        node.PrevInternal = node;
+        node.List         = this;
+        First             = node;
+        Length++;
+    }
+}
+
+internal class LinkedListNode<T> where T : class
+{
+    internal LinkedList<T> List;
+    internal LinkedListNode<T> NextInternal;
+    internal LinkedListNode<T> PrevInternal;
+
+    public T Value { get; set; }
+
+    public LinkedListNode<T> Next => NextInternal == null || List.First == NextInternal ? null : NextInternal;
+
+    public LinkedListNode<T> Prev => PrevInternal == null || this == List.First ? null : PrevInternal;
+
+    public void Invalidate()
+    {
+        List         = null;
+        NextInternal = null;
+        PrevInternal = null;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/IAlphaSynth.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/IAlphaSynth.cs
@@ -123,7 +123,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
         void PlayPause();
 
         /// <summary>
-        /// Stopps the playback
+        /// Stops the playback
         /// </summary>
         void Stop();
 

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/IAlphaSynth.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/IAlphaSynth.cs
@@ -6,216 +6,215 @@
 using System;
 using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth;
+
+/// <summary>
+/// The public API interface for interacting with the synthesizer.
+/// </summary>
+internal interface IAlphaSynth
 {
     /// <summary>
-    /// The public API interface for interacting with the synthesizer.
+    /// Gets or sets whether the synthesizer is ready for interaction. (output and worker are initialized)
     /// </summary>
-    internal interface IAlphaSynth
+    bool IsReady
     {
-        /// <summary>
-        /// Gets or sets whether the synthesizer is ready for interaction. (output and worker are initialized)
-        /// </summary>
-        bool IsReady
-        {
-            get;
-        }
-
-        /// <summary>
-        /// Gets or sets whether the synthesizer is ready for playback. (output, worker are initialized, soundfont and midi are loaded)
-        /// </summary>p
-        bool IsReadyForPlayback
-        {
-            get;
-        }
-
-        /// <summary>
-        /// Gets the current player state.
-        /// </summary>
-        PlayerState State
-        {
-            get;
-        }
-
-        /// <summary>
-        /// Gets or sets the loging level.
-        /// </summary>
-        AlphaTab.Util.LogLevel LogLevel
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the current master volume as percentage. (range: 0.0-3.0, default 1.0)
-        /// </summary>
-        float MasterVolume
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the current playback speed as percentage. (range: 0.125-8.0, default: 1.0)
-        /// </summary>
-        double PlaybackSpeed
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the position within the song in midi ticks.
-        /// </summary>
-        int TickPosition
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the position within the song in milliseconds.
-        /// </summary>
-        double TimePosition
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets the range of the song that should be played. Set this to null
-        /// to play the whole song.
-        /// </summary>
-        PlaybackRange PlaybackRange
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Gets or sets whether the playback should automatically restart after it finished.
-        /// </summary>
-        bool IsLooping
-        {
-            get;
-            set;
-        }
-
-        /// <summary>
-        /// Destroys the synthesizer and all related components
-        /// </summary>
-        void Destroy();
-
-        /// <summary>
-        /// Starts the playback if possible
-        /// </summary>
-        /// <returns>true if the playback was started, otherwise false. Reasons for not starting can be that the player is not ready or already playing.</returns>
-        bool Play();
-
-        /// <summary>
-        /// Pauses the playback if was running
-        /// </summary>
-        void Pause();
-
-        /// <summary>
-        /// Starts the playback if possible, pauses the playback if was running
-        /// </summary>
-        void PlayPause();
-
-        /// <summary>
-        /// Stops the playback
-        /// </summary>
-        void Stop();
-
-        /// <summary>
-        ///Loads a soundfont from the given data
-        /// </summary>
-        /// <param name="data">a byte array to load the data from </param>
-        void LoadSoundFont(byte[] data, bool append);
-
-        /// <summary>
-        /// Loads the given midi file structure.
-        /// </summary>
-        /// <param name="midi"></param>
-        void LoadMidiFile(MidiFile midi);
-
-        /// <summary>
-        /// Gets the mute state of a channel.
-        /// </summary>
-        /// <param name="channel">The channel number</param>
-        /// <param name="mute">true if the channel should be muted, otherwise false.</param>
-        void SetChannelMute(int channel, bool mute);
-
-        /// <summary>
-        /// Resets the mute/solo state of all channels
-        /// </summary>
-        void ResetChannelStates();
-
-        /// <summary>
-        /// Gets the solo state of a channel.
-        /// </summary>
-        /// <param name="channel">The channel number</param>
-        /// <param name="solo">true if the channel should be played solo, otherwise false.</param>
-        void SetChannelSolo(int channel, bool solo);
-
-
-        /// <summary>
-        /// Gets or sets the current and initial volume of the given channel.
-        /// </summary>
-        /// <param name="channel">The channel number.</param>
-        /// <param name="volume">The volume of of the channel (0.0-1.0)</param>
-        void SetChannelVolume(int channel, float volume);
-
-        /// <summary>
-        /// Gets or sets the current and initial program of the given channel.
-        /// </summary>
-        /// <param name="channel">The channel number.</param>
-        /// <param name="program">The midi program.</param>
-        void SetChannelProgram(int channel, byte program);
-
-        /// <summary>
-        /// This event is fired when the player is ready to be interacted with.
-        /// </summary>
-        event Action Ready;
-
-        /// <summary>
-        /// This event is fired when all required data for playback is loaded and ready.
-        /// </summary>
-        event Action ReadyForPlayback;
-
-        /// <summary>
-        /// This event is fired when the playback of the whole song finished.
-        /// </summary>
-        event Action Finished;
-
-        /// <summary>
-        /// This event is fired when the SoundFont needed for playback was loaded.
-        /// </summary>
-        event Action SoundFontLoaded;
-
-        /// <summary>
-        /// This event is fired when the loading of the SoundFont failed.
-        /// </summary>
-        event Action<Exception> SoundFontLoadFailed;
-
-        /// <summary>
-        /// This event is fired when the Midi file needed for playback was loaded.
-        /// </summary>
-        event Action MidiLoaded;
-
-        /// <summary>
-        /// This event is fired when the loading of the Midi file failed.
-        /// </summary>
-        event Action<Exception> MidiLoadFailed;
-
-        /// <summary>
-        /// This event is fired when the playback state changed.
-        /// </summary>
-        event Action<PlayerStateChangedEventArgs> StateChanged;
-
-        /// <summary>
-        /// This event is fired when the current playback position of the song changed.
-        /// </summary>
-        event Action<PositionChangedEventArgs> PositionChanged;
+        get;
     }
+
+    /// <summary>
+    /// Gets or sets whether the synthesizer is ready for playback. (output, worker are initialized, soundfont and midi are loaded)
+    /// </summary>p
+    bool IsReadyForPlayback
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets the current player state.
+    /// </summary>
+    PlayerState State
+    {
+        get;
+    }
+
+    /// <summary>
+    /// Gets or sets the loging level.
+    /// </summary>
+    AlphaTab.Util.LogLevel LogLevel
+    {
+        get;
+        set;
+    }
+
+    /// <summary>
+    /// Gets or sets the current master volume as percentage. (range: 0.0-3.0, default 1.0)
+    /// </summary>
+    float MasterVolume
+    {
+        get;
+        set;
+    }
+
+    /// <summary>
+    /// Gets or sets the current playback speed as percentage. (range: 0.125-8.0, default: 1.0)
+    /// </summary>
+    double PlaybackSpeed
+    {
+        get;
+        set;
+    }
+
+    /// <summary>
+    /// Gets or sets the position within the song in midi ticks.
+    /// </summary>
+    int TickPosition
+    {
+        get;
+        set;
+    }
+
+    /// <summary>
+    /// Gets or sets the position within the song in milliseconds.
+    /// </summary>
+    double TimePosition
+    {
+        get;
+        set;
+    }
+
+    /// <summary>
+    /// Gets or sets the range of the song that should be played. Set this to null
+    /// to play the whole song.
+    /// </summary>
+    PlaybackRange PlaybackRange
+    {
+        get;
+        set;
+    }
+
+    /// <summary>
+    /// Gets or sets whether the playback should automatically restart after it finished.
+    /// </summary>
+    bool IsLooping
+    {
+        get;
+        set;
+    }
+
+    /// <summary>
+    /// Destroys the synthesizer and all related components
+    /// </summary>
+    void Destroy();
+
+    /// <summary>
+    /// Starts the playback if possible
+    /// </summary>
+    /// <returns>true if the playback was started, otherwise false. Reasons for not starting can be that the player is not ready or already playing.</returns>
+    bool Play();
+
+    /// <summary>
+    /// Pauses the playback if was running
+    /// </summary>
+    void Pause();
+
+    /// <summary>
+    /// Starts the playback if possible, pauses the playback if was running
+    /// </summary>
+    void PlayPause();
+
+    /// <summary>
+    /// Stops the playback
+    /// </summary>
+    void Stop();
+
+    /// <summary>
+    ///Loads a soundfont from the given data
+    /// </summary>
+    /// <param name="data">a byte array to load the data from </param>
+    void LoadSoundFont(byte[] data, bool append);
+
+    /// <summary>
+    /// Loads the given midi file structure.
+    /// </summary>
+    /// <param name="midi"></param>
+    void LoadMidiFile(MidiFile midi);
+
+    /// <summary>
+    /// Gets the mute state of a channel.
+    /// </summary>
+    /// <param name="channel">The channel number</param>
+    /// <param name="mute">true if the channel should be muted, otherwise false.</param>
+    void SetChannelMute(int channel, bool mute);
+
+    /// <summary>
+    /// Resets the mute/solo state of all channels
+    /// </summary>
+    void ResetChannelStates();
+
+    /// <summary>
+    /// Gets the solo state of a channel.
+    /// </summary>
+    /// <param name="channel">The channel number</param>
+    /// <param name="solo">true if the channel should be played solo, otherwise false.</param>
+    void SetChannelSolo(int channel, bool solo);
+
+
+    /// <summary>
+    /// Gets or sets the current and initial volume of the given channel.
+    /// </summary>
+    /// <param name="channel">The channel number.</param>
+    /// <param name="volume">The volume of of the channel (0.0-1.0)</param>
+    void SetChannelVolume(int channel, float volume);
+
+    /// <summary>
+    /// Gets or sets the current and initial program of the given channel.
+    /// </summary>
+    /// <param name="channel">The channel number.</param>
+    /// <param name="program">The midi program.</param>
+    void SetChannelProgram(int channel, byte program);
+
+    /// <summary>
+    /// This event is fired when the player is ready to be interacted with.
+    /// </summary>
+    event Action Ready;
+
+    /// <summary>
+    /// This event is fired when all required data for playback is loaded and ready.
+    /// </summary>
+    event Action ReadyForPlayback;
+
+    /// <summary>
+    /// This event is fired when the playback of the whole song finished.
+    /// </summary>
+    event Action Finished;
+
+    /// <summary>
+    /// This event is fired when the SoundFont needed for playback was loaded.
+    /// </summary>
+    event Action SoundFontLoaded;
+
+    /// <summary>
+    /// This event is fired when the loading of the SoundFont failed.
+    /// </summary>
+    event Action<Exception> SoundFontLoadFailed;
+
+    /// <summary>
+    /// This event is fired when the Midi file needed for playback was loaded.
+    /// </summary>
+    event Action MidiLoaded;
+
+    /// <summary>
+    /// This event is fired when the loading of the Midi file failed.
+    /// </summary>
+    event Action<Exception> MidiLoadFailed;
+
+    /// <summary>
+    /// This event is fired when the playback state changed.
+    /// </summary>
+    event Action<PlayerStateChangedEventArgs> StateChanged;
+
+    /// <summary>
+    /// This event is fired when the current playback position of the song changed.
+    /// </summary>
+    event Action<PositionChangedEventArgs> PositionChanged;
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/ISynthOutput.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/ISynthOutput.cs
@@ -51,7 +51,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
         void AddSamples(float[] samples);
 
         /// <summary>
-        /// Called when the samples in the output buffer should be reset. This is neeed for instance when seeking to another position.
+        /// Called when the samples in the output buffer should be reset. This is needed for instance when seeking to another position.
         /// </summary>
         void ResetSamples();
 

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/ISynthOutput.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/ISynthOutput.cs
@@ -5,79 +5,78 @@
 
 using System;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth;
+
+/// <summary>
+/// This is the base interface for output devices which can
+/// request and playback audio samples.
+/// </summary>
+internal interface ISynthOutput
 {
     /// <summary>
-    /// This is the base interface for output devices which can
-    /// request and playback audio samples.
+    /// Gets the sample rate required by the output.
     /// </summary>
-    internal interface ISynthOutput
-    {
-        /// <summary>
-        /// Gets the sample rate required by the output.
-        /// </summary>
-        int SampleRate { get; }
+    int SampleRate { get; }
 
-        /// <summary>
-        /// Called when the output should be opened.
-        /// </summary>
-        void Open();
+    /// <summary>
+    /// Called when the output should be opened.
+    /// </summary>
+    void Open();
 
-        /// <summary>
-        /// Called when the sequencer finished the playback.
-        /// This tells the output not to request any samples anymore after the existing buffers are finished.
-        /// </summary>
-        void SequencerFinished();
+    /// <summary>
+    /// Called when the sequencer finished the playback.
+    /// This tells the output not to request any samples anymore after the existing buffers are finished.
+    /// </summary>
+    void SequencerFinished();
 
-        /// <summary>
-        /// Called when the output should start the playback.
-        /// </summary>
-        void Play();
+    /// <summary>
+    /// Called when the output should start the playback.
+    /// </summary>
+    void Play();
 
-        /// <summary>
-        /// Called when the output should pause the playback.
-        /// </summary>
-        void Pause();
+    /// <summary>
+    /// Called when the output should pause the playback.
+    /// </summary>
+    void Pause();
 
-        /// <summary>
-        /// Called when the output should stop the playback.
-        /// </summary>
-        void Stop();
+    /// <summary>
+    /// Called when the output should stop the playback.
+    /// </summary>
+    void Stop();
 
-        /// <summary>
-        /// Called when samples have been synthesized and should be added to the playback buffer.
-        /// </summary>
-        /// <param name="samples"></param>
-        void AddSamples(float[] samples);
+    /// <summary>
+    /// Called when samples have been synthesized and should be added to the playback buffer.
+    /// </summary>
+    /// <param name="samples"></param>
+    void AddSamples(float[] samples);
 
-        /// <summary>
-        /// Called when the samples in the output buffer should be reset. This is needed for instance when seeking to another position.
-        /// </summary>
-        void ResetSamples();
+    /// <summary>
+    /// Called when the samples in the output buffer should be reset. This is needed for instance when seeking to another position.
+    /// </summary>
+    void ResetSamples();
 
-        /// <summary>
-        /// Fired when the output has been successfully opened and is ready to play samples.
-        /// </summary>
-        event Action Ready;
+    /// <summary>
+    /// Fired when the output has been successfully opened and is ready to play samples.
+    /// </summary>
+    event Action Ready;
 
-        /// <summary>
-        /// Fired when a certain number of samples have been played.
-        /// </summary>
-        event Action<int> SamplesPlayed;
+    /// <summary>
+    /// Fired when a certain number of samples have been played.
+    /// </summary>
+    event Action<int> SamplesPlayed;
 
-        /// <summary>
-        /// Fired when the output needs more samples to be played.
-        /// </summary>
-        event Action SampleRequest;
+    /// <summary>
+    /// Fired when the output needs more samples to be played.
+    /// </summary>
+    event Action SampleRequest;
 
-        /// <summary>
-        /// Fired when the last samples after calling SequencerFinished have been played.
-        /// </summary>
-        event Action Finished;
+    /// <summary>
+    /// Fired when the last samples after calling SequencerFinished have been played.
+    /// </summary>
+    event Action Finished;
 
-        /// <summary>
-        /// Activates the output component.
-        /// </summary>
-        void Activate();
-    }
+    /// <summary>
+    /// Activates the output component.
+    /// </summary>
+    void Activate();
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Midi/Event/MetaDataEvent.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Midi/Event/MetaDataEvent.cs
@@ -5,26 +5,25 @@
 
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.Event
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.Event;
+
+internal class MetaDataEvent : MetaEvent
 {
-    internal class MetaDataEvent : MetaEvent
+    public byte[] Data { get; private set; }
+
+    public MetaDataEvent(int delta, byte status, byte metaId, byte[] data)
+        : base(delta, status, metaId, 0)
     {
-        public byte[] Data { get; private set; }
+        Data = data;
+    }
 
-        public MetaDataEvent(int delta, byte status, byte metaId, byte[] data)
-            : base(delta, status, metaId, 0)
-        {
-            Data = data;
-        }
+    public override void WriteTo(IWriteable s)
+    {
+        s.WriteByte(0xFF);
+        s.WriteByte((byte)MetaStatus);
 
-        public override void WriteTo(IWriteable s)
-        {
-            s.WriteByte(0xFF);
-            s.WriteByte((byte)MetaStatus);
-
-            var l = Data.Length;
-            MidiFile.WriteVariableInt(s, l);
-            s.Write(Data, 0, Data.Length);
-        }
+        var l = Data.Length;
+        MidiFile.WriteVariableInt(s, l);
+        s.Write(Data, 0, Data.Length);
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Midi/Event/MetaEvent.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Midi/Event/MetaEvent.cs
@@ -3,41 +3,40 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.Event
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.Event;
+
+internal enum MetaEventTypeEnum
 {
-    internal enum MetaEventTypeEnum
+    SequenceNumber = 0x00,
+    TextEvent = 0x01,
+    CopyrightNotice = 0x02,
+    SequenceOrTrackName = 0x03,
+    InstrumentName = 0x04,
+    LyricText = 0x05,
+    MarkerText = 0x06,
+    CuePoint = 0x07,
+    PatchName = 0x08,
+    PortName = 0x09,
+    MidiChannel = 0x20,
+    MidiPort = 0x21,
+    EndOfTrack = 0x2F,
+    Tempo = 0x51,
+    SmpteOffset = 0x54,
+    TimeSignature = 0x58,
+    KeySignature = 0x59,
+    SequencerSpecific = 0x7F
+}
+
+internal abstract class MetaEvent : MidiEvent
+{
+    public override int Channel => -1;
+
+    public override MidiEventType Command => (MidiEventType)(Message & 0x00000FF);
+
+    public int MetaStatus => Data1;
+
+    protected MetaEvent(int delta, byte status, byte data1, byte data2)
+        : base(delta, status, data1, data2)
     {
-        SequenceNumber = 0x00,
-        TextEvent = 0x01,
-        CopyrightNotice = 0x02,
-        SequenceOrTrackName = 0x03,
-        InstrumentName = 0x04,
-        LyricText = 0x05,
-        MarkerText = 0x06,
-        CuePoint = 0x07,
-        PatchName = 0x08,
-        PortName = 0x09,
-        MidiChannel = 0x20,
-        MidiPort = 0x21,
-        EndOfTrack = 0x2F,
-        Tempo = 0x51,
-        SmpteOffset = 0x54,
-        TimeSignature = 0x58,
-        KeySignature = 0x59,
-        SequencerSpecific = 0x7F
-    }
-
-    internal abstract class MetaEvent : MidiEvent
-    {
-        public override int Channel => -1;
-
-        public override MidiEventType Command => (MidiEventType)(Message & 0x00000FF);
-
-        public int MetaStatus => Data1;
-
-        protected MetaEvent(int delta, byte status, byte data1, byte data2)
-            : base(delta, status, data1, data2)
-        {
-        }
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Midi/Event/MetaNumberEvent.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Midi/Event/MetaNumberEvent.cs
@@ -5,31 +5,30 @@
 
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.Event
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.Event;
+
+internal class MetaNumberEvent : MetaEvent
 {
-    internal class MetaNumberEvent : MetaEvent
+    public int Value { get; private set; }
+
+    public MetaNumberEvent(int delta, byte status, byte metaId, int number)
+        : base(delta, status, metaId, 0)
     {
-        public int Value { get; private set; }
+        Value = number;
+    }
 
-        public MetaNumberEvent(int delta, byte status, byte metaId, int number)
-            : base(delta, status, metaId, 0)
+
+    public override void WriteTo(IWriteable s)
+    {
+        s.WriteByte(0xFF);
+        s.WriteByte((byte)MetaStatus);
+
+        MidiFile.WriteVariableInt(s, 3);
+
+        var b = new[]
         {
-            Value = number;
-        }
-
-
-        public override void WriteTo(IWriteable s)
-        {
-            s.WriteByte(0xFF);
-            s.WriteByte((byte)MetaStatus);
-
-            MidiFile.WriteVariableInt(s, 3);
-
-            var b = new[]
-            {
-                (byte)((Value >> 16) & 0xFF), (byte)((Value >> 8) & 0xFF), (byte)(Value & 0xFF)
-            };
-            s.Write(b, 0, b.Length);
-        }
+            (byte)((Value >> 16) & 0xFF), (byte)((Value >> 8) & 0xFF), (byte)(Value & 0xFF)
+        };
+        s.Write(b, 0, b.Length);
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Midi/Event/MidiEvent.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Midi/Event/MidiEvent.cs
@@ -5,285 +5,284 @@
 
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.Event
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.Event;
+
+/// <summary>
+/// Lists all midi events.
+/// </summary>
+internal enum MidiEventType
 {
     /// <summary>
-    /// Lists all midi events.
+    /// A note is released.
     /// </summary>
-    internal enum MidiEventType
+    NoteOff = 0x80,
+
+    /// <summary>
+    /// A note is started.
+    /// </summary>
+    NoteOn = 0x90,
+
+    /// <summary>
+    /// The pressure that was used to play the note.
+    /// </summary>
+    NoteAftertouch = 0xA0,
+
+    /// <summary>
+    /// Change of a midi controller
+    /// </summary>
+    Controller = 0xB0,
+
+    /// <summary>
+    /// Change of a midi program
+    /// </summary>
+    ProgramChange = 0xC0,
+
+    /// <summary>
+    /// The pressure that should be applied to the whole channel.
+    /// </summary>
+    ChannelAftertouch = 0xD0,
+
+    /// <summary>
+    /// A change of the audio pitch.
+    /// </summary>
+    PitchBend = 0xE0,
+
+    /// <summary>
+    /// A meta event. See <see cref="MetaEventTypeEnum"/> for details.
+    /// </summary>
+    Meta = 0xFF
+}
+
+/// <summary>
+/// Lists all midi controllers.
+/// </summary>
+internal enum ControllerType
+{
+    /// <summary>
+    /// Bank Select. MSB
+    /// </summary>
+    BankSelectCoarse = 0x00,
+
+    /// <summary>
+    /// Modulation wheel or lever MSB
+    /// </summary>
+    ModulationCoarse = 0x01,
+
+    //BreathControllerCoarse = 0x02,
+    //FootControllerCoarse = 0x04,
+    //PortamentoTimeCoarse = 0x05,
+    /// <summary>
+    /// Data entry MSB
+    /// </summary>
+    DataEntryCoarse = 0x06,
+
+    /// <summary>
+    /// Channel Volume MSB
+    /// </summary>
+    VolumeCoarse = 0x07,
+
+    //BalanceCoarse = 0x08,
+    /// <summary>
+    /// Pan MSB
+    /// </summary>
+    PanCoarse = 0x0A,
+
+    /// <summary>
+    /// Expression Controller MSB
+    /// </summary>
+    ExpressionControllerCoarse = 0x0B,
+
+    //EffectControl1Coarse = 0x0C,
+    //EffectControl2Coarse = 0x0D,
+    //GeneralPurposeSlider1 = 0x10,
+    //GeneralPurposeSlider2 = 0x11,
+    //GeneralPurposeSlider3 = 0x12,
+    //GeneralPurposeSlider4 = 0x13,
+    //BankSelectFine = 0x20,
+    /// <summary>
+    /// Modulation wheel or level LSB
+    /// </summary>
+    ModulationFine = 0x21,
+
+    //BreathControllerFine = 0x22,
+    //FootControllerFine = 0x24,
+    //PortamentoTimeFine = 0x25,
+    /// <summary>
+    /// Data Entry LSB
+    /// </summary>
+    DataEntryFine = 0x26,
+
+    /// <summary>
+    /// Channel Volume LSB
+    /// </summary>
+    VolumeFine = 0x27,
+
+    //BalanceFine = 0x28,
+    /// <summary>
+    /// Pan LSB
+    /// </summary>
+    PanFine = 0x2A,
+
+    /// <summary>
+    /// Expression controller LSB
+    /// </summary>
+    ExpressionControllerFine = 0x2B,
+
+    //EffectControl1Fine = 0x2C,
+    //EffectControl2Fine = 0x2D,
+    /// <summary>
+    /// Damper pedal (sustain)
+    /// </summary>
+    HoldPedal = 0x40,
+
+    //Portamento = 0x41,
+    //SostenutoPedal = 0x42,
+    //SoftPedal = 0x43,
+    /// <summary>
+    /// Legato Footswitch
+    /// </summary>
+    LegatoPedal = 0x44,
+
+    //Hold2Pedal = 0x45,
+    //SoundVariation = 0x46,
+    //SoundTimbre = 0x47,
+    //SoundReleaseTime = 0x48,
+    //SoundAttackTime = 0x49,
+    //SoundBrightness = 0x4A,
+    //SoundControl6 = 0x4B,
+    //SoundControl7 = 0x4C,
+    //SoundControl8 = 0x4D,
+    //SoundControl9 = 0x4E,
+    //SoundControl10 = 0x4F,
+    //GeneralPurposeButton1 = 0x50,
+    //GeneralPurposeButton2 = 0x51,
+    //GeneralPurposeButton3 = 0x52,
+    //GeneralPurposeButton4 = 0x53,
+    //EffectsLevel = 0x5B,
+    //TremuloLevel = 0x5C,
+    //ChorusLevel = 0x5D,
+    //CelesteLevel = 0x5E,
+    //PhaseLevel = 0x5F,
+    //DataButtonIncrement = 0x60,
+    //DataButtonDecrement = 0x61,
+    /// <summary>
+    /// Non-Registered Parameter Number LSB
+    /// </summary>
+    NonRegisteredParameterFine = 0x62,
+
+    /// <summary>
+    /// Non-Registered Parameter Number MSB
+    /// </summary>
+    NonRegisteredParameterCourse = 0x63,
+
+    /// <summary>
+    /// Registered Parameter Number LSB
+    /// </summary>
+    RegisteredParameterFine = 0x64,
+
+    /// <summary>
+    /// Registered Parameter Number MSB
+    /// </summary>
+    RegisteredParameterCourse = 0x65,
+
+    //AllSoundOff = 0x78,
+    /// <summary>
+    /// Reset all controllers
+    /// </summary>
+    ResetControllers = 0x79,
+
+    //LocalKeyboard = 0x7A,
+    /// <summary>
+    /// All notes of.
+    /// </summary>
+    AllNotesOff = 0x7B
+
+    //OmniModeOff = 0x7C,
+    //OmniModeOn = 0x7D,
+    //MonoMode = 0x7E,
+    //PolyMode = 0x7F
+}
+
+/// <summary>
+/// Represents a midi event.
+/// </summary>
+internal class MidiEvent
+{
+    /// <summary>
+    /// Gets or sets the raw midi message.
+    /// </summary>
+    public int Message { get; set; }
+
+    /// <summary>
+    /// Gets or sets the absolute tick of this midi event.
+    /// </summary>
+    public int Tick { get; set; }
+
+    /// <summary>
+    /// Gets or sets the channel of this midi event.
+    /// </summary>
+    public virtual int Channel => _customChannel ? _customChannelValue : Message & 0x000000F;
+
+    private readonly bool _customChannel;
+    private readonly int _customChannelValue;
+
+    /// <summary>
+    /// Gets or sets the command of this midi event.
+    /// </summary>
+    public virtual MidiEventType Command => (MidiEventType)(Message & 0x00000F0);
+
+    /// <summary>
+    /// Gets or sets the first data component of this midi event.
+    /// </summary>
+    public int Data1
     {
-        /// <summary>
-        /// A note is released.
-        /// </summary>
-        NoteOff = 0x80,
-
-        /// <summary>
-        /// A note is started.
-        /// </summary>
-        NoteOn = 0x90,
-
-        /// <summary>
-        /// The pressure that was used to play the note.
-        /// </summary>
-        NoteAftertouch = 0xA0,
-
-        /// <summary>
-        /// Change of a midi controller
-        /// </summary>
-        Controller = 0xB0,
-
-        /// <summary>
-        /// Change of a midi program
-        /// </summary>
-        ProgramChange = 0xC0,
-
-        /// <summary>
-        /// The pressure that should be applied to the whole channel.
-        /// </summary>
-        ChannelAftertouch = 0xD0,
-
-        /// <summary>
-        /// A change of the audio pitch.
-        /// </summary>
-        PitchBend = 0xE0,
-
-        /// <summary>
-        /// A meta event. See <see cref="MetaEventTypeEnum"/> for details.
-        /// </summary>
-        Meta = 0xFF
+        get => (Message & 0x000FF00) >> 8;
+        set
+        {
+            Message &= ~0x000FF00;
+            Message |= value << 8;
+        }
     }
 
     /// <summary>
-    /// Lists all midi controllers.
+    /// Gets or sets the second data component of this midi event.
     /// </summary>
-    internal enum ControllerType
+    public int Data2
     {
-        /// <summary>
-        /// Bank Select. MSB
-        /// </summary>
-        BankSelectCoarse = 0x00,
-
-        /// <summary>
-        /// Modulation wheel or lever MSB
-        /// </summary>
-        ModulationCoarse = 0x01,
-
-        //BreathControllerCoarse = 0x02,
-        //FootControllerCoarse = 0x04,
-        //PortamentoTimeCoarse = 0x05,
-        /// <summary>
-        /// Data entry MSB
-        /// </summary>
-        DataEntryCoarse = 0x06,
-
-        /// <summary>
-        /// Channel Volume MSB
-        /// </summary>
-        VolumeCoarse = 0x07,
-
-        //BalanceCoarse = 0x08,
-        /// <summary>
-        /// Pan MSB
-        /// </summary>
-        PanCoarse = 0x0A,
-
-        /// <summary>
-        /// Expression Controller MSB
-        /// </summary>
-        ExpressionControllerCoarse = 0x0B,
-
-        //EffectControl1Coarse = 0x0C,
-        //EffectControl2Coarse = 0x0D,
-        //GeneralPurposeSlider1 = 0x10,
-        //GeneralPurposeSlider2 = 0x11,
-        //GeneralPurposeSlider3 = 0x12,
-        //GeneralPurposeSlider4 = 0x13,
-        //BankSelectFine = 0x20,
-        /// <summary>
-        /// Modulation wheel or level LSB
-        /// </summary>
-        ModulationFine = 0x21,
-
-        //BreathControllerFine = 0x22,
-        //FootControllerFine = 0x24,
-        //PortamentoTimeFine = 0x25,
-        /// <summary>
-        /// Data Entry LSB
-        /// </summary>
-        DataEntryFine = 0x26,
-
-        /// <summary>
-        /// Channel Volume LSB
-        /// </summary>
-        VolumeFine = 0x27,
-
-        //BalanceFine = 0x28,
-        /// <summary>
-        /// Pan LSB
-        /// </summary>
-        PanFine = 0x2A,
-
-        /// <summary>
-        /// Expression controller LSB
-        /// </summary>
-        ExpressionControllerFine = 0x2B,
-
-        //EffectControl1Fine = 0x2C,
-        //EffectControl2Fine = 0x2D,
-        /// <summary>
-        /// Damper pedal (sustain)
-        /// </summary>
-        HoldPedal = 0x40,
-
-        //Portamento = 0x41,
-        //SostenutoPedal = 0x42,
-        //SoftPedal = 0x43,
-        /// <summary>
-        /// Legato Footswitch
-        /// </summary>
-        LegatoPedal = 0x44,
-
-        //Hold2Pedal = 0x45,
-        //SoundVariation = 0x46,
-        //SoundTimbre = 0x47,
-        //SoundReleaseTime = 0x48,
-        //SoundAttackTime = 0x49,
-        //SoundBrightness = 0x4A,
-        //SoundControl6 = 0x4B,
-        //SoundControl7 = 0x4C,
-        //SoundControl8 = 0x4D,
-        //SoundControl9 = 0x4E,
-        //SoundControl10 = 0x4F,
-        //GeneralPurposeButton1 = 0x50,
-        //GeneralPurposeButton2 = 0x51,
-        //GeneralPurposeButton3 = 0x52,
-        //GeneralPurposeButton4 = 0x53,
-        //EffectsLevel = 0x5B,
-        //TremuloLevel = 0x5C,
-        //ChorusLevel = 0x5D,
-        //CelesteLevel = 0x5E,
-        //PhaseLevel = 0x5F,
-        //DataButtonIncrement = 0x60,
-        //DataButtonDecrement = 0x61,
-        /// <summary>
-        /// Non-Registered Parameter Number LSB
-        /// </summary>
-        NonRegisteredParameterFine = 0x62,
-
-        /// <summary>
-        /// Non-Registered Parameter Number MSB
-        /// </summary>
-        NonRegisteredParameterCourse = 0x63,
-
-        /// <summary>
-        /// Registered Parameter Number LSB
-        /// </summary>
-        RegisteredParameterFine = 0x64,
-
-        /// <summary>
-        /// Registered Parameter Number MSB
-        /// </summary>
-        RegisteredParameterCourse = 0x65,
-
-        //AllSoundOff = 0x78,
-        /// <summary>
-        /// Reset all controllers
-        /// </summary>
-        ResetControllers = 0x79,
-
-        //LocalKeyboard = 0x7A,
-        /// <summary>
-        /// All notes of.
-        /// </summary>
-        AllNotesOff = 0x7B
-
-        //OmniModeOff = 0x7C,
-        //OmniModeOn = 0x7D,
-        //MonoMode = 0x7E,
-        //PolyMode = 0x7F
+        get => (Message & 0x0FF0000) >> 16;
+        set
+        {
+            Message &= ~0x0FF0000;
+            Message |= value << 16;
+        }
     }
 
     /// <summary>
-    /// Represents a midi event.
+    /// Initializes a new instance of the <see cref="MidiEvent"/> class.
     /// </summary>
-    internal class MidiEvent
+    /// <param name="tick">The absolute midi ticks of this event..</param>
+    /// <param name="status">The status information of this event.</param>
+    /// <param name="data1">The first data component of this midi event.</param>
+    /// <param name="data2">The second data component of this midi event.</param>
+    public MidiEvent(int tick, int status, byte data1, byte data2, bool customChannel = false, byte customChannelValue = 0)
     {
-        /// <summary>
-        /// Gets or sets the raw midi message.
-        /// </summary>
-        public int Message { get; set; }
+        Tick                = tick;
+        Message             = status | (data1 << 8) | (data2 << 16);
+        _customChannel      = customChannel;
+        _customChannelValue = customChannelValue;
+    }
 
-        /// <summary>
-        /// Gets or sets the absolute tick of this midi event.
-        /// </summary>
-        public int Tick { get; set; }
-
-        /// <summary>
-        /// Gets or sets the channel of this midi event.
-        /// </summary>
-        public virtual int Channel => _customChannel ? _customChannelValue : Message & 0x000000F;
-
-        private readonly bool _customChannel;
-        private readonly int _customChannelValue;
-
-        /// <summary>
-        /// Gets or sets the command of this midi event.
-        /// </summary>
-        public virtual MidiEventType Command => (MidiEventType)(Message & 0x00000F0);
-
-        /// <summary>
-        /// Gets or sets the first data component of this midi event.
-        /// </summary>
-        public int Data1
+    /// <summary>
+    /// Writes the midi event as binary into the given stream.
+    /// </summary>
+    /// <param name="s">The stream to write to.</param>
+    public virtual void WriteTo(IWriteable s)
+    {
+        var b = new[]
         {
-            get => (Message & 0x000FF00) >> 8;
-            set
-            {
-                Message &= ~0x000FF00;
-                Message |= value << 8;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets the second data component of this midi event.
-        /// </summary>
-        public int Data2
-        {
-            get => (Message & 0x0FF0000) >> 16;
-            set
-            {
-                Message &= ~0x0FF0000;
-                Message |= value << 16;
-            }
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MidiEvent"/> class.
-        /// </summary>
-        /// <param name="tick">The absolute midi ticks of this event..</param>
-        /// <param name="status">The status information of this event.</param>
-        /// <param name="data1">The first data component of this midi event.</param>
-        /// <param name="data2">The second data component of this midi event.</param>
-        public MidiEvent(int tick, int status, byte data1, byte data2, bool customChannel = false, byte customChannelValue = 0)
-        {
-            Tick = tick;
-            Message = status | (data1 << 8) | (data2 << 16);
-            _customChannel = customChannel;
-            _customChannelValue = customChannelValue;
-        }
-
-        /// <summary>
-        /// Writes the midi event as binary into the given stream.
-        /// </summary>
-        /// <param name="s">The stream to write to.</param>
-        public virtual void WriteTo(IWriteable s)
-        {
-            var b = new[]
-            {
-                (byte)((Message >> 24) & 0xFF), (byte)((Message >> 16) & 0xFF), (byte)((Message >> 8) & 0xFF),
-                (byte)(Message & 0xFF)
-            };
-            s.Write(b, 0, b.Length);
-        }
+            (byte)((Message >> 24) & 0xFF), (byte)((Message >> 16) & 0xFF), (byte)((Message >> 8) & 0xFF),
+            (byte)(Message & 0xFF)
+        };
+        s.Write(b, 0, b.Length);
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Midi/Event/SystemCommonEvent.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Midi/Event/SystemCommonEvent.cs
@@ -3,27 +3,26 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.Event
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.Event;
+
+internal enum SystemCommonTypeEnum
 {
-    internal enum SystemCommonTypeEnum
+    SystemExclusive = 0xF0,
+    MtcQuarterFrame = 0xF1,
+    SongPosition = 0xF2,
+    SongSelect = 0xF3,
+    TuneRequest = 0xF6,
+    SystemExclusive2 = 0xF7
+}
+
+internal abstract class SystemCommonEvent : MidiEvent
+{
+    public override int Channel => -1;
+
+    public override MidiEventType Command => (MidiEventType)(Message & 0x00000FF);
+
+    protected SystemCommonEvent(int delta, byte status, byte data1, byte data2)
+        : base(delta, status, data1, data2)
     {
-        SystemExclusive = 0xF0,
-        MtcQuarterFrame = 0xF1,
-        SongPosition = 0xF2,
-        SongSelect = 0xF3,
-        TuneRequest = 0xF6,
-        SystemExclusive2 = 0xF7
-    }
-
-    internal abstract class SystemCommonEvent : MidiEvent
-    {
-        public override int Channel => -1;
-
-        public override MidiEventType Command => (MidiEventType)(Message & 0x00000FF);
-
-        protected SystemCommonEvent(int delta, byte status, byte data1, byte data2)
-            : base(delta, status, data1, data2)
-        {
-        }
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Midi/Event/SystemExclusiveEvent.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Midi/Event/SystemExclusiveEvent.cs
@@ -5,32 +5,31 @@
 
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.Event
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.Event;
+
+internal class SystemExclusiveEvent : SystemCommonEvent
 {
-    internal class SystemExclusiveEvent : SystemCommonEvent
+    public byte[] Data { get; private set; }
+
+
+    public int ManufacturerId => Message >> 8;
+
+    public SystemExclusiveEvent(int delta, byte status, short id, byte[] data)
+        : base(delta, status, (byte)(id & 0x00FF), (byte)(id >> 8))
     {
-        public byte[] Data { get; private set; }
+        Data = data;
+    }
 
-
-        public int ManufacturerId => Message >> 8;
-
-        public SystemExclusiveEvent(int delta, byte status, short id, byte[] data)
-            : base(delta, status, (byte)(id & 0x00FF), (byte)(id >> 8))
+    public override void WriteTo(IWriteable s)
+    {
+        s.WriteByte(0xF0);
+        var l = Data.Length + 2;
+        s.WriteByte((byte)ManufacturerId);
+        var b = new[]
         {
-            Data = data;
-        }
-
-        public override void WriteTo(IWriteable s)
-        {
-            s.WriteByte(0xF0);
-            var l = Data.Length + 2;
-            s.WriteByte((byte)ManufacturerId);
-            var b = new[]
-            {
-                (byte)((l >> 24) & 0xFF), (byte)((l >> 16) & 0xFF), (byte)((l >> 8) & 0xFF), (byte)(l & 0xFF)
-            };
-            s.Write(b, 0, b.Length);
-            s.WriteByte(0xF7);
-        }
+            (byte)((l >> 24) & 0xFF), (byte)((l >> 16) & 0xFF), (byte)((l >> 8) & 0xFF), (byte)(l & 0xFF)
+        };
+        s.Write(b, 0, b.Length);
+        s.WriteByte(0xF7);
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Midi/MidiFile.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Midi/MidiFile.cs
@@ -8,150 +8,149 @@ using System.Linq;
 using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.Event;
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi;
+
+/// <summary>
+/// Represents a midi file with a single track that can be played via <see cref="AlphaSynth"/>
+/// </summary>
+internal class MidiFile
 {
     /// <summary>
-    /// Represents a midi file with a single track that can be played via <see cref="AlphaSynth"/>
+    /// Gets or sets the division per quarter notes.
     /// </summary>
-    internal class MidiFile
+    public int Division { get; set; }
+
+    /// <summary>
+    /// Gets a list of midi events sorted by time.
+    /// </summary>
+    public List<MidiEvent> Events { get; private set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MidiFile"/> class.
+    /// </summary>
+    public MidiFile()
     {
-        /// <summary>
-        /// Gets or sets the division per quarter notes.
-        /// </summary>
-        public int Division { get; set; }
+        Division = MidiUtils.QuarterTime;
+        Events   = new List<MidiEvent>();
+    }
 
-        /// <summary>
-        /// Gets a list of midi events sorted by time.
-        /// </summary>
-        public List<MidiEvent> Events { get; private set; }
+    /// <summary>
+    /// Adds the given midi event a the correct time position into the file.
+    /// </summary>
+    /// <param name="e"></param>
+    public void AddEvent(MidiEvent e) => Events.Add(e);
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MidiFile"/> class.
-        /// </summary>
-        public MidiFile()
+    /// <summary>
+    /// Sort the event list by event tick.
+    /// </summary>
+    public void Sort() => Events = Events.OrderBy(x=>x.Tick).ToList();
+
+    /// <summary>
+    /// Writes the midi file into a binary format.
+    /// </summary>
+    /// <returns>The binary midi file.</returns>
+    // ReSharper disable once UnusedMember.Global
+    public byte[] ToBinary()
+    {
+        var data = ByteBuffer.Empty();
+        WriteTo(data);
+        return data.ToArray();
+    }
+
+    /// <summary>
+    /// Writes the midi file as binary into the given stream.
+    /// </summary>
+    /// <returns>The stream to write to.</returns>
+    public void WriteTo(IWriteable s)
+    {
+        // magic number "MThd" (0x4D546864)
+        var b = new byte[]
         {
-            Division = MidiUtils.QuarterTime;
-            Events = new List<MidiEvent>();
+            0x4D, 0x54, 0x68, 0x64
+        };
+        s.Write(b, 0, b.Length);
+
+        // Header Length 6 (0x00000006)
+        b = new byte[]
+        {
+            0x00, 0x00, 0x00, 0x06
+        };
+        s.Write(b, 0, b.Length);
+
+        // format
+        b = new byte[]
+        {
+            0x00, 0x00
+        };
+        s.Write(b, 0, b.Length);
+
+        // number of tracks
+        short v = 1;
+        b = new[]
+        {
+            (byte)((v >> 8) & 0xFF), (byte)(v & 0xFF)
+        };
+        s.Write(b, 0, b.Length);
+
+        v = MidiUtils.QuarterTime;
+        b = new[]
+        {
+            (byte)((v >> 8) & 0xFF), (byte)(v & 0xFF)
+        };
+        s.Write(b, 0, b.Length);
+
+        // build track data first
+        var trackData = ByteBuffer.Empty();
+        var previousTick = 0;
+        foreach (var midiEvent in Events)
+        {
+            var delta = midiEvent.Tick - previousTick;
+            WriteVariableInt(trackData, delta);
+            midiEvent.WriteTo(trackData);
+            previousTick = midiEvent.Tick;
         }
 
-        /// <summary>
-        /// Adds the given midi event a the correct time position into the file.
-        /// </summary>
-        /// <param name="e"></param>
-        public void AddEvent(MidiEvent e) => Events.Add(e);
+        // end of track
 
-        /// <summary>
-        /// Sort the event list by event tick.
-        /// </summary>
-        public void Sort() => Events = Events.OrderBy(x=>x.Tick).ToList();
-
-        /// <summary>
-        /// Writes the midi file into a binary format.
-        /// </summary>
-        /// <returns>The binary midi file.</returns>
-        // ReSharper disable once UnusedMember.Global
-        public byte[] ToBinary()
+        // magic number "MTrk" (0x4D54726B)
+        b = new byte[]
         {
-            var data = ByteBuffer.Empty();
-            WriteTo(data);
-            return data.ToArray();
-        }
+            0x4D, 0x54, 0x72, 0x6B
+        };
+        s.Write(b, 0, b.Length);
 
-        /// <summary>
-        /// Writes the midi file as binary into the given stream.
-        /// </summary>
-        /// <returns>The stream to write to.</returns>
-        public void WriteTo(IWriteable s)
+        // size as integer
+        var data = trackData.ToArray();
+        var l = data.Length;
+        b = new[]
         {
-            // magic number "MThd" (0x4D546864)
-            var b = new byte[]
-            {
-                0x4D, 0x54, 0x68, 0x64
-            };
-            s.Write(b, 0, b.Length);
+            (byte)((l >> 24) & 0xFF), (byte)((l >> 16) & 0xFF), (byte)((l >> 8) & 0xFF), (byte)(l & 0xFF)
+        };
+        s.Write(b, 0, b.Length);
+        s.Write(data, 0, data.Length);
+    }
 
-            // Header Length 6 (0x00000006)
-            b = new byte[]
-            {
-                0x00, 0x00, 0x00, 0x06
-            };
-            s.Write(b, 0, b.Length);
+    internal static void WriteVariableInt(IWriteable s, int value)
+    {
+        var array = new byte[4];
 
-            // format
-            b = new byte[]
-            {
-                0x00, 0x00
-            };
-            s.Write(b, 0, b.Length);
+        var n = 0;
+        do
+        {
+            array[n++] =   (byte)(value & 0x7F & 0xFF);
+            value      >>= 7;
+        } while (value > 0);
 
-            // number of tracks
-            short v = 1;
-            b = new[]
+        while (n > 0)
+        {
+            n--;
+            if (n > 0)
             {
-                (byte)((v >> 8) & 0xFF), (byte)(v & 0xFF)
-            };
-            s.Write(b, 0, b.Length);
-
-            v = MidiUtils.QuarterTime;
-            b = new[]
-            {
-                (byte)((v >> 8) & 0xFF), (byte)(v & 0xFF)
-            };
-            s.Write(b, 0, b.Length);
-
-            // build track data first
-            var trackData = ByteBuffer.Empty();
-            var previousTick = 0;
-            foreach (var midiEvent in Events)
-            {
-                var delta = midiEvent.Tick - previousTick;
-                WriteVariableInt(trackData, delta);
-                midiEvent.WriteTo(trackData);
-                previousTick = midiEvent.Tick;
+                s.WriteByte((byte)(array[n] | 0x80));
             }
-
-            // end of track
-
-            // magic number "MTrk" (0x4D54726B)
-            b = new byte[]
+            else
             {
-                0x4D, 0x54, 0x72, 0x6B
-            };
-            s.Write(b, 0, b.Length);
-
-            // size as integer
-            var data = trackData.ToArray();
-            var l = data.Length;
-            b = new[]
-            {
-                (byte)((l >> 24) & 0xFF), (byte)((l >> 16) & 0xFF), (byte)((l >> 8) & 0xFF), (byte)(l & 0xFF)
-            };
-            s.Write(b, 0, b.Length);
-            s.Write(data, 0, data.Length);
-        }
-
-        internal static void WriteVariableInt(IWriteable s, int value)
-        {
-            var array = new byte[4];
-
-            var n = 0;
-            do
-            {
-                array[n++] = (byte)(value & 0x7F & 0xFF);
-                value >>= 7;
-            } while (value > 0);
-
-            while (n > 0)
-            {
-                n--;
-                if (n > 0)
-                {
-                    s.WriteByte((byte)(array[n] | 0x80));
-                }
-                else
-                {
-                    s.WriteByte(array[n]);
-                }
+                s.WriteByte(array[n]);
             }
         }
     }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Midi/MidiHelper.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Midi/MidiHelper.cs
@@ -3,13 +3,12 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi;
+
+internal static class MidiHelper
 {
-    internal static class MidiHelper
-    {
-        public const int MicroSecondsPerMinute = 60000000;
-        public const int MinChannel = 0;
-        public const int MaxChannel = 15;
-        public const int DrumChannel = 9;
-    }
+    public const int MicroSecondsPerMinute = 60000000;
+    public const int MinChannel = 0;
+    public const int MaxChannel = 15;
+    public const int DrumChannel = 9;
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/MidiFileSequencer.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/MidiFileSequencer.cs
@@ -10,360 +10,359 @@ using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis;
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 using BardMusicPlayer.Siren.AlphaTab.Util;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth;
+
+/// <summary>
+/// This sequencer dispatches midi events to the synthesizer based on the current
+/// synthesize position. The sequencer does not consider the playback speed.
+/// </summary>
+internal sealed class MidiFileSequencer
 {
-    /// <summary>
-    /// This sequencer dispatches midi events to the synthesizer based on the current
-    /// synthesize position. The sequencer does not consider the playback speed.
-    /// </summary>
-    internal sealed class MidiFileSequencer
+    private readonly TinySoundFont _synthesizer;
+
+    private FastList<MidiFileSequencerTempoChange> _tempoChanges;
+    private readonly FastDictionary<int, SynthEvent> _firstProgramEventPerChannel;
+    private FastList<SynthEvent> _synthData;
+    private int _division;
+    private int _eventIndex;
+
+    /// <remarks>
+    /// Note that this is not the actual playback position. It's the position where we are currently synthesizing at.
+    /// Depending on the buffer size of the output, this position is after the actual playback.
+    /// </remarks>
+    private double _currentTime;
+
+
+    private PlaybackRange _playbackRange;
+    private double _playbackRangeStartTime;
+    private double _playbackRangeEndTime;
+    private double _endTime;
+
+    public PlaybackRange PlaybackRange
     {
-        private readonly TinySoundFont _synthesizer;
-
-        private FastList<MidiFileSequencerTempoChange> _tempoChanges;
-        private readonly FastDictionary<int, SynthEvent> _firstProgramEventPerChannel;
-        private FastList<SynthEvent> _synthData;
-        private int _division;
-        private int _eventIndex;
-
-        /// <remarks>
-        /// Note that this is not the actual playback position. It's the position where we are currently synthesizing at.
-        /// Depending on the buffer size of the output, this position is after the actual playback.
-        /// </remarks>
-        private double _currentTime;
-
-
-        private PlaybackRange _playbackRange;
-        private double _playbackRangeStartTime;
-        private double _playbackRangeEndTime;
-        private double _endTime;
-
-        public PlaybackRange PlaybackRange
+        get => _playbackRange;
+        set
         {
-            get => _playbackRange;
-            set
+            _playbackRange = value;
+            if (value != null)
             {
-                _playbackRange = value;
-                if (value != null)
-                {
-                    _playbackRangeStartTime = TickPositionToTimePositionWithSpeed(value.StartTick, 1);
-                    _playbackRangeEndTime = TickPositionToTimePositionWithSpeed(value.EndTick, 1);
-                }
-            }
-        }
-
-        public bool IsLooping { get; set; }
-
-        /// <summary>
-        /// Gets the duration of the song in ticks.
-        /// </summary>
-        public int EndTick { get; private set; }
-
-        /// <summary>
-        /// Gets the duration of the song in milliseconds.
-        /// </summary>
-        public double EndTime => _endTime / PlaybackSpeed;
-
-        /// <summary>
-        /// Gets or sets the playback speed.
-        /// </summary>
-        public double PlaybackSpeed
-        {
-            get;
-            set;
-        }
-
-        public MidiFileSequencer(TinySoundFont synthesizer)
-        {
-            _synthesizer = synthesizer;
-            _firstProgramEventPerChannel = new FastDictionary<int, SynthEvent>();
-            _tempoChanges = new FastList<MidiFileSequencerTempoChange>();
-            PlaybackSpeed = 1;
-        }
-
-        public void Seek(double timePosition)
-        {
-            // map to speed=1
-            timePosition *= PlaybackSpeed;
-
-            // ensure playback range
-            if (PlaybackRange != null)
-            {
-                if (timePosition < _playbackRangeStartTime)
-                {
-                    timePosition = _playbackRangeStartTime;
-                }
-                else if (timePosition > _playbackRangeEndTime)
-                {
-                    timePosition = _playbackRangeEndTime;
-                }
-            }
-
-            // move back some ticks to ensure the on-time events are played
-            timePosition -= 25;
-            if (timePosition < 0)
-            {
-                timePosition = 0;
-            }
-
-            if (timePosition > _currentTime)
-            {
-                SilentProcess(timePosition - _currentTime);
-            }
-            else if (timePosition < _currentTime)
-            {
-                //we have to restart the midi to make sure we get the right state: instruments, volume, pan, etc
-                _currentTime = 0;
-                _eventIndex = 0;
-                _synthesizer.NoteOffAll(true);
-                _synthesizer.ResetSoft();
-
-                SilentProcess(timePosition);
-            }
-        }
-
-        private void SilentProcess(double milliseconds)
-        {
-            if (milliseconds <= 0)
-            {
-                return;
-            }
-
-            var start = Platform.GetCurrentMilliseconds();
-
-            var finalTime = _currentTime + milliseconds;
-
-            while (_currentTime < finalTime)
-            {
-                if (FillMidiEventQueueLimited(finalTime - _currentTime))
-                {
-                    _synthesizer.SynthesizeSilent();
-                }
-            }
-
-            var duration = Platform.GetCurrentMilliseconds() - start;
-            Logger.Debug("Sequencer", "Silent seek finished in " + duration + "ms");
-        }
-
-
-        public void LoadMidi(MidiFile midiFile)
-        {
-            _tempoChanges = new FastList<MidiFileSequencerTempoChange>();
-
-            _division = midiFile.Division;
-            _eventIndex = 0;
-            _currentTime = 0;
-
-            // build synth events.
-            _synthData = new FastList<SynthEvent>();
-
-            // Converts midi to milliseconds for easy sequencing
-            double bpm = 120;
-            var absTick = 0;
-            var absTime = 0.0;
-
-            var previousTick = 0;
-
-            foreach (var mEvent in midiFile.Events)
-            {
-                var synthData = new SynthEvent(_synthData.Count, mEvent);
-                _synthData.Add(synthData);
-
-                var deltaTick = mEvent.Tick - previousTick;
-                absTick += deltaTick;
-                absTime += deltaTick * (60000.0 / (bpm * midiFile.Division));
-                synthData.Time = absTime;
-                previousTick = mEvent.Tick;
-
-                switch (mEvent.Command)
-                {
-                    case MidiEventType.Meta when mEvent.Data1 == (int)MetaEventTypeEnum.Tempo:
-                    {
-                        var meta = (MetaNumberEvent)mEvent;
-                        bpm = MidiHelper.MicroSecondsPerMinute / (double)meta.Value;
-                        _tempoChanges.Add(new MidiFileSequencerTempoChange(bpm, absTick, (int)absTime));
-                        break;
-                    }
-                    case MidiEventType.ProgramChange:
-                    {
-                        var channel = mEvent.Channel;
-                        if (!_firstProgramEventPerChannel.ContainsKey(channel))
-                        {
-                            _firstProgramEventPerChannel[channel] = synthData;
-                        }
-
-                        break;
-                    }
-                }
-            }
-
-            _synthData.Sort((a, b) =>
-            {
-                if (a.Time > b.Time)
-                {
-                    return 1;
-                }
-
-                if (a.Time < b.Time)
-                {
-                    return -1;
-                }
-
-                return a.EventIndex - b.EventIndex;
-            });
-            _endTime = absTime;
-            EndTick = absTick;
-        }
-
-
-        public bool FillMidiEventQueue()
-        {
-            return FillMidiEventQueueLimited(-1);
-        }
-
-        private bool FillMidiEventQueueLimited(double maxMilliseconds)
-        {
-            var millisecondsPerBuffer = TinySoundFont.MicroBufferSize / (double)_synthesizer.OutSampleRate * 1000 * PlaybackSpeed;
-            if (maxMilliseconds > 0 && maxMilliseconds < millisecondsPerBuffer)
-            {
-                millisecondsPerBuffer = maxMilliseconds;
-            }
-
-            var anyEventsDispatched = false;
-            var endTime = InternalEndTime;
-            for (var i = 0; i < TinySoundFont.MicroBufferCount; i++)
-            {
-                _currentTime += millisecondsPerBuffer;
-                while (_eventIndex < _synthData.Count && _synthData[_eventIndex].Time < _currentTime && _currentTime < endTime)
-                {
-                    _synthesizer.DispatchEvent(i, _synthData[_eventIndex]);
-                    _eventIndex++;
-                    anyEventsDispatched = true;
-                }
-            }
-
-            return anyEventsDispatched;
-        }
-
-        public double TickPositionToTimePosition(int tickPosition)
-        {
-            return TickPositionToTimePositionWithSpeed(tickPosition, PlaybackSpeed);
-        }
-
-        public int TimePositionToTickPosition(double timePosition)
-        {
-            return TimePositionToTickPositionWithSpeed(timePosition, PlaybackSpeed);
-        }
-
-        private double TickPositionToTimePositionWithSpeed(int tickPosition, double playbackSpeed)
-        {
-            var timePosition = 0.0;
-            var bpm = 120.0;
-            var lastChange = 0;
-
-            // find start and bpm of last tempo change before time
-            foreach (var c in _tempoChanges)
-            {
-                if (tickPosition < c.Ticks)
-                {
-                    break;
-                }
-
-                timePosition = c.Time;
-                bpm          = c.Bpm;
-                lastChange   = c.Ticks;
-            }
-
-            // add the missing millis
-            tickPosition -= lastChange;
-            timePosition += tickPosition * (60000.0 / (bpm * _division));
-
-            return timePosition / playbackSpeed;
-        }
-
-        private int TimePositionToTickPositionWithSpeed(double timePosition, double playbackSpeed)
-        {
-            timePosition *= playbackSpeed;
-
-            var ticks = 0;
-            var bpm = 120.0;
-            var lastChange = 0;
-
-            // find start and bpm of last tempo change before time
-            foreach (var c in _tempoChanges)
-            {
-                if (timePosition < c.Time)
-                {
-                    break;
-                }
-
-                ticks      = c.Ticks;
-                bpm        = c.Bpm;
-                lastChange = c.Time;
-            }
-
-            // add the missing ticks
-            timePosition -= lastChange;
-            ticks += (int)(timePosition / (60000.0 / (bpm * _division)));
-            // we add 1 for possible rounding errors.(floating point issuses)
-            return ticks + 1;
-        }
-
-        public event Action Finished;
-
-        private void OnFinished()
-        {
-            var finished = Finished;
-            finished?.Invoke();
-        }
-
-
-        private double InternalEndTime => PlaybackRange == null ? _endTime : _playbackRangeEndTime;
-
-        public void CheckForStop()
-        {
-            if (_currentTime >= InternalEndTime)
-            {
-                _synthesizer.NoteOffAll(true);
-                _synthesizer.ResetSoft();
-                OnFinished();
-            }
-        }
-
-        public void Stop()
-        {
-            if (PlaybackRange == null)
-            {
-                _currentTime = 0;
-                _eventIndex = 0;
-            }
-            else if (PlaybackRange != null)
-            {
-                _currentTime = PlaybackRange.StartTick;
-                _eventIndex = 0;
-            }
-        }
-
-        public void SetChannelProgram(int channel, byte program)
-        {
-            if (_firstProgramEventPerChannel.ContainsKey(channel))
-            {
-                _firstProgramEventPerChannel[channel].Event.Data1 = program;
+                _playbackRangeStartTime = TickPositionToTimePositionWithSpeed(value.StartTick, 1);
+                _playbackRangeEndTime   = TickPositionToTimePositionWithSpeed(value.EndTick, 1);
             }
         }
     }
 
-    internal class MidiFileSequencerTempoChange
-    {
-        public double Bpm { get; set; }
-        public int Ticks { get; set; }
-        public int Time { get; set; }
+    public bool IsLooping { get; set; }
 
-        public MidiFileSequencerTempoChange(double bpm, int ticks, int time)
+    /// <summary>
+    /// Gets the duration of the song in ticks.
+    /// </summary>
+    public int EndTick { get; private set; }
+
+    /// <summary>
+    /// Gets the duration of the song in milliseconds.
+    /// </summary>
+    public double EndTime => _endTime / PlaybackSpeed;
+
+    /// <summary>
+    /// Gets or sets the playback speed.
+    /// </summary>
+    public double PlaybackSpeed
+    {
+        get;
+        set;
+    }
+
+    public MidiFileSequencer(TinySoundFont synthesizer)
+    {
+        _synthesizer                 = synthesizer;
+        _firstProgramEventPerChannel = new FastDictionary<int, SynthEvent>();
+        _tempoChanges                = new FastList<MidiFileSequencerTempoChange>();
+        PlaybackSpeed                = 1;
+    }
+
+    public void Seek(double timePosition)
+    {
+        // map to speed=1
+        timePosition *= PlaybackSpeed;
+
+        // ensure playback range
+        if (PlaybackRange != null)
         {
-            Bpm = bpm;
-            Ticks = ticks;
-            Time = time;
+            if (timePosition < _playbackRangeStartTime)
+            {
+                timePosition = _playbackRangeStartTime;
+            }
+            else if (timePosition > _playbackRangeEndTime)
+            {
+                timePosition = _playbackRangeEndTime;
+            }
         }
+
+        // move back some ticks to ensure the on-time events are played
+        timePosition -= 25;
+        if (timePosition < 0)
+        {
+            timePosition = 0;
+        }
+
+        if (timePosition > _currentTime)
+        {
+            SilentProcess(timePosition - _currentTime);
+        }
+        else if (timePosition < _currentTime)
+        {
+            //we have to restart the midi to make sure we get the right state: instruments, volume, pan, etc
+            _currentTime = 0;
+            _eventIndex  = 0;
+            _synthesizer.NoteOffAll(true);
+            _synthesizer.ResetSoft();
+
+            SilentProcess(timePosition);
+        }
+    }
+
+    private void SilentProcess(double milliseconds)
+    {
+        if (milliseconds <= 0)
+        {
+            return;
+        }
+
+        var start = Platform.GetCurrentMilliseconds();
+
+        var finalTime = _currentTime + milliseconds;
+
+        while (_currentTime < finalTime)
+        {
+            if (FillMidiEventQueueLimited(finalTime - _currentTime))
+            {
+                _synthesizer.SynthesizeSilent();
+            }
+        }
+
+        var duration = Platform.GetCurrentMilliseconds() - start;
+        Logger.Debug("Sequencer", "Silent seek finished in " + duration + "ms");
+    }
+
+
+    public void LoadMidi(MidiFile midiFile)
+    {
+        _tempoChanges = new FastList<MidiFileSequencerTempoChange>();
+
+        _division    = midiFile.Division;
+        _eventIndex  = 0;
+        _currentTime = 0;
+
+        // build synth events.
+        _synthData = new FastList<SynthEvent>();
+
+        // Converts midi to milliseconds for easy sequencing
+        double bpm = 120;
+        var absTick = 0;
+        var absTime = 0.0;
+
+        var previousTick = 0;
+
+        foreach (var mEvent in midiFile.Events)
+        {
+            var synthData = new SynthEvent(_synthData.Count, mEvent);
+            _synthData.Add(synthData);
+
+            var deltaTick = mEvent.Tick - previousTick;
+            absTick        += deltaTick;
+            absTime        += deltaTick * (60000.0 / (bpm * midiFile.Division));
+            synthData.Time =  absTime;
+            previousTick   =  mEvent.Tick;
+
+            switch (mEvent.Command)
+            {
+                case MidiEventType.Meta when mEvent.Data1 == (int)MetaEventTypeEnum.Tempo:
+                {
+                    var meta = (MetaNumberEvent)mEvent;
+                    bpm = MidiHelper.MicroSecondsPerMinute / (double)meta.Value;
+                    _tempoChanges.Add(new MidiFileSequencerTempoChange(bpm, absTick, (int)absTime));
+                    break;
+                }
+                case MidiEventType.ProgramChange:
+                {
+                    var channel = mEvent.Channel;
+                    if (!_firstProgramEventPerChannel.ContainsKey(channel))
+                    {
+                        _firstProgramEventPerChannel[channel] = synthData;
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        _synthData.Sort((a, b) =>
+        {
+            if (a.Time > b.Time)
+            {
+                return 1;
+            }
+
+            if (a.Time < b.Time)
+            {
+                return -1;
+            }
+
+            return a.EventIndex - b.EventIndex;
+        });
+        _endTime = absTime;
+        EndTick  = absTick;
+    }
+
+
+    public bool FillMidiEventQueue()
+    {
+        return FillMidiEventQueueLimited(-1);
+    }
+
+    private bool FillMidiEventQueueLimited(double maxMilliseconds)
+    {
+        var millisecondsPerBuffer = TinySoundFont.MicroBufferSize / (double)_synthesizer.OutSampleRate * 1000 * PlaybackSpeed;
+        if (maxMilliseconds > 0 && maxMilliseconds < millisecondsPerBuffer)
+        {
+            millisecondsPerBuffer = maxMilliseconds;
+        }
+
+        var anyEventsDispatched = false;
+        var endTime = InternalEndTime;
+        for (var i = 0; i < TinySoundFont.MicroBufferCount; i++)
+        {
+            _currentTime += millisecondsPerBuffer;
+            while (_eventIndex < _synthData.Count && _synthData[_eventIndex].Time < _currentTime && _currentTime < endTime)
+            {
+                _synthesizer.DispatchEvent(i, _synthData[_eventIndex]);
+                _eventIndex++;
+                anyEventsDispatched = true;
+            }
+        }
+
+        return anyEventsDispatched;
+    }
+
+    public double TickPositionToTimePosition(int tickPosition)
+    {
+        return TickPositionToTimePositionWithSpeed(tickPosition, PlaybackSpeed);
+    }
+
+    public int TimePositionToTickPosition(double timePosition)
+    {
+        return TimePositionToTickPositionWithSpeed(timePosition, PlaybackSpeed);
+    }
+
+    private double TickPositionToTimePositionWithSpeed(int tickPosition, double playbackSpeed)
+    {
+        var timePosition = 0.0;
+        var bpm = 120.0;
+        var lastChange = 0;
+
+        // find start and bpm of last tempo change before time
+        foreach (var c in _tempoChanges)
+        {
+            if (tickPosition < c.Ticks)
+            {
+                break;
+            }
+
+            timePosition = c.Time;
+            bpm          = c.Bpm;
+            lastChange   = c.Ticks;
+        }
+
+        // add the missing millis
+        tickPosition -= lastChange;
+        timePosition += tickPosition * (60000.0 / (bpm * _division));
+
+        return timePosition / playbackSpeed;
+    }
+
+    private int TimePositionToTickPositionWithSpeed(double timePosition, double playbackSpeed)
+    {
+        timePosition *= playbackSpeed;
+
+        var ticks = 0;
+        var bpm = 120.0;
+        var lastChange = 0;
+
+        // find start and bpm of last tempo change before time
+        foreach (var c in _tempoChanges)
+        {
+            if (timePosition < c.Time)
+            {
+                break;
+            }
+
+            ticks      = c.Ticks;
+            bpm        = c.Bpm;
+            lastChange = c.Time;
+        }
+
+        // add the missing ticks
+        timePosition -= lastChange;
+        ticks        += (int)(timePosition / (60000.0 / (bpm * _division)));
+        // we add 1 for possible rounding errors.(floating point issuses)
+        return ticks + 1;
+    }
+
+    public event Action Finished;
+
+    private void OnFinished()
+    {
+        var finished = Finished;
+        finished?.Invoke();
+    }
+
+
+    private double InternalEndTime => PlaybackRange == null ? _endTime : _playbackRangeEndTime;
+
+    public void CheckForStop()
+    {
+        if (_currentTime >= InternalEndTime)
+        {
+            _synthesizer.NoteOffAll(true);
+            _synthesizer.ResetSoft();
+            OnFinished();
+        }
+    }
+
+    public void Stop()
+    {
+        if (PlaybackRange == null)
+        {
+            _currentTime = 0;
+            _eventIndex  = 0;
+        }
+        else if (PlaybackRange != null)
+        {
+            _currentTime = PlaybackRange.StartTick;
+            _eventIndex  = 0;
+        }
+    }
+
+    public void SetChannelProgram(int channel, byte program)
+    {
+        if (_firstProgramEventPerChannel.ContainsKey(channel))
+        {
+            _firstProgramEventPerChannel[channel].Event.Data1 = program;
+        }
+    }
+}
+
+internal class MidiFileSequencerTempoChange
+{
+    public double Bpm { get; set; }
+    public int Ticks { get; set; }
+    public int Time { get; set; }
+
+    public MidiFileSequencerTempoChange(double bpm, int ticks, int time)
+    {
+        Bpm   = bpm;
+        Ticks = ticks;
+        Time  = time;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/PlaybackRange.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/PlaybackRange.cs
@@ -3,21 +3,20 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth;
+
+/// <summary>
+/// Represents a range of the song that should be played.
+/// </summary>
+internal class PlaybackRange
 {
     /// <summary>
-    /// Represents a range of the song that should be played.
+    /// The position in midi ticks from where the song should start.
     /// </summary>
-    internal class PlaybackRange
-    {
-        /// <summary>
-        /// The position in midi ticks from where the song should start.
-        /// </summary>
-        public int StartTick { get; set; }
+    public int StartTick { get; set; }
 
-        /// <summary>
-        /// The position in midi ticks to where the song should be played.
-        /// </summary>
-        public int EndTick { get; set; }
-    }
+    /// <summary>
+    /// The position in midi ticks to where the song should be played.
+    /// </summary>
+    public int EndTick { get; set; }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/PlayerState.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/PlayerState.cs
@@ -3,21 +3,20 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth;
+
+/// <summary>
+/// Lists the different states of the player
+/// </summary>
+internal enum PlayerState
 {
     /// <summary>
-    /// Lists the different states of the player
+    /// Player is paused
     /// </summary>
-    internal enum PlayerState
-    {
-        /// <summary>
-        /// Player is paused
-        /// </summary>
-        Paused,
+    Paused,
 
-        /// <summary>
-        /// Player is playing
-        /// </summary>
-        Playing
-    }
+    /// <summary>
+    /// Player is playing
+    /// </summary>
+    Playing
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/Hydra.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/Hydra.cs
@@ -77,99 +77,105 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
             while (RiffChunk.Load(chunkHead, chunkFastList, readable))
             {
                 var chunk = new RiffChunk();
-                if (chunkFastList.Id == "pdta")
+                switch (chunkFastList.Id)
                 {
-                    while (RiffChunk.Load(chunkFastList, chunk, readable))
+                    case "pdta":
                     {
-                        switch (chunk.Id)
+                        while (RiffChunk.Load(chunkFastList, chunk, readable))
                         {
-                            case "phdr":
-                                for (uint i = 0, count = chunk.Size / HydraPhdr.SizeInFile; i < count; i++)
-                                {
-                                    Phdrs.Add(HydraPhdr.Load(readable));
-                                }
+                            switch (chunk.Id)
+                            {
+                                case "phdr":
+                                    for (uint i = 0, count = chunk.Size / HydraPhdr.SizeInFile; i < count; i++)
+                                    {
+                                        Phdrs.Add(HydraPhdr.Load(readable));
+                                    }
 
-                                break;
-                            case "pbag":
-                                for (uint i = 0, count = chunk.Size / HydraPbag.SizeInFile; i < count; i++)
-                                {
-                                    Pbags.Add(HydraPbag.Load(readable));
-                                }
+                                    break;
+                                case "pbag":
+                                    for (uint i = 0, count = chunk.Size / HydraPbag.SizeInFile; i < count; i++)
+                                    {
+                                        Pbags.Add(HydraPbag.Load(readable));
+                                    }
 
-                                break;
-                            case "pmod":
-                                for (uint i = 0, count = chunk.Size / HydraPmod.SizeInFile; i < count; i++)
-                                {
-                                    Pmods.Add(HydraPmod.Load(readable));
-                                }
+                                    break;
+                                case "pmod":
+                                    for (uint i = 0, count = chunk.Size / HydraPmod.SizeInFile; i < count; i++)
+                                    {
+                                        Pmods.Add(HydraPmod.Load(readable));
+                                    }
 
-                                break;
-                            case "pgen":
-                                for (uint i = 0, count = chunk.Size / HydraPgen.SizeInFile; i < count; i++)
-                                {
-                                    Pgens.Add(HydraPgen.Load(readable));
-                                }
+                                    break;
+                                case "pgen":
+                                    for (uint i = 0, count = chunk.Size / HydraPgen.SizeInFile; i < count; i++)
+                                    {
+                                        Pgens.Add(HydraPgen.Load(readable));
+                                    }
 
-                                break;
-                            case "inst":
-                                for (uint i = 0, count = chunk.Size / HydraInst.SizeInFile; i < count; i++)
-                                {
-                                    Insts.Add(HydraInst.Load(readable));
-                                }
+                                    break;
+                                case "inst":
+                                    for (uint i = 0, count = chunk.Size / HydraInst.SizeInFile; i < count; i++)
+                                    {
+                                        Insts.Add(HydraInst.Load(readable));
+                                    }
 
-                                break;
-                            case "ibag":
-                                for (uint i = 0, count = chunk.Size / HydraIbag.SizeInFile; i < count; i++)
-                                {
-                                    Ibags.Add(HydraIbag.Load(readable));
-                                }
+                                    break;
+                                case "ibag":
+                                    for (uint i = 0, count = chunk.Size / HydraIbag.SizeInFile; i < count; i++)
+                                    {
+                                        Ibags.Add(HydraIbag.Load(readable));
+                                    }
 
-                                break;
-                            case "imod":
-                                for (uint i = 0, count = chunk.Size / HydraImod.SizeInFile; i < count; i++)
-                                {
-                                    Imods.Add(HydraImod.Load(readable));
-                                }
+                                    break;
+                                case "imod":
+                                    for (uint i = 0, count = chunk.Size / HydraImod.SizeInFile; i < count; i++)
+                                    {
+                                        Imods.Add(HydraImod.Load(readable));
+                                    }
 
-                                break;
-                            case "igen":
-                                for (uint i = 0, count = chunk.Size / HydraIgen.SizeInFile; i < count; i++)
-                                {
-                                    Igens.Add(HydraIgen.Load(readable));
-                                }
+                                    break;
+                                case "igen":
+                                    for (uint i = 0, count = chunk.Size / HydraIgen.SizeInFile; i < count; i++)
+                                    {
+                                        Igens.Add(HydraIgen.Load(readable));
+                                    }
 
-                                break;
-                            case "shdr":
-                                for (uint i = 0, count = chunk.Size / HydraShdr.SizeInFile; i < count; i++)
-                                {
-                                    SHdrs.Add(HydraShdr.Load(readable));
-                                }
+                                    break;
+                                case "shdr":
+                                    for (uint i = 0, count = chunk.Size / HydraShdr.SizeInFile; i < count; i++)
+                                    {
+                                        SHdrs.Add(HydraShdr.Load(readable));
+                                    }
 
-                                break;
-                            default:
-                                readable.Position += (int)chunk.Size;
-                                break;
+                                    break;
+                                default:
+                                    readable.Position += (int)chunk.Size;
+                                    break;
+                            }
                         }
+
+                        break;
                     }
-                }
-                else if (chunkFastList.Id == "sdta")
-                {
-                    while (RiffChunk.Load(chunkFastList, chunk, readable))
+                    case "sdta":
                     {
-                        switch (chunk.Id)
+                        while (RiffChunk.Load(chunkFastList, chunk, readable))
                         {
-                            case "smpl":
-                                FontSamples = LoadSamples(chunk, readable);
-                                break;
-                            default:
-                                readable.Position += (int)chunk.Size;
-                                break;
+                            switch (chunk.Id)
+                            {
+                                case "smpl":
+                                    FontSamples = LoadSamples(chunk, readable);
+                                    break;
+                                default:
+                                    readable.Position += (int)chunk.Size;
+                                    break;
+                            }
                         }
+
+                        break;
                     }
-                }
-                else
-                {
-                    readable.Position += (int)chunkFastList.Size;
+                    default:
+                        readable.Position += (int)chunkFastList.Size;
+                        break;
                 }
             }
         }
@@ -184,11 +190,11 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
             var testBuffer = new short[sampleBuffer.Length / 2];
             while (samplesLeft > 0)
             {
-                var samplesToRead = (int)Math.Min(samplesLeft, sampleBuffer.Length / 2);
+                var samplesToRead = Math.Min(samplesLeft, sampleBuffer.Length / 2);
                 reader.Read(sampleBuffer, 0, samplesToRead * 2);
                 for (var i = 0; i < samplesToRead; i++)
                 {
-                    testBuffer[i] = Platform.ToInt16((sampleBuffer[(i * 2) + 1] << 8) | sampleBuffer[(i * 2)]);
+                    testBuffer[i]           = Platform.ToInt16((sampleBuffer[i * 2 + 1] << 8) | sampleBuffer[i * 2]);
                     samples[samplesPos + i] = testBuffer[i] / 32767f;
                 }
 

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/Hydra.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/Hydra.cs
@@ -36,173 +36,172 @@ using System;
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont;
+
+internal class Hydra
 {
-    internal class Hydra
+    public FastList<HydraPhdr> Phdrs { get; set; }
+    public FastList<HydraPbag> Pbags { get; set; }
+    public FastList<HydraPmod> Pmods { get; set; }
+    public FastList<HydraPgen> Pgens { get; set; }
+    public FastList<HydraInst> Insts { get; set; }
+    public FastList<HydraIbag> Ibags { get; set; }
+    public FastList<HydraImod> Imods { get; set; }
+    public FastList<HydraIgen> Igens { get; set; }
+    public FastList<HydraShdr> SHdrs { get; set; }
+    public float[] FontSamples { get; set; }
+
+    public Hydra()
     {
-        public FastList<HydraPhdr> Phdrs { get; set; }
-        public FastList<HydraPbag> Pbags { get; set; }
-        public FastList<HydraPmod> Pmods { get; set; }
-        public FastList<HydraPgen> Pgens { get; set; }
-        public FastList<HydraInst> Insts { get; set; }
-        public FastList<HydraIbag> Ibags { get; set; }
-        public FastList<HydraImod> Imods { get; set; }
-        public FastList<HydraIgen> Igens { get; set; }
-        public FastList<HydraShdr> SHdrs { get; set; }
-        public float[] FontSamples { get; set; }
+        Phdrs = new FastList<HydraPhdr>();
+        Pbags = new FastList<HydraPbag>();
+        Pmods = new FastList<HydraPmod>();
+        Pgens = new FastList<HydraPgen>();
+        Insts = new FastList<HydraInst>();
+        Ibags = new FastList<HydraIbag>();
+        Imods = new FastList<HydraImod>();
+        Igens = new FastList<HydraIgen>();
+        SHdrs = new FastList<HydraShdr>();
+    }
 
-        public Hydra()
+    public void Load(IReadable readable)
+    {
+        var chunkHead = new RiffChunk();
+        var chunkFastList = new RiffChunk();
+
+        if (!RiffChunk.Load(null, chunkHead, readable) || chunkHead.Id != "sfbk")
         {
-            Phdrs = new FastList<HydraPhdr>();
-            Pbags = new FastList<HydraPbag>();
-            Pmods = new FastList<HydraPmod>();
-            Pgens = new FastList<HydraPgen>();
-            Insts = new FastList<HydraInst>();
-            Ibags = new FastList<HydraIbag>();
-            Imods = new FastList<HydraImod>();
-            Igens = new FastList<HydraIgen>();
-            SHdrs = new FastList<HydraShdr>();
+            return;
         }
 
-        public void Load(IReadable readable)
+        while (RiffChunk.Load(chunkHead, chunkFastList, readable))
         {
-            var chunkHead = new RiffChunk();
-            var chunkFastList = new RiffChunk();
-
-            if (!RiffChunk.Load(null, chunkHead, readable) || chunkHead.Id != "sfbk")
+            var chunk = new RiffChunk();
+            switch (chunkFastList.Id)
             {
-                return;
-            }
-
-            while (RiffChunk.Load(chunkHead, chunkFastList, readable))
-            {
-                var chunk = new RiffChunk();
-                switch (chunkFastList.Id)
+                case "pdta":
                 {
-                    case "pdta":
+                    while (RiffChunk.Load(chunkFastList, chunk, readable))
                     {
-                        while (RiffChunk.Load(chunkFastList, chunk, readable))
+                        switch (chunk.Id)
                         {
-                            switch (chunk.Id)
-                            {
-                                case "phdr":
-                                    for (uint i = 0, count = chunk.Size / HydraPhdr.SizeInFile; i < count; i++)
-                                    {
-                                        Phdrs.Add(HydraPhdr.Load(readable));
-                                    }
+                            case "phdr":
+                                for (uint i = 0, count = chunk.Size / HydraPhdr.SizeInFile; i < count; i++)
+                                {
+                                    Phdrs.Add(HydraPhdr.Load(readable));
+                                }
 
-                                    break;
-                                case "pbag":
-                                    for (uint i = 0, count = chunk.Size / HydraPbag.SizeInFile; i < count; i++)
-                                    {
-                                        Pbags.Add(HydraPbag.Load(readable));
-                                    }
+                                break;
+                            case "pbag":
+                                for (uint i = 0, count = chunk.Size / HydraPbag.SizeInFile; i < count; i++)
+                                {
+                                    Pbags.Add(HydraPbag.Load(readable));
+                                }
 
-                                    break;
-                                case "pmod":
-                                    for (uint i = 0, count = chunk.Size / HydraPmod.SizeInFile; i < count; i++)
-                                    {
-                                        Pmods.Add(HydraPmod.Load(readable));
-                                    }
+                                break;
+                            case "pmod":
+                                for (uint i = 0, count = chunk.Size / HydraPmod.SizeInFile; i < count; i++)
+                                {
+                                    Pmods.Add(HydraPmod.Load(readable));
+                                }
 
-                                    break;
-                                case "pgen":
-                                    for (uint i = 0, count = chunk.Size / HydraPgen.SizeInFile; i < count; i++)
-                                    {
-                                        Pgens.Add(HydraPgen.Load(readable));
-                                    }
+                                break;
+                            case "pgen":
+                                for (uint i = 0, count = chunk.Size / HydraPgen.SizeInFile; i < count; i++)
+                                {
+                                    Pgens.Add(HydraPgen.Load(readable));
+                                }
 
-                                    break;
-                                case "inst":
-                                    for (uint i = 0, count = chunk.Size / HydraInst.SizeInFile; i < count; i++)
-                                    {
-                                        Insts.Add(HydraInst.Load(readable));
-                                    }
+                                break;
+                            case "inst":
+                                for (uint i = 0, count = chunk.Size / HydraInst.SizeInFile; i < count; i++)
+                                {
+                                    Insts.Add(HydraInst.Load(readable));
+                                }
 
-                                    break;
-                                case "ibag":
-                                    for (uint i = 0, count = chunk.Size / HydraIbag.SizeInFile; i < count; i++)
-                                    {
-                                        Ibags.Add(HydraIbag.Load(readable));
-                                    }
+                                break;
+                            case "ibag":
+                                for (uint i = 0, count = chunk.Size / HydraIbag.SizeInFile; i < count; i++)
+                                {
+                                    Ibags.Add(HydraIbag.Load(readable));
+                                }
 
-                                    break;
-                                case "imod":
-                                    for (uint i = 0, count = chunk.Size / HydraImod.SizeInFile; i < count; i++)
-                                    {
-                                        Imods.Add(HydraImod.Load(readable));
-                                    }
+                                break;
+                            case "imod":
+                                for (uint i = 0, count = chunk.Size / HydraImod.SizeInFile; i < count; i++)
+                                {
+                                    Imods.Add(HydraImod.Load(readable));
+                                }
 
-                                    break;
-                                case "igen":
-                                    for (uint i = 0, count = chunk.Size / HydraIgen.SizeInFile; i < count; i++)
-                                    {
-                                        Igens.Add(HydraIgen.Load(readable));
-                                    }
+                                break;
+                            case "igen":
+                                for (uint i = 0, count = chunk.Size / HydraIgen.SizeInFile; i < count; i++)
+                                {
+                                    Igens.Add(HydraIgen.Load(readable));
+                                }
 
-                                    break;
-                                case "shdr":
-                                    for (uint i = 0, count = chunk.Size / HydraShdr.SizeInFile; i < count; i++)
-                                    {
-                                        SHdrs.Add(HydraShdr.Load(readable));
-                                    }
+                                break;
+                            case "shdr":
+                                for (uint i = 0, count = chunk.Size / HydraShdr.SizeInFile; i < count; i++)
+                                {
+                                    SHdrs.Add(HydraShdr.Load(readable));
+                                }
 
-                                    break;
-                                default:
-                                    readable.Position += (int)chunk.Size;
-                                    break;
-                            }
+                                break;
+                            default:
+                                readable.Position += (int)chunk.Size;
+                                break;
                         }
-
-                        break;
                     }
-                    case "sdta":
-                    {
-                        while (RiffChunk.Load(chunkFastList, chunk, readable))
-                        {
-                            switch (chunk.Id)
-                            {
-                                case "smpl":
-                                    FontSamples = LoadSamples(chunk, readable);
-                                    break;
-                                default:
-                                    readable.Position += (int)chunk.Size;
-                                    break;
-                            }
-                        }
 
-                        break;
-                    }
-                    default:
-                        readable.Position += (int)chunkFastList.Size;
-                        break;
+                    break;
                 }
-            }
-        }
-
-        private static float[] LoadSamples(RiffChunk chunk, IReadable reader)
-        {
-            var samplesLeft = (int)(chunk.Size / 2);
-            var samples = new float[samplesLeft];
-            var samplesPos = 0;
-
-            var sampleBuffer = new byte[2048];
-            var testBuffer = new short[sampleBuffer.Length / 2];
-            while (samplesLeft > 0)
-            {
-                var samplesToRead = Math.Min(samplesLeft, sampleBuffer.Length / 2);
-                reader.Read(sampleBuffer, 0, samplesToRead * 2);
-                for (var i = 0; i < samplesToRead; i++)
+                case "sdta":
                 {
-                    testBuffer[i]           = Platform.ToInt16((sampleBuffer[i * 2 + 1] << 8) | sampleBuffer[i * 2]);
-                    samples[samplesPos + i] = testBuffer[i] / 32767f;
-                }
+                    while (RiffChunk.Load(chunkFastList, chunk, readable))
+                    {
+                        switch (chunk.Id)
+                        {
+                            case "smpl":
+                                FontSamples = LoadSamples(chunk, readable);
+                                break;
+                            default:
+                                readable.Position += (int)chunk.Size;
+                                break;
+                        }
+                    }
 
-                samplesLeft -= samplesToRead;
-                samplesPos += samplesToRead;
+                    break;
+                }
+                default:
+                    readable.Position += (int)chunkFastList.Size;
+                    break;
+            }
+        }
+    }
+
+    private static float[] LoadSamples(RiffChunk chunk, IReadable reader)
+    {
+        var samplesLeft = (int)(chunk.Size / 2);
+        var samples = new float[samplesLeft];
+        var samplesPos = 0;
+
+        var sampleBuffer = new byte[2048];
+        var testBuffer = new short[sampleBuffer.Length / 2];
+        while (samplesLeft > 0)
+        {
+            var samplesToRead = Math.Min(samplesLeft, sampleBuffer.Length / 2);
+            reader.Read(sampleBuffer, 0, samplesToRead * 2);
+            for (var i = 0; i < samplesToRead; i++)
+            {
+                testBuffer[i]           = Platform.ToInt16((sampleBuffer[i * 2 + 1] << 8) | sampleBuffer[i * 2]);
+                samples[samplesPos + i] = testBuffer[i] / 32767f;
             }
 
-            return samples;
+            samplesLeft -= samplesToRead;
+            samplesPos  += samplesToRead;
         }
+
+        return samples;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraGenAmount.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraGenAmount.cs
@@ -34,31 +34,30 @@
 
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont;
+
+internal class HydraGenAmount
 {
-    internal class HydraGenAmount
+    public ushort WordAmount { get; set; }
+    public short ShortAmount => (short)WordAmount;
+    public byte LowByteAmount
     {
-        public ushort WordAmount { get; set; }
-        public short ShortAmount => (short)WordAmount;
-        public byte LowByteAmount
-        {
-            get => (byte)(WordAmount & 0x00FF);
-            set => WordAmount = (ushort)((WordAmount & 0xFF00) | value);
-        }
+        get => (byte)(WordAmount & 0x00FF);
+        set => WordAmount = (ushort)((WordAmount & 0xFF00) | value);
+    }
 
-        public byte HighByteAmount
-        {
-            get => (byte)((WordAmount & 0xFF00) >> 8);
-            set => WordAmount = (ushort)((value & 0xFF00) | (WordAmount & 0xFF));
-        }
+    public byte HighByteAmount
+    {
+        get => (byte)((WordAmount & 0xFF00) >> 8);
+        set => WordAmount = (ushort)((value & 0xFF00) | (WordAmount & 0xFF));
+    }
 
-        public static HydraGenAmount Load(IReadable reader)
+    public static HydraGenAmount Load(IReadable reader)
+    {
+        var genAmount = new HydraGenAmount
         {
-            var genAmount = new HydraGenAmount
-            {
-                WordAmount = reader.ReadUInt16LE()
-            };
-            return genAmount;
-        }
+            WordAmount = reader.ReadUInt16LE()
+        };
+        return genAmount;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraGenAmount.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraGenAmount.cs
@@ -54,8 +54,10 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
 
         public static HydraGenAmount Load(IReadable reader)
         {
-            var genAmount = new HydraGenAmount();
-            genAmount.WordAmount = reader.ReadUInt16LE();
+            var genAmount = new HydraGenAmount
+            {
+                WordAmount = reader.ReadUInt16LE()
+            };
             return genAmount;
         }
     }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraIbag.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraIbag.cs
@@ -34,23 +34,22 @@
 
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont;
+
+internal class HydraIbag
 {
-    internal class HydraIbag
+    public const int SizeInFile = 4;
+
+    public ushort InstGenNdx { get; set; }
+    public ushort InstModNdx { get; set; }
+
+    public static HydraIbag Load(IReadable reader)
     {
-        public const int SizeInFile = 4;
-
-        public ushort InstGenNdx { get; set; }
-        public ushort InstModNdx { get; set; }
-
-        public static HydraIbag Load(IReadable reader)
+        var ibag = new HydraIbag
         {
-            var ibag = new HydraIbag
-            {
-                InstGenNdx = reader.ReadUInt16LE(),
-                InstModNdx = reader.ReadUInt16LE()
-            };
-            return ibag;
-        }
+            InstGenNdx = reader.ReadUInt16LE(),
+            InstModNdx = reader.ReadUInt16LE()
+        };
+        return ibag;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraIbag.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraIbag.cs
@@ -45,9 +45,11 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
 
         public static HydraIbag Load(IReadable reader)
         {
-            var ibag = new HydraIbag();
-            ibag.InstGenNdx = reader.ReadUInt16LE();
-            ibag.InstModNdx = reader.ReadUInt16LE();
+            var ibag = new HydraIbag
+            {
+                InstGenNdx = reader.ReadUInt16LE(),
+                InstModNdx = reader.ReadUInt16LE()
+            };
             return ibag;
         }
     }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraIgen.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraIgen.cs
@@ -34,23 +34,22 @@
 
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont;
+
+internal class HydraIgen
 {
-    internal class HydraIgen
+    public const int SizeInFile = 4;
+
+    public ushort GenOper { get; set; }
+    public HydraGenAmount GenAmount { get; set; }
+
+    public static HydraIgen Load(IReadable reader)
     {
-        public const int SizeInFile = 4;
-
-        public ushort GenOper { get; set; }
-        public HydraGenAmount GenAmount { get; set; }
-
-        public static HydraIgen Load(IReadable reader)
+        var igen = new HydraIgen
         {
-            var igen = new HydraIgen
-            {
-                GenOper   = reader.ReadUInt16LE(),
-                GenAmount = HydraGenAmount.Load(reader)
-            };
-            return igen;
-        }
+            GenOper   = reader.ReadUInt16LE(),
+            GenAmount = HydraGenAmount.Load(reader)
+        };
+        return igen;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraIgen.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraIgen.cs
@@ -45,9 +45,11 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
 
         public static HydraIgen Load(IReadable reader)
         {
-            var igen = new HydraIgen();
-            igen.GenOper = reader.ReadUInt16LE();
-            igen.GenAmount = HydraGenAmount.Load(reader);
+            var igen = new HydraIgen
+            {
+                GenOper   = reader.ReadUInt16LE(),
+                GenAmount = HydraGenAmount.Load(reader)
+            };
             return igen;
         }
     }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraImod.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraImod.cs
@@ -34,29 +34,28 @@
 
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont;
+
+internal class HydraImod
 {
-    internal class HydraImod
+    public const int SizeInFile = 10;
+
+    public ushort ModSrcOper { get; set; }
+    public ushort ModDestOper { get; set; }
+    public short ModAmount { get; set; }
+    public ushort ModAmtSrcOper { get; set; }
+    public ushort ModTransOper { get; set; }
+
+    public static HydraImod Load(IReadable reader)
     {
-        public const int SizeInFile = 10;
-
-        public ushort ModSrcOper { get; set; }
-        public ushort ModDestOper { get; set; }
-        public short ModAmount { get; set; }
-        public ushort ModAmtSrcOper { get; set; }
-        public ushort ModTransOper { get; set; }
-
-        public static HydraImod Load(IReadable reader)
+        var imod = new HydraImod
         {
-            var imod = new HydraImod
-            {
-                ModSrcOper    = reader.ReadUInt16LE(),
-                ModDestOper   = reader.ReadUInt16LE(),
-                ModAmount     = reader.ReadInt16LE(),
-                ModAmtSrcOper = reader.ReadUInt16LE(),
-                ModTransOper  = reader.ReadUInt16LE()
-            };
-            return imod;
-        }
+            ModSrcOper    = reader.ReadUInt16LE(),
+            ModDestOper   = reader.ReadUInt16LE(),
+            ModAmount     = reader.ReadInt16LE(),
+            ModAmtSrcOper = reader.ReadUInt16LE(),
+            ModTransOper  = reader.ReadUInt16LE()
+        };
+        return imod;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraImod.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraImod.cs
@@ -48,12 +48,14 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
 
         public static HydraImod Load(IReadable reader)
         {
-            var imod = new HydraImod();
-            imod.ModSrcOper = reader.ReadUInt16LE();
-            imod.ModDestOper = reader.ReadUInt16LE();
-            imod.ModAmount = reader.ReadInt16LE();
-            imod.ModAmtSrcOper = reader.ReadUInt16LE();
-            imod.ModTransOper = reader.ReadUInt16LE();
+            var imod = new HydraImod
+            {
+                ModSrcOper    = reader.ReadUInt16LE(),
+                ModDestOper   = reader.ReadUInt16LE(),
+                ModAmount     = reader.ReadInt16LE(),
+                ModAmtSrcOper = reader.ReadUInt16LE(),
+                ModTransOper  = reader.ReadUInt16LE()
+            };
             return imod;
         }
     }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraInst.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraInst.cs
@@ -45,9 +45,11 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
 
         public static HydraInst Load(IReadable reader)
         {
-            var inst = new HydraInst();
-            inst.InstName = reader.Read8BitStringLength(20);
-            inst.InstBagNdx = reader.ReadUInt16LE();
+            var inst = new HydraInst
+            {
+                InstName   = reader.Read8BitStringLength(20),
+                InstBagNdx = reader.ReadUInt16LE()
+            };
             return inst;
         }
     }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraInst.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraInst.cs
@@ -34,23 +34,22 @@
 
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont;
+
+internal class HydraInst
 {
-    internal class HydraInst
+    public const int SizeInFile = 22;
+
+    public string InstName { get; set; }
+    public ushort InstBagNdx { get; set; }
+
+    public static HydraInst Load(IReadable reader)
     {
-        public const int SizeInFile = 22;
-
-        public string InstName { get; set; }
-        public ushort InstBagNdx { get; set; }
-
-        public static HydraInst Load(IReadable reader)
+        var inst = new HydraInst
         {
-            var inst = new HydraInst
-            {
-                InstName   = reader.Read8BitStringLength(20),
-                InstBagNdx = reader.ReadUInt16LE()
-            };
-            return inst;
-        }
+            InstName   = reader.Read8BitStringLength(20),
+            InstBagNdx = reader.ReadUInt16LE()
+        };
+        return inst;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraPbag.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraPbag.cs
@@ -34,23 +34,22 @@
 
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont;
+
+internal class HydraPbag
 {
-    internal class HydraPbag
+    public const int SizeInFile = 4;
+
+    public ushort GenNdx { get; set; }
+    public ushort ModNdx { get; set; }
+
+    public static HydraPbag Load(IReadable reader)
     {
-        public const int SizeInFile = 4;
-
-        public ushort GenNdx { get; set; }
-        public ushort ModNdx { get; set; }
-
-        public static HydraPbag Load(IReadable reader)
+        var pbag = new HydraPbag
         {
-            var pbag = new HydraPbag
-            {
-                GenNdx = reader.ReadUInt16LE(),
-                ModNdx = reader.ReadUInt16LE()
-            };
-            return pbag;
-        }
+            GenNdx = reader.ReadUInt16LE(),
+            ModNdx = reader.ReadUInt16LE()
+        };
+        return pbag;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraPbag.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraPbag.cs
@@ -45,9 +45,11 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
 
         public static HydraPbag Load(IReadable reader)
         {
-            var pbag = new HydraPbag();
-            pbag.GenNdx = reader.ReadUInt16LE();
-            pbag.ModNdx = reader.ReadUInt16LE();
+            var pbag = new HydraPbag
+            {
+                GenNdx = reader.ReadUInt16LE(),
+                ModNdx = reader.ReadUInt16LE()
+            };
             return pbag;
         }
     }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraPgen.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraPgen.cs
@@ -50,9 +50,11 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
 
         public static HydraPgen Load(IReadable reader)
         {
-            var pgen = new HydraPgen();
-            pgen.GenOper = reader.ReadUInt16LE();
-            pgen.GenAmount = HydraGenAmount.Load(reader);
+            var pgen = new HydraPgen
+            {
+                GenOper   = reader.ReadUInt16LE(),
+                GenAmount = HydraGenAmount.Load(reader)
+            };
             return pgen;
         }
     }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraPgen.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraPgen.cs
@@ -34,28 +34,27 @@
 
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont;
+
+internal class HydraPgen
 {
-    internal class HydraPgen
+    public const int SizeInFile = 4;
+
+    public const int GenInstrument = 41;
+    public const int GenKeyRange = 43;
+    public const int GenVelRange = 44;
+    public const int GenSampleId = 53;
+
+    public ushort GenOper { get; set; }
+    public HydraGenAmount GenAmount { get; set; }
+
+    public static HydraPgen Load(IReadable reader)
     {
-        public const int SizeInFile = 4;
-
-        public const int GenInstrument = 41;
-        public const int GenKeyRange = 43;
-        public const int GenVelRange = 44;
-        public const int GenSampleId = 53;
-
-        public ushort GenOper { get; set; }
-        public HydraGenAmount GenAmount { get; set; }
-
-        public static HydraPgen Load(IReadable reader)
+        var pgen = new HydraPgen
         {
-            var pgen = new HydraPgen
-            {
-                GenOper   = reader.ReadUInt16LE(),
-                GenAmount = HydraGenAmount.Load(reader)
-            };
-            return pgen;
-        }
+            GenOper   = reader.ReadUInt16LE(),
+            GenAmount = HydraGenAmount.Load(reader)
+        };
+        return pgen;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraPhdr.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraPhdr.cs
@@ -50,15 +50,16 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
 
         public static HydraPhdr Load(IReadable reader)
         {
-            HydraPhdr phdr = new HydraPhdr();
-
-            phdr.PresetName = reader.Read8BitStringLength(20);
-            phdr.Preset = reader.ReadUInt16LE();
-            phdr.Bank = reader.ReadUInt16LE();
-            phdr.PresetBagNdx = reader.ReadUInt16LE();
-            phdr.Library = reader.ReadUInt32LE();
-            phdr.Genre = reader.ReadUInt32LE();
-            phdr.Morphology = reader.ReadUInt32LE();
+            var phdr = new HydraPhdr
+            {
+                PresetName   = reader.Read8BitStringLength(20),
+                Preset       = reader.ReadUInt16LE(),
+                Bank         = reader.ReadUInt16LE(),
+                PresetBagNdx = reader.ReadUInt16LE(),
+                Library      = reader.ReadUInt32LE(),
+                Genre        = reader.ReadUInt32LE(),
+                Morphology   = reader.ReadUInt32LE()
+            };
 
             return phdr;
         }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraPhdr.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraPhdr.cs
@@ -34,34 +34,33 @@
 
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont;
+
+internal class HydraPhdr
 {
-    internal class HydraPhdr
+    public const int SizeInFile = 38;
+
+    public string PresetName { get; set; }
+    public ushort Preset { get; set; }
+    public ushort Bank { get; set; }
+    public ushort PresetBagNdx { get; set; }
+    public uint Library { get; set; }
+    public uint Genre { get; set; }
+    public uint Morphology { get; set; }
+
+    public static HydraPhdr Load(IReadable reader)
     {
-        public const int SizeInFile = 38;
-
-        public string PresetName { get; set; }
-        public ushort Preset { get; set; }
-        public ushort Bank { get; set; }
-        public ushort PresetBagNdx { get; set; }
-        public uint Library { get; set; }
-        public uint Genre { get; set; }
-        public uint Morphology { get; set; }
-
-        public static HydraPhdr Load(IReadable reader)
+        var phdr = new HydraPhdr
         {
-            var phdr = new HydraPhdr
-            {
-                PresetName   = reader.Read8BitStringLength(20),
-                Preset       = reader.ReadUInt16LE(),
-                Bank         = reader.ReadUInt16LE(),
-                PresetBagNdx = reader.ReadUInt16LE(),
-                Library      = reader.ReadUInt32LE(),
-                Genre        = reader.ReadUInt32LE(),
-                Morphology   = reader.ReadUInt32LE()
-            };
+            PresetName   = reader.Read8BitStringLength(20),
+            Preset       = reader.ReadUInt16LE(),
+            Bank         = reader.ReadUInt16LE(),
+            PresetBagNdx = reader.ReadUInt16LE(),
+            Library      = reader.ReadUInt32LE(),
+            Genre        = reader.ReadUInt32LE(),
+            Morphology   = reader.ReadUInt32LE()
+        };
 
-            return phdr;
-        }
+        return phdr;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraPmod.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraPmod.cs
@@ -48,13 +48,14 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
 
         public static HydraPmod Load(IReadable reader)
         {
-            var pmod = new HydraPmod();
-
-            pmod.ModSrcOper = reader.ReadUInt16LE();
-            pmod.ModDestOper = reader.ReadUInt16LE();
-            pmod.ModAmount = reader.ReadUInt16LE();
-            pmod.ModAmtSrcOper = reader.ReadUInt16LE();
-            pmod.ModTransOper = reader.ReadUInt16LE();
+            var pmod = new HydraPmod
+            {
+                ModSrcOper    = reader.ReadUInt16LE(),
+                ModDestOper   = reader.ReadUInt16LE(),
+                ModAmount     = reader.ReadUInt16LE(),
+                ModAmtSrcOper = reader.ReadUInt16LE(),
+                ModTransOper  = reader.ReadUInt16LE()
+            };
 
             return pmod;
         }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraPmod.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraPmod.cs
@@ -34,30 +34,29 @@
 
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont;
+
+internal class HydraPmod
 {
-    internal class HydraPmod
+    public const int SizeInFile = 10;
+
+    public ushort ModSrcOper { get; set; }
+    public ushort ModDestOper { get; set; }
+    public ushort ModAmount { get; set; }
+    public ushort ModAmtSrcOper { get; set; }
+    public ushort ModTransOper { get; set; }
+
+    public static HydraPmod Load(IReadable reader)
     {
-        public const int SizeInFile = 10;
-
-        public ushort ModSrcOper { get; set; }
-        public ushort ModDestOper { get; set; }
-        public ushort ModAmount { get; set; }
-        public ushort ModAmtSrcOper { get; set; }
-        public ushort ModTransOper { get; set; }
-
-        public static HydraPmod Load(IReadable reader)
+        var pmod = new HydraPmod
         {
-            var pmod = new HydraPmod
-            {
-                ModSrcOper    = reader.ReadUInt16LE(),
-                ModDestOper   = reader.ReadUInt16LE(),
-                ModAmount     = reader.ReadUInt16LE(),
-                ModAmtSrcOper = reader.ReadUInt16LE(),
-                ModTransOper  = reader.ReadUInt16LE()
-            };
+            ModSrcOper    = reader.ReadUInt16LE(),
+            ModDestOper   = reader.ReadUInt16LE(),
+            ModAmount     = reader.ReadUInt16LE(),
+            ModAmtSrcOper = reader.ReadUInt16LE(),
+            ModTransOper  = reader.ReadUInt16LE()
+        };
 
-            return pmod;
-        }
+        return pmod;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraShdr.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraShdr.cs
@@ -53,17 +53,19 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
 
         public static HydraShdr Load(IReadable reader)
         {
-            var shdr = new HydraShdr();
-            shdr.SampleName = reader.Read8BitStringLength(20);
-            shdr.Start = reader.ReadUInt32LE();
-            shdr.End = reader.ReadUInt32LE();
-            shdr.StartLoop = reader.ReadUInt32LE();
-            shdr.EndLoop = reader.ReadUInt32LE();
-            shdr.SampleRate = reader.ReadUInt32LE();
-            shdr.OriginalPitch = (byte)reader.ReadByte();
-            shdr.PitchCorrection = reader.ReadSignedByte();
-            shdr.SampleLink = reader.ReadUInt16LE();
-            shdr.SampleType = reader.ReadUInt16LE();
+            var shdr = new HydraShdr
+            {
+                SampleName      = reader.Read8BitStringLength(20),
+                Start           = reader.ReadUInt32LE(),
+                End             = reader.ReadUInt32LE(),
+                StartLoop       = reader.ReadUInt32LE(),
+                EndLoop         = reader.ReadUInt32LE(),
+                SampleRate      = reader.ReadUInt32LE(),
+                OriginalPitch   = (byte)reader.ReadByte(),
+                PitchCorrection = reader.ReadSignedByte(),
+                SampleLink      = reader.ReadUInt16LE(),
+                SampleType      = reader.ReadUInt16LE()
+            };
             return shdr;
         }
     }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraShdr.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/HydraShdr.cs
@@ -34,39 +34,38 @@
 
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont;
+
+internal class HydraShdr
 {
-    internal class HydraShdr
+    public const int SizeInFile = 46;
+
+    public string SampleName { get; set; }
+    public uint Start { get; set; }
+    public uint End { get; set; }
+    public uint StartLoop { get; set; }
+    public uint EndLoop { get; set; }
+    public uint SampleRate { get; set; }
+    public byte OriginalPitch { get; set; }
+    public sbyte PitchCorrection { get; set; }
+    public ushort SampleLink { get; set; }
+    public ushort SampleType { get; set; }
+
+    public static HydraShdr Load(IReadable reader)
     {
-        public const int SizeInFile = 46;
-
-        public string SampleName { get; set; }
-        public uint Start { get; set; }
-        public uint End { get; set; }
-        public uint StartLoop { get; set; }
-        public uint EndLoop { get; set; }
-        public uint SampleRate { get; set; }
-        public byte OriginalPitch { get; set; }
-        public sbyte PitchCorrection { get; set; }
-        public ushort SampleLink { get; set; }
-        public ushort SampleType { get; set; }
-
-        public static HydraShdr Load(IReadable reader)
+        var shdr = new HydraShdr
         {
-            var shdr = new HydraShdr
-            {
-                SampleName      = reader.Read8BitStringLength(20),
-                Start           = reader.ReadUInt32LE(),
-                End             = reader.ReadUInt32LE(),
-                StartLoop       = reader.ReadUInt32LE(),
-                EndLoop         = reader.ReadUInt32LE(),
-                SampleRate      = reader.ReadUInt32LE(),
-                OriginalPitch   = (byte)reader.ReadByte(),
-                PitchCorrection = reader.ReadSignedByte(),
-                SampleLink      = reader.ReadUInt16LE(),
-                SampleType      = reader.ReadUInt16LE()
-            };
-            return shdr;
-        }
+            SampleName      = reader.Read8BitStringLength(20),
+            Start           = reader.ReadUInt32LE(),
+            End             = reader.ReadUInt32LE(),
+            StartLoop       = reader.ReadUInt32LE(),
+            EndLoop         = reader.ReadUInt32LE(),
+            SampleRate      = reader.ReadUInt32LE(),
+            OriginalPitch   = (byte)reader.ReadByte(),
+            PitchCorrection = reader.ReadSignedByte(),
+            SampleLink      = reader.ReadUInt16LE(),
+            SampleType      = reader.ReadUInt16LE()
+        };
+        return shdr;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/RiffChunk.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/RiffChunk.cs
@@ -43,7 +43,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
 
         public static bool Load(RiffChunk parent, RiffChunk chunk, IReadable stream)
         {
-            if (parent != null && RiffChunk.HeaderSize > parent.Size)
+            if (parent is { Size: < HeaderSize })
             {
                 return false;
             }
@@ -73,16 +73,14 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
             var isRiff = chunk.Id == "RIFF";
             var isList = chunk.Id == "LIST";
 
-            if (isRiff && parent != null)
+            switch (isRiff)
             {
-                // not allowed
-                return false;
-            }
-
-            if (!isRiff && !isList)
-            {
-                // custom type without sub type
-                return true;
+                case true when parent != null:
+                    // not allowed
+                    return false;
+                case false when !isList:
+                    // custom type without sub type
+                    return true;
             }
 
             // for lists unwrap the list type

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/RiffChunk.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SoundFont/RiffChunk.cs
@@ -34,66 +34,65 @@
 
 using BardMusicPlayer.Siren.AlphaTab.IO;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont;
+
+internal class RiffChunk
 {
-    internal class RiffChunk
+    public string Id { get; set; }
+    public uint Size { get; set; }
+
+    public static bool Load(RiffChunk parent, RiffChunk chunk, IReadable stream)
     {
-        public string Id { get; set; }
-        public uint Size { get; set; }
-
-        public static bool Load(RiffChunk parent, RiffChunk chunk, IReadable stream)
+        if (parent is { Size: < HeaderSize })
         {
-            if (parent is { Size: < HeaderSize })
-            {
-                return false;
-            }
-
-            if (stream.Position + HeaderSize >= stream.Length)
-            {
-                return false;
-            }
-
-            chunk.Id = stream.Read8BitStringLength(4);
-            if (chunk.Id[0] <= ' ' || chunk.Id[0] >= 'z')
-            {
-                return false;
-            }
-            chunk.Size = stream.ReadUInt32LE();
-
-            if (parent != null && HeaderSize + chunk.Size > parent.Size)
-            {
-                return false;
-            }
-
-            if (parent != null)
-            {
-                parent.Size -= HeaderSize + chunk.Size;
-            }
-
-            var isRiff = chunk.Id == "RIFF";
-            var isList = chunk.Id == "LIST";
-
-            switch (isRiff)
-            {
-                case true when parent != null:
-                    // not allowed
-                    return false;
-                case false when !isList:
-                    // custom type without sub type
-                    return true;
-            }
-
-            // for lists unwrap the list type
-            chunk.Id = stream.Read8BitStringLength(4);
-            if (chunk.Id[0] <= ' ' || chunk.Id[0] >= 'z')
-            {
-                return false;
-            }
-            chunk.Size -= 4;
-
-            return true;
+            return false;
         }
 
-        public const int HeaderSize = 4 /*FourCC*/ + 4 /*Size*/;
+        if (stream.Position + HeaderSize >= stream.Length)
+        {
+            return false;
+        }
+
+        chunk.Id = stream.Read8BitStringLength(4);
+        if (chunk.Id[0] <= ' ' || chunk.Id[0] >= 'z')
+        {
+            return false;
+        }
+        chunk.Size = stream.ReadUInt32LE();
+
+        if (parent != null && HeaderSize + chunk.Size > parent.Size)
+        {
+            return false;
+        }
+
+        if (parent != null)
+        {
+            parent.Size -= HeaderSize + chunk.Size;
+        }
+
+        var isRiff = chunk.Id == "RIFF";
+        var isList = chunk.Id == "LIST";
+
+        switch (isRiff)
+        {
+            case true when parent != null:
+                // not allowed
+                return false;
+            case false when !isList:
+                // custom type without sub type
+                return true;
+        }
+
+        // for lists unwrap the list type
+        chunk.Id = stream.Read8BitStringLength(4);
+        if (chunk.Id[0] <= ' ' || chunk.Id[0] >= 'z')
+        {
+            return false;
+        }
+        chunk.Size -= 4;
+
+        return true;
     }
+
+    public const int HeaderSize = 4 /*FourCC*/ + 4 /*Size*/;
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SynthEvent.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/SynthEvent.cs
@@ -5,18 +5,17 @@
 
 using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.Event;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth
-{
-    internal class SynthEvent
-    {
-        public int EventIndex { get; set; }
-        public MidiEvent Event { get; set; }
-        public double Time { get; set; }
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth;
 
-        public SynthEvent(int eventIndex, MidiEvent e)
-        {
-            EventIndex = eventIndex;
-            Event = e;
-        }
+internal class SynthEvent
+{
+    public int EventIndex { get; set; }
+    public MidiEvent Event { get; set; }
+    public double Time { get; set; }
+
+    public SynthEvent(int eventIndex, MidiEvent e)
+    {
+        EventIndex = eventIndex;
+        Event      = e;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Channel.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Channel.cs
@@ -31,25 +31,24 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
  * USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
-{
-    internal class Channel
-    {
-        public ushort PresetIndex { get; set; }
-        public ushort Bank { get; set; }
-        public ushort PitchWheel { get; set; }
-        public ushort MidiPan { get; set; }
-        public ushort MidiVolume { get; set; }
-        public ushort MidiExpression { get; set; }
-        public ushort MidiRpn { get; set; }
-        public ushort MidiData { get; set; }
-        public float PanOffset { get; set; }
-        public float GainDb { get; set; }
-        public float PitchRange { get; set; }
-        public float Tuning { get; set; }
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis;
 
-        public float MixVolume { get; set; }
-        public bool Mute { get; set; }
-        public bool Solo { get; set; }
-    }
+internal class Channel
+{
+    public ushort PresetIndex { get; set; }
+    public ushort Bank { get; set; }
+    public ushort PitchWheel { get; set; }
+    public ushort MidiPan { get; set; }
+    public ushort MidiVolume { get; set; }
+    public ushort MidiExpression { get; set; }
+    public ushort MidiRpn { get; set; }
+    public ushort MidiData { get; set; }
+    public float PanOffset { get; set; }
+    public float GainDb { get; set; }
+    public float PitchRange { get; set; }
+    public float Tuning { get; set; }
+
+    public float MixVolume { get; set; }
+    public bool Mute { get; set; }
+    public bool Solo { get; set; }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Channels.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Channels.cs
@@ -35,47 +35,46 @@
 using System;
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis;
+
+internal class Channels
 {
-    internal class Channels
+    public int ActiveChannel { get; set; }
+    public FastList<Channel> ChannelList { get; set; }
+
+    public Channels()
     {
-        public int ActiveChannel { get; set; }
-        public FastList<Channel> ChannelList { get; set; }
+        ChannelList = new FastList<Channel>();
+    }
 
-        public Channels()
+    public void SetupVoice(TinySoundFont tinySoundFont, Voice voice)
+    {
+        var c = ChannelList[ActiveChannel];
+        var newpan = voice.Region.Pan + c.PanOffset;
+        voice.PlayingChannel =  ActiveChannel;
+        voice.MixVolume      =  c.MixVolume;
+        voice.NoteGainDb     += c.GainDb;
+        voice.CalcPitchRatio(
+            c.PitchWheel == 8192
+                ? c.Tuning
+                : c.PitchWheel / 16383.0f * c.PitchRange * 2.0f - c.PitchRange + c.Tuning,
+            tinySoundFont.OutSampleRate
+        );
+
+        switch (newpan)
         {
-            ChannelList = new FastList<Channel>();
-        }
-
-        public void SetupVoice(TinySoundFont tinySoundFont, Voice voice)
-        {
-            var c = ChannelList[ActiveChannel];
-            var newpan = voice.Region.Pan + c.PanOffset;
-            voice.PlayingChannel = ActiveChannel;
-            voice.MixVolume = c.MixVolume;
-            voice.NoteGainDb += c.GainDb;
-            voice.CalcPitchRatio(
-                c.PitchWheel == 8192
-                    ? c.Tuning
-                    : c.PitchWheel / 16383.0f * c.PitchRange * 2.0f - c.PitchRange + c.Tuning,
-                tinySoundFont.OutSampleRate
-            );
-
-            switch (newpan)
-            {
-                case <= -0.5f:
-                    voice.PanFactorLeft  = 1.0f;
-                    voice.PanFactorRight = 0.0f;
-                    break;
-                case >= 0.5f:
-                    voice.PanFactorLeft  = 0.0f;
-                    voice.PanFactorRight = 1.0f;
-                    break;
-                default:
-                    voice.PanFactorLeft  = (float)Math.Sqrt(0.5f - newpan);
-                    voice.PanFactorRight = (float)Math.Sqrt(0.5f + newpan);
-                    break;
-            }
+            case <= -0.5f:
+                voice.PanFactorLeft  = 1.0f;
+                voice.PanFactorRight = 0.0f;
+                break;
+            case >= 0.5f:
+                voice.PanFactorLeft  = 0.0f;
+                voice.PanFactorRight = 1.0f;
+                break;
+            default:
+                voice.PanFactorLeft  = (float)Math.Sqrt(0.5f - newpan);
+                voice.PanFactorRight = (float)Math.Sqrt(0.5f + newpan);
+                break;
         }
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Channels.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Channels.cs
@@ -55,26 +55,26 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
             voice.MixVolume = c.MixVolume;
             voice.NoteGainDb += c.GainDb;
             voice.CalcPitchRatio(
-                (c.PitchWheel == 8192
+                c.PitchWheel == 8192
                     ? c.Tuning
-                    : ((c.PitchWheel / 16383.0f * c.PitchRange * 2.0f) - c.PitchRange + c.Tuning)),
+                    : c.PitchWheel / 16383.0f * c.PitchRange * 2.0f - c.PitchRange + c.Tuning,
                 tinySoundFont.OutSampleRate
             );
 
-            if (newpan <= -0.5f)
+            switch (newpan)
             {
-                voice.PanFactorLeft = 1.0f;
-                voice.PanFactorRight = 0.0f;
-            }
-            else if (newpan >= 0.5f)
-            {
-                voice.PanFactorLeft = 0.0f;
-                voice.PanFactorRight = 1.0f;
-            }
-            else
-            {
-                voice.PanFactorLeft = (float)Math.Sqrt(0.5f - newpan);
-                voice.PanFactorRight = (float)Math.Sqrt(0.5f + newpan);
+                case <= -0.5f:
+                    voice.PanFactorLeft  = 1.0f;
+                    voice.PanFactorRight = 0.0f;
+                    break;
+                case >= 0.5f:
+                    voice.PanFactorLeft  = 0.0f;
+                    voice.PanFactorRight = 1.0f;
+                    break;
+                default:
+                    voice.PanFactorLeft  = (float)Math.Sqrt(0.5f - newpan);
+                    voice.PanFactorRight = (float)Math.Sqrt(0.5f + newpan);
+                    break;
             }
         }
     }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Envelope.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Envelope.cs
@@ -34,80 +34,79 @@
 
 using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Util;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis;
+
+internal class Envelope
 {
-    internal class Envelope
+    public float Delay { get; set; }
+    public float Attack { get; set; }
+    public float Hold { get; set; }
+    public float Decay { get; set; }
+    public float Sustain { get; set; }
+    public float Release { get; set; }
+    public float KeynumToHold { get; set; }
+    public float KeynumToDecay { get; set; }
+
+    public Envelope()
     {
-        public float Delay { get; set; }
-        public float Attack { get; set; }
-        public float Hold { get; set; }
-        public float Decay { get; set; }
-        public float Sustain { get; set; }
-        public float Release { get; set; }
-        public float KeynumToHold { get; set; }
-        public float KeynumToDecay { get; set; }
+    }
 
-        public Envelope()
+    public Envelope(Envelope other)
+    {
+        Delay         = other.Delay;
+        Attack        = other.Attack;
+        Hold          = other.Hold;
+        Decay         = other.Decay;
+        Sustain       = other.Sustain;
+        Release       = other.Release;
+        KeynumToHold  = other.KeynumToHold;
+        KeynumToDecay = other.KeynumToDecay;
+    }
+
+    public void Clear()
+    {
+        Delay         = 0;
+        Attack        = 0;
+        Hold          = 0;
+        Decay         = 0;
+        Sustain       = 0;
+        Release       = 0;
+        KeynumToHold  = 0;
+        KeynumToDecay = 0;
+    }
+
+    public void EnvToSecs(bool sustainIsGain)
+    {
+        // EG times need to be converted from timecents to seconds.
+        // Pin very short EG segments.  Timecents don't get to zero, and our EG is
+        // happier with zero values.
+        Delay   = Delay < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Delay);
+        Attack  = Attack < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Attack);
+        Release = Release < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Release);
+
+        // If we have dynamic hold or decay times depending on key number we need
+        // to keep the values in timecents so we can calculate it during startNote
+        if (KeynumToHold == 0)
         {
+            Hold = Hold < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Hold);
         }
 
-        public Envelope(Envelope other)
+        if (KeynumToDecay == 0)
         {
-            Delay = other.Delay;
-            Attack = other.Attack;
-            Hold = other.Hold;
-            Decay = other.Decay;
-            Sustain = other.Sustain;
-            Release = other.Release;
-            KeynumToHold = other.KeynumToHold;
-            KeynumToDecay = other.KeynumToDecay;
+            Decay = Decay < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Decay);
         }
 
-        public void Clear()
+        if (Sustain < 0.0f)
         {
-            Delay = 0;
-            Attack = 0;
-            Hold = 0;
-            Decay = 0;
-            Sustain = 0;
-            Release = 0;
-            KeynumToHold = 0;
-            KeynumToDecay = 0;
+            Sustain = 0.0f;
         }
-
-        public void EnvToSecs(bool sustainIsGain)
+        else if (sustainIsGain)
         {
-            // EG times need to be converted from timecents to seconds.
-            // Pin very short EG segments.  Timecents don't get to zero, and our EG is
-            // happier with zero values.
-            Delay   = Delay < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Delay);
-            Attack  = Attack < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Attack);
-            Release = Release < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Release);
-
-            // If we have dynamic hold or decay times depending on key number we need
-            // to keep the values in timecents so we can calculate it during startNote
-            if (KeynumToHold == 0)
-            {
-                Hold = Hold < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Hold);
-            }
-
-            if (KeynumToDecay == 0)
-            {
-                Decay = Decay < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Decay);
-            }
-
-            if (Sustain < 0.0f)
-            {
-                Sustain = 0.0f;
-            }
-            else if (sustainIsGain)
-            {
-                Sustain = SynthHelper.DecibelsToGain(-Sustain / 10.0f);
-            }
-            else
-            {
-                Sustain = 1.0f - Sustain / 1000.0f;
-            }
+            Sustain = SynthHelper.DecibelsToGain(-Sustain / 10.0f);
+        }
+        else
+        {
+            Sustain = 1.0f - Sustain / 1000.0f;
         }
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Envelope.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Envelope.cs
@@ -80,20 +80,20 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
             // EG times need to be converted from timecents to seconds.
             // Pin very short EG segments.  Timecents don't get to zero, and our EG is
             // happier with zero values.
-            Delay = (Delay < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Delay));
-            Attack = (Attack < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Attack));
-            Release = (Release < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Release));
+            Delay   = Delay < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Delay);
+            Attack  = Attack < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Attack);
+            Release = Release < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Release);
 
             // If we have dynamic hold or decay times depending on key number we need
             // to keep the values in timecents so we can calculate it during startNote
             if (KeynumToHold == 0)
             {
-                Hold = (Hold < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Hold));
+                Hold = Hold < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Hold);
             }
 
             if (KeynumToDecay == 0)
             {
-                Decay = (Decay < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Decay));
+                Decay = Decay < -11950.0f ? 0.0f : SynthHelper.Timecents2Secs(Decay);
             }
 
             if (Sustain < 0.0f)
@@ -106,7 +106,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
             }
             else
             {
-                Sustain = 1.0f - (Sustain / 1000.0f);
+                Sustain = 1.0f - Sustain / 1000.0f;
             }
         }
     }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/LoopMode.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/LoopMode.cs
@@ -31,12 +31,11 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
  * USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis;
+
+internal enum LoopMode
 {
-    internal enum LoopMode
-    {
-        None,
-        Continuous,
-        Sustain
-    }
+    None,
+    Continuous,
+    Sustain
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/OutputMode.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/OutputMode.cs
@@ -31,24 +31,23 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
  * USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis;
+
+/// <summary>
+/// Supported output modes by the render methods
+/// </summary>
+internal enum OutputMode
 {
     /// <summary>
-    /// Supported output modes by the render methods
+    /// Two channels with single left/right samples one after another
     /// </summary>
-    internal enum OutputMode
-    {
-        /// <summary>
-        /// Two channels with single left/right samples one after another
-        /// </summary>
-        StereoInterleaved,
-        /// <summary>
-        /// Two channels with all samples for the left channel first then right
-        /// </summary>
-        StereoUnweaved,
-        /// <summary>
-        /// A single channel (stereo instruments are mixed into center)
-        /// </summary>
-        Mono
-    }
+    StereoInterleaved,
+    /// <summary>
+    /// Two channels with all samples for the left channel first then right
+    /// </summary>
+    StereoUnweaved,
+    /// <summary>
+    /// A single channel (stereo instruments are mixed into center)
+    /// </summary>
+    Mono
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Preset.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Preset.cs
@@ -31,15 +31,14 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
  * USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
-{
-    internal class Preset
-    {
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis;
 
-        public string Name { get; set; }
-        public ushort PresetNumber { get; set; }
-        public ushort Bank { get; set; }
-        public Region[] Regions { get; set; }
-        public float[] FontSamples { get; set; }
-    }
+internal class Preset
+{
+
+    public string Name { get; set; }
+    public ushort PresetNumber { get; set; }
+    public ushort Bank { get; set; }
+    public Region[] Regions { get; set; }
+    public float[] FontSamples { get; set; }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Region.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Region.cs
@@ -277,7 +277,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
                 case GenOperators.EndloopAddrsCoarseOffset: LoopEnd += (uint)amount.ShortAmount * 32768; break;
                 case GenOperators.CoarseTune: Transpose += amount.ShortAmount; break;
                 case GenOperators.FineTune: Tune += amount.ShortAmount; break;
-                case GenOperators.SampleModes: LoopMode = ((amount.WordAmount & 3) == 3 ? LoopMode.Sustain : ((amount.WordAmount & 3) == 1 ? LoopMode.Continuous : LoopMode.None)); break;
+                case GenOperators.SampleModes: LoopMode = (amount.WordAmount & 3) == 3 ? LoopMode.Sustain : (amount.WordAmount & 3) == 1 ? LoopMode.Continuous : LoopMode.None; break;
                 case GenOperators.ScaleTuning: PitchKeyTrack = amount.ShortAmount; break;
                 case GenOperators.ExclusiveClass: Group = amount.WordAmount; break;
                 case GenOperators.OverridingRootKey: PitchKeyCenter = amount.ShortAmount; break;

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Region.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Region.cs
@@ -34,254 +34,253 @@
 
 using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.SoundFont;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis;
+
+internal class Region
 {
-    internal class Region
+    public LoopMode LoopMode { get; set; }
+    public uint SampleRate { get; set; }
+    public byte LoKey { get; set; }
+    public byte HiKey { get; set; }
+    public byte LoVel { get; set; }
+    public byte HiVel { get; set; }
+    public uint Group { get; set; }
+    public uint Offset { get; set; }
+    public uint End { get; set; }
+    public uint LoopStart { get; set; }
+    public uint LoopEnd { get; set; }
+    public int Transpose { get; set; }
+    public int Tune { get; set; }
+    public int PitchKeyCenter { get; set; }
+    public int PitchKeyTrack { get; set; }
+    public float Attenuation { get; set; }
+    public float Pan { get; set; }
+    public Envelope AmpEnv { get; set; }
+    public Envelope ModEnv { get; set; }
+    public int InitialFilterQ { get; set; }
+    public int InitialFilterFc { get; set; }
+    public int ModEnvToPitch { get; set; }
+    public int ModEnvToFilterFc { get; set; }
+    public int ModLfoToFilterFc { get; set; }
+    public int ModLfoToVolume { get; set; }
+    public float DelayModLFO { get; set; }
+    public int FreqModLFO { get; set; }
+    public int ModLfoToPitch { get; set; }
+    public float DelayVibLFO { get; set; }
+    public int FreqVibLFO { get; set; }
+    public int VibLfoToPitch { get; set; }
+
+    public Region()
     {
-        public LoopMode LoopMode { get; set; }
-        public uint SampleRate { get; set; }
-        public byte LoKey { get; set; }
-        public byte HiKey { get; set; }
-        public byte LoVel { get; set; }
-        public byte HiVel { get; set; }
-        public uint Group { get; set; }
-        public uint Offset { get; set; }
-        public uint End { get; set; }
-        public uint LoopStart { get; set; }
-        public uint LoopEnd { get; set; }
-        public int Transpose { get; set; }
-        public int Tune { get; set; }
-        public int PitchKeyCenter { get; set; }
-        public int PitchKeyTrack { get; set; }
-        public float Attenuation { get; set; }
-        public float Pan { get; set; }
-        public Envelope AmpEnv { get; set; }
-        public Envelope ModEnv { get; set; }
-        public int InitialFilterQ { get; set; }
-        public int InitialFilterFc { get; set; }
-        public int ModEnvToPitch { get; set; }
-        public int ModEnvToFilterFc { get; set; }
-        public int ModLfoToFilterFc { get; set; }
-        public int ModLfoToVolume { get; set; }
-        public float DelayModLFO { get; set; }
-        public int FreqModLFO { get; set; }
-        public int ModLfoToPitch { get; set; }
-        public float DelayVibLFO { get; set; }
-        public int FreqVibLFO { get; set; }
-        public int VibLfoToPitch { get; set; }
+        AmpEnv = new Envelope();
+        ModEnv = new Envelope();
+    }
 
-        public Region()
+    public Region(Region other)
+    {
+        LoopMode         = other.LoopMode;
+        SampleRate       = other.SampleRate;
+        LoKey            = other.LoKey;
+        HiKey            = other.HiKey;
+        LoVel            = other.LoVel;
+        HiVel            = other.HiVel;
+        Group            = other.Group;
+        Offset           = other.Offset;
+        End              = other.End;
+        LoopStart        = other.LoopStart;
+        LoopEnd          = other.LoopEnd;
+        Transpose        = other.Transpose;
+        Tune             = other.Tune;
+        PitchKeyCenter   = other.PitchKeyCenter;
+        PitchKeyTrack    = other.PitchKeyTrack;
+        Attenuation      = other.Attenuation;
+        Pan              = other.Pan;
+        AmpEnv           = new Envelope(other.AmpEnv);
+        ModEnv           = new Envelope(other.ModEnv);
+        InitialFilterQ   = other.InitialFilterQ;
+        InitialFilterFc  = other.InitialFilterFc;
+        ModEnvToPitch    = other.ModEnvToPitch;
+        ModEnvToFilterFc = other.ModEnvToFilterFc;
+        ModLfoToFilterFc = other.ModLfoToFilterFc;
+        ModLfoToVolume   = other.ModLfoToVolume;
+        DelayModLFO      = other.DelayModLFO;
+        FreqModLFO       = other.FreqModLFO;
+        ModLfoToPitch    = other.ModLfoToPitch;
+        DelayVibLFO      = other.DelayVibLFO;
+        FreqVibLFO       = other.FreqVibLFO;
+        VibLfoToPitch    = other.VibLfoToPitch;
+    }
+
+    public void Clear(bool forRelative)
+    {
+        LoopMode       = 0;
+        SampleRate     = 0;
+        LoKey          = 0;
+        HiKey          = 0;
+        LoVel          = 0;
+        HiVel          = 0;
+        Group          = 0;
+        Offset         = 0;
+        End            = 0;
+        LoopStart      = 0;
+        LoopEnd        = 0;
+        Transpose      = 0;
+        Tune           = 0;
+        PitchKeyCenter = 0;
+        PitchKeyTrack  = 0;
+        Attenuation    = 0;
+        Pan            = 0;
+        AmpEnv.Clear();
+        ModEnv.Clear();
+        InitialFilterQ   = 0;
+        InitialFilterFc  = 0;
+        ModEnvToPitch    = 0;
+        ModEnvToFilterFc = 0;
+        ModLfoToFilterFc = 0;
+        ModLfoToVolume   = 0;
+        DelayModLFO      = 0;
+        FreqModLFO       = 0;
+        ModLfoToPitch    = 0;
+        DelayVibLFO      = 0;
+        FreqVibLFO       = 0;
+        VibLfoToPitch    = 0;
+
+        HiKey          = HiVel = 127;
+        PitchKeyCenter = 60; // C4
+        if (forRelative)
         {
-            AmpEnv = new Envelope();
-            ModEnv = new Envelope();
+            return;
         }
 
-        public Region(Region other)
+        PitchKeyTrack = 100;
+
+        PitchKeyCenter = -1;
+
+        // SF2 defaults in timecents.
+        AmpEnv.Delay = AmpEnv.Attack = AmpEnv.Hold = AmpEnv.Decay = AmpEnv.Release = -12000.0f;
+        ModEnv.Delay = ModEnv.Attack = ModEnv.Hold = ModEnv.Decay = ModEnv.Release = -12000.0f;
+
+        InitialFilterFc = 13500;
+
+        DelayModLFO = -12000.0f;
+        DelayVibLFO = -12000.0f;
+    }
+
+    private enum GenOperators
+    {
+        StartAddrsOffset,
+        EndAddrsOffset,
+        StartloopAddrsOffset,
+        EndloopAddrsOffset,
+        StartAddrsCoarseOffset,
+        ModLfoToPitch,
+        VibLfoToPitch,
+        ModEnvToPitch,
+        InitialFilterFc,
+        InitialFilterQ,
+        ModLfoToFilterFc,
+        ModEnvToFilterFc,
+        EndAddrsCoarseOffset,
+        ModLfoToVolume,
+        Unused1,
+        ChorusEffectsSend,
+        ReverbEffectsSend,
+        Pan,
+        Unused2,
+        Unused3,
+        Unused4,
+        DelayModLFO,
+        FreqModLFO,
+        DelayVibLFO,
+        FreqVibLFO,
+        DelayModEnv,
+        AttackModEnv,
+        HoldModEnv,
+        DecayModEnv,
+        SustainModEnv,
+        ReleaseModEnv,
+        KeynumToModEnvHold,
+        KeynumToModEnvDecay,
+        DelayVolEnv,
+        AttackVolEnv,
+        HoldVolEnv,
+        DecayVolEnv,
+        SustainVolEnv,
+        ReleaseVolEnv,
+        KeynumToVolEnvHold,
+        KeynumToVolEnvDecay,
+        Instrument,
+        Reserved1,
+        KeyRange,
+        VelRange,
+        StartloopAddrsCoarseOffset,
+        Keynum,
+        Velocity,
+        InitialAttenuation,
+        Reserved2,
+        EndloopAddrsCoarseOffset,
+        CoarseTune,
+        FineTune,
+        SampleID,
+        SampleModes,
+        Reserved3,
+        ScaleTuning,
+        ExclusiveClass,
+        OverridingRootKey,
+        Unused5,
+        EndOper
+    }
+
+    internal void Operator(ushort genOper, HydraGenAmount amount)
+    {
+        switch ((GenOperators)genOper)
         {
-            LoopMode = other.LoopMode;
-            SampleRate = other.SampleRate;
-            LoKey = other.LoKey;
-            HiKey = other.HiKey;
-            LoVel = other.LoVel;
-            HiVel = other.HiVel;
-            Group = other.Group;
-            Offset = other.Offset;
-            End = other.End;
-            LoopStart = other.LoopStart;
-            LoopEnd = other.LoopEnd;
-            Transpose = other.Transpose;
-            Tune = other.Tune;
-            PitchKeyCenter = other.PitchKeyCenter;
-            PitchKeyTrack = other.PitchKeyTrack;
-            Attenuation = other.Attenuation;
-            Pan = other.Pan;
-            AmpEnv = new Envelope(other.AmpEnv);
-            ModEnv = new Envelope(other.ModEnv);
-            InitialFilterQ = other.InitialFilterQ;
-            InitialFilterFc = other.InitialFilterFc;
-            ModEnvToPitch = other.ModEnvToPitch;
-            ModEnvToFilterFc = other.ModEnvToFilterFc;
-            ModLfoToFilterFc = other.ModLfoToFilterFc;
-            ModLfoToVolume = other.ModLfoToVolume;
-            DelayModLFO = other.DelayModLFO;
-            FreqModLFO = other.FreqModLFO;
-            ModLfoToPitch = other.ModLfoToPitch;
-            DelayVibLFO = other.DelayVibLFO;
-            FreqVibLFO = other.FreqVibLFO;
-            VibLfoToPitch = other.VibLfoToPitch;
-        }
-
-        public void Clear(bool forRelative)
-        {
-            LoopMode = 0;
-            SampleRate = 0;
-            LoKey = 0;
-            HiKey = 0;
-            LoVel = 0;
-            HiVel = 0;
-            Group = 0;
-            Offset = 0;
-            End = 0;
-            LoopStart = 0;
-            LoopEnd = 0;
-            Transpose = 0;
-            Tune = 0;
-            PitchKeyCenter = 0;
-            PitchKeyTrack = 0;
-            Attenuation = 0;
-            Pan = 0;
-            AmpEnv.Clear();
-            ModEnv.Clear();
-            InitialFilterQ = 0;
-            InitialFilterFc = 0;
-            ModEnvToPitch = 0;
-            ModEnvToFilterFc = 0;
-            ModLfoToFilterFc = 0;
-            ModLfoToVolume = 0;
-            DelayModLFO = 0;
-            FreqModLFO = 0;
-            ModLfoToPitch = 0;
-            DelayVibLFO = 0;
-            FreqVibLFO = 0;
-            VibLfoToPitch = 0;
-
-            HiKey = HiVel = 127;
-            PitchKeyCenter = 60; // C4
-            if (forRelative)
-            {
-                return;
-            }
-
-            PitchKeyTrack = 100;
-
-            PitchKeyCenter = -1;
-
-            // SF2 defaults in timecents.
-            AmpEnv.Delay = AmpEnv.Attack = AmpEnv.Hold = AmpEnv.Decay = AmpEnv.Release = -12000.0f;
-            ModEnv.Delay = ModEnv.Attack = ModEnv.Hold = ModEnv.Decay = ModEnv.Release = -12000.0f;
-
-            InitialFilterFc = 13500;
-
-            DelayModLFO = -12000.0f;
-            DelayVibLFO = -12000.0f;
-        }
-
-        private enum GenOperators
-        {
-            StartAddrsOffset,
-            EndAddrsOffset,
-            StartloopAddrsOffset,
-            EndloopAddrsOffset,
-            StartAddrsCoarseOffset,
-            ModLfoToPitch,
-            VibLfoToPitch,
-            ModEnvToPitch,
-            InitialFilterFc,
-            InitialFilterQ,
-            ModLfoToFilterFc,
-            ModEnvToFilterFc,
-            EndAddrsCoarseOffset,
-            ModLfoToVolume,
-            Unused1,
-            ChorusEffectsSend,
-            ReverbEffectsSend,
-            Pan,
-            Unused2,
-            Unused3,
-            Unused4,
-            DelayModLFO,
-            FreqModLFO,
-            DelayVibLFO,
-            FreqVibLFO,
-            DelayModEnv,
-            AttackModEnv,
-            HoldModEnv,
-            DecayModEnv,
-            SustainModEnv,
-            ReleaseModEnv,
-            KeynumToModEnvHold,
-            KeynumToModEnvDecay,
-            DelayVolEnv,
-            AttackVolEnv,
-            HoldVolEnv,
-            DecayVolEnv,
-            SustainVolEnv,
-            ReleaseVolEnv,
-            KeynumToVolEnvHold,
-            KeynumToVolEnvDecay,
-            Instrument,
-            Reserved1,
-            KeyRange,
-            VelRange,
-            StartloopAddrsCoarseOffset,
-            Keynum,
-            Velocity,
-            InitialAttenuation,
-            Reserved2,
-            EndloopAddrsCoarseOffset,
-            CoarseTune,
-            FineTune,
-            SampleID,
-            SampleModes,
-            Reserved3,
-            ScaleTuning,
-            ExclusiveClass,
-            OverridingRootKey,
-            Unused5,
-            EndOper
-        }
-
-        internal void Operator(ushort genOper, HydraGenAmount amount)
-        {
-            switch ((GenOperators)genOper)
-            {
-                case GenOperators.StartAddrsOffset: Offset += (uint)amount.ShortAmount; break;
-                case GenOperators.EndAddrsOffset: End += (uint)amount.ShortAmount; break;
-                case GenOperators.StartloopAddrsOffset: LoopStart += (uint)amount.ShortAmount; break;
-                case GenOperators.EndloopAddrsOffset: LoopEnd += (uint)amount.ShortAmount; break;
-                case GenOperators.StartAddrsCoarseOffset: Offset += (uint)amount.ShortAmount * 32768; break;
-                case GenOperators.ModLfoToPitch: ModLfoToPitch = amount.ShortAmount; break;
-                case GenOperators.VibLfoToPitch: VibLfoToPitch = amount.ShortAmount; break;
-                case GenOperators.ModEnvToPitch: ModEnvToPitch = amount.ShortAmount; break;
-                case GenOperators.InitialFilterFc: InitialFilterFc = amount.ShortAmount; break;
-                case GenOperators.InitialFilterQ: InitialFilterQ = amount.ShortAmount; break;
-                case GenOperators.ModLfoToFilterFc: ModLfoToFilterFc = amount.ShortAmount; break;
-                case GenOperators.ModEnvToFilterFc: ModEnvToFilterFc = amount.ShortAmount; break;
-                case GenOperators.EndAddrsCoarseOffset: End += (uint)amount.ShortAmount * 32768; break;
-                case GenOperators.ModLfoToVolume: ModLfoToVolume = amount.ShortAmount; break;
-                case GenOperators.Pan: Pan = amount.ShortAmount / 1000.0f; break;
-                case GenOperators.DelayModLFO: DelayModLFO = amount.ShortAmount; break;
-                case GenOperators.FreqModLFO: FreqModLFO = amount.ShortAmount; break;
-                case GenOperators.DelayVibLFO: DelayVibLFO = amount.ShortAmount; break;
-                case GenOperators.FreqVibLFO: FreqVibLFO = amount.ShortAmount; break;
-                case GenOperators.DelayModEnv: ModEnv.Delay = amount.ShortAmount; break;
-                case GenOperators.AttackModEnv: ModEnv.Attack = amount.ShortAmount; break;
-                case GenOperators.HoldModEnv: ModEnv.Hold = amount.ShortAmount; break;
-                case GenOperators.DecayModEnv: ModEnv.Decay = amount.ShortAmount; break;
-                case GenOperators.SustainModEnv: ModEnv.Sustain = amount.ShortAmount; break;
-                case GenOperators.ReleaseModEnv: ModEnv.Release = amount.ShortAmount; break;
-                case GenOperators.KeynumToModEnvHold: ModEnv.KeynumToHold = amount.ShortAmount; break;
-                case GenOperators.KeynumToModEnvDecay: ModEnv.KeynumToDecay = amount.ShortAmount; break;
-                case GenOperators.DelayVolEnv: AmpEnv.Delay = amount.ShortAmount; break;
-                case GenOperators.AttackVolEnv: AmpEnv.Attack = amount.ShortAmount; break;
-                case GenOperators.HoldVolEnv: AmpEnv.Hold = amount.ShortAmount; break;
-                case GenOperators.DecayVolEnv: AmpEnv.Decay = amount.ShortAmount; break;
-                case GenOperators.SustainVolEnv: AmpEnv.Sustain = amount.ShortAmount; break;
-                case GenOperators.ReleaseVolEnv: AmpEnv.Release = amount.ShortAmount; break;
-                case GenOperators.KeynumToVolEnvHold: AmpEnv.KeynumToHold = amount.ShortAmount; break;
-                case GenOperators.KeynumToVolEnvDecay: AmpEnv.KeynumToDecay = amount.ShortAmount; break;
-                case GenOperators.KeyRange: LoKey = amount.LowByteAmount; HiKey = amount.HighByteAmount; break;
-                case GenOperators.VelRange: LoVel = amount.LowByteAmount; HiVel = amount.HighByteAmount; break;
-                case GenOperators.StartloopAddrsCoarseOffset: LoopStart += (uint)amount.ShortAmount * 32768; break;
-                case GenOperators.InitialAttenuation: Attenuation += amount.ShortAmount * 0.1f; break;
-                case GenOperators.EndloopAddrsCoarseOffset: LoopEnd += (uint)amount.ShortAmount * 32768; break;
-                case GenOperators.CoarseTune: Transpose += amount.ShortAmount; break;
-                case GenOperators.FineTune: Tune += amount.ShortAmount; break;
-                case GenOperators.SampleModes: LoopMode = (amount.WordAmount & 3) == 3 ? LoopMode.Sustain : (amount.WordAmount & 3) == 1 ? LoopMode.Continuous : LoopMode.None; break;
-                case GenOperators.ScaleTuning: PitchKeyTrack = amount.ShortAmount; break;
-                case GenOperators.ExclusiveClass: Group = amount.WordAmount; break;
-                case GenOperators.OverridingRootKey: PitchKeyCenter = amount.ShortAmount; break;
-            }
+            case GenOperators.StartAddrsOffset: Offset += (uint)amount.ShortAmount; break;
+            case GenOperators.EndAddrsOffset: End += (uint)amount.ShortAmount; break;
+            case GenOperators.StartloopAddrsOffset: LoopStart += (uint)amount.ShortAmount; break;
+            case GenOperators.EndloopAddrsOffset: LoopEnd += (uint)amount.ShortAmount; break;
+            case GenOperators.StartAddrsCoarseOffset: Offset += (uint)amount.ShortAmount * 32768; break;
+            case GenOperators.ModLfoToPitch: ModLfoToPitch = amount.ShortAmount; break;
+            case GenOperators.VibLfoToPitch: VibLfoToPitch = amount.ShortAmount; break;
+            case GenOperators.ModEnvToPitch: ModEnvToPitch = amount.ShortAmount; break;
+            case GenOperators.InitialFilterFc: InitialFilterFc = amount.ShortAmount; break;
+            case GenOperators.InitialFilterQ: InitialFilterQ = amount.ShortAmount; break;
+            case GenOperators.ModLfoToFilterFc: ModLfoToFilterFc = amount.ShortAmount; break;
+            case GenOperators.ModEnvToFilterFc: ModEnvToFilterFc = amount.ShortAmount; break;
+            case GenOperators.EndAddrsCoarseOffset: End += (uint)amount.ShortAmount * 32768; break;
+            case GenOperators.ModLfoToVolume: ModLfoToVolume = amount.ShortAmount; break;
+            case GenOperators.Pan: Pan = amount.ShortAmount / 1000.0f; break;
+            case GenOperators.DelayModLFO: DelayModLFO = amount.ShortAmount; break;
+            case GenOperators.FreqModLFO: FreqModLFO = amount.ShortAmount; break;
+            case GenOperators.DelayVibLFO: DelayVibLFO = amount.ShortAmount; break;
+            case GenOperators.FreqVibLFO: FreqVibLFO = amount.ShortAmount; break;
+            case GenOperators.DelayModEnv: ModEnv.Delay = amount.ShortAmount; break;
+            case GenOperators.AttackModEnv: ModEnv.Attack = amount.ShortAmount; break;
+            case GenOperators.HoldModEnv: ModEnv.Hold = amount.ShortAmount; break;
+            case GenOperators.DecayModEnv: ModEnv.Decay = amount.ShortAmount; break;
+            case GenOperators.SustainModEnv: ModEnv.Sustain = amount.ShortAmount; break;
+            case GenOperators.ReleaseModEnv: ModEnv.Release = amount.ShortAmount; break;
+            case GenOperators.KeynumToModEnvHold: ModEnv.KeynumToHold = amount.ShortAmount; break;
+            case GenOperators.KeynumToModEnvDecay: ModEnv.KeynumToDecay = amount.ShortAmount; break;
+            case GenOperators.DelayVolEnv: AmpEnv.Delay = amount.ShortAmount; break;
+            case GenOperators.AttackVolEnv: AmpEnv.Attack = amount.ShortAmount; break;
+            case GenOperators.HoldVolEnv: AmpEnv.Hold = amount.ShortAmount; break;
+            case GenOperators.DecayVolEnv: AmpEnv.Decay = amount.ShortAmount; break;
+            case GenOperators.SustainVolEnv: AmpEnv.Sustain = amount.ShortAmount; break;
+            case GenOperators.ReleaseVolEnv: AmpEnv.Release = amount.ShortAmount; break;
+            case GenOperators.KeynumToVolEnvHold: AmpEnv.KeynumToHold = amount.ShortAmount; break;
+            case GenOperators.KeynumToVolEnvDecay: AmpEnv.KeynumToDecay = amount.ShortAmount; break;
+            case GenOperators.KeyRange: LoKey = amount.LowByteAmount; HiKey = amount.HighByteAmount; break;
+            case GenOperators.VelRange: LoVel = amount.LowByteAmount; HiVel = amount.HighByteAmount; break;
+            case GenOperators.StartloopAddrsCoarseOffset: LoopStart += (uint)amount.ShortAmount * 32768; break;
+            case GenOperators.InitialAttenuation: Attenuation += amount.ShortAmount * 0.1f; break;
+            case GenOperators.EndloopAddrsCoarseOffset: LoopEnd += (uint)amount.ShortAmount * 32768; break;
+            case GenOperators.CoarseTune: Transpose += amount.ShortAmount; break;
+            case GenOperators.FineTune: Tune += amount.ShortAmount; break;
+            case GenOperators.SampleModes: LoopMode = (amount.WordAmount & 3) == 3 ? LoopMode.Sustain : (amount.WordAmount & 3) == 1 ? LoopMode.Continuous : LoopMode.None; break;
+            case GenOperators.ScaleTuning: PitchKeyTrack = amount.ShortAmount; break;
+            case GenOperators.ExclusiveClass: Group = amount.WordAmount; break;
+            case GenOperators.OverridingRootKey: PitchKeyCenter = amount.ShortAmount; break;
         }
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/TinySoundFont.AlphaTab.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/TinySoundFont.AlphaTab.cs
@@ -12,195 +12,194 @@ using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Util;
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 using BardMusicPlayer.Siren.AlphaTab.Util;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis;
+
+internal sealed partial class TinySoundFont
 {
-    internal sealed partial class TinySoundFont
+    public const int MicroBufferCount = 32; // 4069 samples in total
+    public const int MicroBufferSize = 64;  // 64 stereo samples
+
+    private readonly LinkedList<SynthEvent> _midiEventQueue = new();
+    private readonly int[] _midiEventCounts = new int[MicroBufferCount];
+    private FastDictionary<int, bool> _mutedChannels = new();
+    private FastDictionary<int, bool> _soloChannels = new();
+    private bool _isAnySolo;
+
+    public float[] Synthesize()
     {
-        public const int MicroBufferCount = 32; // 4069 samples in total
-        public const int MicroBufferSize = 64; // 64 stereo samples
+        return FillWorkingBuffer(false);
+    }
 
-        private readonly LinkedList<SynthEvent> _midiEventQueue = new();
-        private readonly int[] _midiEventCounts = new int[MicroBufferCount];
-        private FastDictionary<int, bool> _mutedChannels = new();
-        private FastDictionary<int, bool> _soloChannels = new();
-        private bool _isAnySolo;
+    public void SynthesizeSilent()
+    {
+        FillWorkingBuffer(true);
+    }
 
-        public float[] Synthesize()
+    public float ChannelGetMixVolume(int channel)
+    {
+        return _channels != null && channel < _channels.ChannelList.Count
+            ? _channels.ChannelList[channel].MixVolume
+            : 1.0f;
+    }
+
+    public void ChannelSetMixVolume(int channel, float volume)
+    {
+        var c = ChannelInit(channel);
+        foreach (var v in _voices.Where(v => v.PlayingChannel == channel && v.PlayingPreset != -1))
         {
-            return FillWorkingBuffer(false);
+            v.MixVolume = volume;
         }
 
-        public void SynthesizeSilent()
+        c.MixVolume = volume;
+    }
+
+    public void ChannelSetMute(int channel, bool mute)
+    {
+        if (mute)
         {
-            FillWorkingBuffer(true);
+            _mutedChannels[channel] = true;
+        }
+        else
+        {
+            _mutedChannels.Remove(channel);
+        }
+    }
+
+    public void ChannelSetSolo(int channel, bool solo)
+    {
+        if (solo)
+        {
+            _soloChannels[channel] = true;
+        }
+        else
+        {
+            _soloChannels.Remove(channel);
         }
 
-        public float ChannelGetMixVolume(int channel)
-        {
-            return _channels != null && channel < _channels.ChannelList.Count
-                ? _channels.ChannelList[channel].MixVolume
-                : 1.0f;
-        }
+        _isAnySolo = _soloChannels.Count > 0;
+    }
 
-        public void ChannelSetMixVolume(int channel, float volume)
+    public void ResetChannelStates()
+    {
+        _mutedChannels = new FastDictionary<int, bool>();
+        _soloChannels  = new FastDictionary<int, bool>();
+        _isAnySolo     = false;
+    }
+
+    public void DispatchEvent(int i, SynthEvent synthEvent)
+    {
+        _midiEventQueue.AddFirst(synthEvent);
+        _midiEventCounts[i]++;
+    }
+
+    private float[] FillWorkingBuffer(bool silent)
+    {
+        /*Break the process loop into sections representing the smallest timeframe before the midi controls need to be updated
+        the bigger the timeframe the more efficient the process is, but playback quality will be reduced.*/
+        var buffer = new float[MicroBufferSize * MicroBufferCount * SynthConstants.AudioChannels];
+        var bufferPos = 0;
+        var anySolo = _isAnySolo;
+
+        // process in micro-buffers
+        for (var x = 0; x < MicroBufferCount; x++)
         {
-            var c = ChannelInit(channel);
-            foreach (var v in _voices.Where(v => v.PlayingChannel == channel && v.PlayingPreset != -1))
+            // process events for first microbuffer
+            if (_midiEventQueue.Length > 0)
             {
-                v.MixVolume = volume;
-            }
-
-            c.MixVolume = volume;
-        }
-
-        public void ChannelSetMute(int channel, bool mute)
-        {
-            if (mute)
-            {
-                _mutedChannels[channel] = true;
-            }
-            else
-            {
-                _mutedChannels.Remove(channel);
-            }
-        }
-
-        public void ChannelSetSolo(int channel, bool solo)
-        {
-            if (solo)
-            {
-                _soloChannels[channel] = true;
-            }
-            else
-            {
-                _soloChannels.Remove(channel);
-            }
-
-            _isAnySolo = _soloChannels.Count > 0;
-        }
-
-        public void ResetChannelStates()
-        {
-            _mutedChannels = new FastDictionary<int, bool>();
-            _soloChannels = new FastDictionary<int, bool>();
-            _isAnySolo = false;
-        }
-
-        public void DispatchEvent(int i, SynthEvent synthEvent)
-        {
-            _midiEventQueue.AddFirst(synthEvent);
-            _midiEventCounts[i]++;
-        }
-
-        private float[] FillWorkingBuffer(bool silent)
-        {
-            /*Break the process loop into sections representing the smallest timeframe before the midi controls need to be updated
-            the bigger the timeframe the more efficient the process is, but playback quality will be reduced.*/
-            var buffer = new float[MicroBufferSize * MicroBufferCount * SynthConstants.AudioChannels];
-            var bufferPos = 0;
-            var anySolo = _isAnySolo;
-
-            // process in micro-buffers
-            for (var x = 0; x < MicroBufferCount; x++)
-            {
-                // process events for first microbuffer
-                if (_midiEventQueue.Length > 0)
+                for (var i = 0; i < _midiEventCounts[x]; i++)
                 {
-                    for (var i = 0; i < _midiEventCounts[x]; i++)
+                    var m = _midiEventQueue.RemoveLast();
+                    if (m == null)
+                        continue;
+                    ProcessMidiMessage(m.Event);
+                }
+            }
+
+            // voice processing loop
+            foreach (var voice in _voices)
+            {
+                if (voice.PlayingPreset != -1)
+                {
+                    var channel = voice.PlayingChannel;
+                    // channel is muted if it is either explicitly muted, or another channel is set to solo but not this one.
+                    var isChannelMuted = _mutedChannels.ContainsKey(channel) ||
+                                         anySolo && !_soloChannels.ContainsKey(channel);
+
+                    if (silent)
                     {
-                        var m = _midiEventQueue.RemoveLast();
-                        if (m == null)
-                            continue;
-                        ProcessMidiMessage(m.Event);
+                        voice.Kill();
+                    }
+                    else
+                    {
+                        voice.Render(this, buffer, bufferPos, MicroBufferSize, isChannelMuted);
                     }
                 }
-
-                // voice processing loop
-                foreach (var voice in _voices)
-                {
-                    if (voice.PlayingPreset != -1)
-                    {
-                        var channel = voice.PlayingChannel;
-                        // channel is muted if it is either explicitly muted, or another channel is set to solo but not this one.
-                        var isChannelMuted = _mutedChannels.ContainsKey(channel) ||
-                                             anySolo && !_soloChannels.ContainsKey(channel);
-
-                        if (silent)
-                        {
-                            voice.Kill();
-                        }
-                        else
-                        {
-                            voice.Render(this, buffer, bufferPos, MicroBufferSize, isChannelMuted);
-                        }
-                    }
-                }
-
-                bufferPos += MicroBufferSize * SynthConstants.AudioChannels;
             }
 
-            Platform.ClearIntArray(_midiEventCounts);
-            return buffer;
+            bufferPos += MicroBufferSize * SynthConstants.AudioChannels;
         }
 
-        private void ProcessMidiMessage(MidiEvent e)
+        Platform.ClearIntArray(_midiEventCounts);
+        return buffer;
+    }
+
+    private void ProcessMidiMessage(MidiEvent e)
+    {
+        Logger.Debug("Midi", "Processing midi " + e.Command);
+        var command = e.Command;
+        var channel = e.Channel;
+        var data1 = e.Data1;
+        var data2 = e.Data2;
+        switch (command)
         {
-            Logger.Debug("Midi", "Processing midi " + e.Command);
-            var command = e.Command;
-            var channel = e.Channel;
-            var data1 = e.Data1;
-            var data2 = e.Data2;
-            switch (command)
-            {
-                case MidiEventType.NoteOff:
-                    ChannelNoteOff(channel, data1);
-                    break;
-                case MidiEventType.NoteOn:
-                    ChannelNoteOn(channel, data1, data2 / 127f);
-                    break;
-                case MidiEventType.NoteAftertouch:
-                    break;
-                case MidiEventType.Controller:
-                    ChannelMidiControl(channel, data1, data2);
-                    break;
-                case MidiEventType.ProgramChange:
-                    ChannelSetPresetNumber(channel, data1, channel == 9);
-                    break;
-                case MidiEventType.ChannelAftertouch:
-                    break;
-                case MidiEventType.PitchBend:
-                    ChannelSetPitchWheel(channel, (short)(data1 | (data2 << 8)));
-                    break;
-            }
+            case MidiEventType.NoteOff:
+                ChannelNoteOff(channel, data1);
+                break;
+            case MidiEventType.NoteOn:
+                ChannelNoteOn(channel, data1, data2 / 127f);
+                break;
+            case MidiEventType.NoteAftertouch:
+                break;
+            case MidiEventType.Controller:
+                ChannelMidiControl(channel, data1, data2);
+                break;
+            case MidiEventType.ProgramChange:
+                ChannelSetPresetNumber(channel, data1, channel == 9);
+                break;
+            case MidiEventType.ChannelAftertouch:
+                break;
+            case MidiEventType.PitchBend:
+                ChannelSetPitchWheel(channel, (short)(data1 | (data2 << 8)));
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Stop all playing notes immediately and reset all channel parameters but keeps user
+    /// defined settings
+    /// </summary>
+    public void ResetSoft()
+    {
+        _noteCounter = 0;
+        foreach (var v in _voices.Where(v => v.PlayingPreset != -1 &&
+                                             (v.AmpEnv.Segment < VoiceEnvelopeSegment.Release || v.AmpEnv.Parameters.Release != 0)))
+        {
+            v.EndQuick(OutSampleRate);
         }
 
-        /// <summary>
-        /// Stop all playing notes immediately and reset all channel parameters but keeps user
-        /// defined settings
-        /// </summary>
-        public void ResetSoft()
+        if (_channels != null)
         {
-            _noteCounter = 0;
-            foreach (var v in _voices.Where(v => v.PlayingPreset != -1 &&
-                                                 (v.AmpEnv.Segment < VoiceEnvelopeSegment.Release || v.AmpEnv.Parameters.Release != 0)))
+            foreach (var c in _channels.ChannelList)
             {
-                v.EndQuick(OutSampleRate);
-            }
-
-            if (_channels != null)
-            {
-                foreach (var c in _channels.ChannelList)
-                {
-                    c.PresetIndex = c.Bank = 0;
-                    c.PitchWheel = c.MidiPan = 8192;
-                    c.MidiVolume = c.MidiExpression = 16383;
-                    c.MidiRpn = 0xFFFF;
-                    c.MidiData = 0;
-                    c.PanOffset = 0.0f;
-                    c.GainDb = 0.0f;
-                    c.PitchRange = 2.0f;
-                    c.Tuning = 0.0f;
-                }
+                c.PresetIndex = c.Bank           = 0;
+                c.PitchWheel  = c.MidiPan        = 8192;
+                c.MidiVolume  = c.MidiExpression = 16383;
+                c.MidiRpn     = 0xFFFF;
+                c.MidiData    = 0;
+                c.PanOffset   = 0.0f;
+                c.GainDb      = 0.0f;
+                c.PitchRange  = 2.0f;
+                c.Tuning      = 0.0f;
             }
         }
     }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/TinySoundFont.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/TinySoundFont.cs
@@ -42,1151 +42,1150 @@ using BardMusicPlayer.Siren.AlphaTab.Collections;
 
 // ReSharper disable UnusedMember.Global
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis;
+
+/// <summary>
+/// This is a tiny soundfont based synthesizer.
+/// </summary>
+/// <remarks>
+///    NOT YET IMPLEMENTED
+///    - Support for ChorusEffectsSend and ReverbEffectsSend generators
+///    - Better low-pass filter without lowering performance too much
+///    - Support for modulators
+/// </remarks>
+internal sealed partial class TinySoundFont
 {
+    private ulong _noteCounter;
+    private readonly List<Voice> _voices;
+    private Channels _channels;
+    private uint _voicePlayIndex;
+
+    internal float[] FontSamples { get; set; }
+
     /// <summary>
-    /// This is a tiny soundfont based synthesizer.
+    /// Returns the number of presets in the loaded SoundFont
     /// </summary>
-    /// <remarks>
-    ///    NOT YET IMPLEMENTED
-    ///    - Support for ChorusEffectsSend and ReverbEffectsSend generators
-    ///    - Better low-pass filter without lowering performance too much
-    ///    - Support for modulators
-    /// </remarks>
-    internal sealed partial class TinySoundFont
+    public int PresetCount => Presets.Count;
+
+    public List<Preset> Presets { get; private set; }
+
+    /// <summary>
+    /// Gets the currently configured output mode.
+    /// </summary>
+    /// <seealso cref="SetOutput"/>
+    public OutputMode OutputMode { get; private set; }
+
+    /// <summary>
+    /// Gets the currently configured sample rate.
+    /// </summary>
+    /// <seealso cref="SetOutput"/>
+    public float OutSampleRate { get; private set; }
+
+    /// <summary>
+    /// Gets the currently configured global gain in DB.
+    /// </summary>
+    public float GlobalGainDb { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <seealso cref="TinySoundFont"/> class.
+    /// </summary>
+    public TinySoundFont(float sampleRate)
     {
-        private ulong _noteCounter;
-        private readonly List<Voice> _voices;
-        private Channels _channels;
-        private uint _voicePlayIndex;
+        OutSampleRate = sampleRate;
+        OutputMode    = OutputMode.StereoInterleaved;
+        _voices       = new List<Voice>();
+    }
 
-        internal float[] FontSamples { get; set; }
-
-        /// <summary>
-        /// Returns the number of presets in the loaded SoundFont
-        /// </summary>
-        public int PresetCount => Presets.Count;
-
-        public List<Preset> Presets { get; private set; }
-
-        /// <summary>
-        /// Gets the currently configured output mode.
-        /// </summary>
-        /// <seealso cref="SetOutput"/>
-        public OutputMode OutputMode { get; private set; }
-
-        /// <summary>
-        /// Gets the currently configured sample rate.
-        /// </summary>
-        /// <seealso cref="SetOutput"/>
-        public float OutSampleRate { get; private set; }
-
-        /// <summary>
-        /// Gets the currently configured global gain in DB.
-        /// </summary>
-        public float GlobalGainDb { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <seealso cref="TinySoundFont"/> class.
-        /// </summary>
-        public TinySoundFont(float sampleRate)
+    /// <summary>
+    /// Stop all playing notes immediately and reset all channel parameters
+    /// </summary>
+    public void Reset()
+    {
+        foreach (var v in _voices.Where(v => v.PlayingPreset != -1 &&
+                                             (v.AmpEnv.Segment < VoiceEnvelopeSegment.Release || v.AmpEnv.Parameters.Release != 0)))
         {
-            OutSampleRate = sampleRate;
-            OutputMode = OutputMode.StereoInterleaved;
-            _voices = new List<Voice>();
+            v.EndQuick(OutSampleRate);
         }
 
-        /// <summary>
-        /// Stop all playing notes immediately and reset all channel parameters
-        /// </summary>
-        public void Reset()
-        {
-            foreach (var v in _voices.Where(v => v.PlayingPreset != -1 &&
-                                                 (v.AmpEnv.Segment < VoiceEnvelopeSegment.Release || v.AmpEnv.Parameters.Release != 0)))
-            {
-                v.EndQuick(OutSampleRate);
-            }
+        _channels = null;
+    }
 
-            _channels = null;
+    /// <summary>
+    /// Setup the parameters for the voice render methods
+    /// </summary>
+    /// <param name="outputMode">if mono or stereo and how stereo channel data is ordered</param>
+    /// <param name="sampleRate">the number of samples per second (output frequency)</param>
+    /// <param name="globalGainDb">volume gain in decibels (&gt;0 means higher, &lt;0 means lower)</param>
+    public void SetOutput(OutputMode outputMode, int sampleRate, float globalGainDb)
+    {
+        OutputMode    = outputMode;
+        OutSampleRate = sampleRate >= 1 ? sampleRate : 48000;
+        GlobalGainDb  = globalGainDb;
+    }
+
+    /// <summary>
+    /// Start playing a note
+    /// </summary>
+    /// <param name="presetIndex">preset index &gt;= 0 and &lt; <see cref="PresetCount"/></param>
+    /// <param name="key">note value between 0 and 127 (60 being middle C)</param>
+    /// <param name="vel">velocity as a float between 0.0 (equal to note off) and 1.0 (full)</param>
+    public void NoteOn(int presetIndex, int key, float vel)
+    {
+        var midiVelocity = (int)(vel * 127);
+
+        if (presetIndex < 0 || presetIndex >= Presets.Count)
+        {
+            return;
         }
 
-        /// <summary>
-        /// Setup the parameters for the voice render methods
-        /// </summary>
-        /// <param name="outputMode">if mono or stereo and how stereo channel data is ordered</param>
-        /// <param name="sampleRate">the number of samples per second (output frequency)</param>
-        /// <param name="globalGainDb">volume gain in decibels (&gt;0 means higher, &lt;0 means lower)</param>
-        public void SetOutput(OutputMode outputMode, int sampleRate, float globalGainDb)
+        if (vel <= 0.0f)
         {
-            OutputMode = outputMode;
-            OutSampleRate = sampleRate >= 1 ? sampleRate : 48000;
-            GlobalGainDb = globalGainDb;
+            NoteOff(presetIndex, key);
+            return;
         }
-
-        /// <summary>
-        /// Start playing a note
-        /// </summary>
-        /// <param name="presetIndex">preset index &gt;= 0 and &lt; <see cref="PresetCount"/></param>
-        /// <param name="key">note value between 0 and 127 (60 being middle C)</param>
-        /// <param name="vel">velocity as a float between 0.0 (equal to note off) and 1.0 (full)</param>
-        public void NoteOn(int presetIndex, int key, float vel)
-        {
-            var midiVelocity = (int)(vel * 127);
-
-            if (presetIndex < 0 || presetIndex >= Presets.Count)
-            {
-                return;
-            }
-
-            if (vel <= 0.0f)
-            {
-                NoteOff(presetIndex, key);
-                return;
-            }
             
-            if (BmpPigeonhole.Instance.EnableSynthVoiceLimiter && ActiveVoiceCount >= 16)
+        if (BmpPigeonhole.Instance.EnableSynthVoiceLimiter && ActiveVoiceCount >= 16)
+        {
+            var voice = _voices.First(a => a.Counter == _voices.Where(b => b.PlayingPreset != -1).Min(b => b.Counter));
+            voice.EndQuick(OutSampleRate);
+            voice.Stopped = true;
+        }
+
+        // Play all matching regions.
+        var voicePlayIndex = _voicePlayIndex++;
+        foreach (var region in Presets[presetIndex].Regions)
+        {
+            if (_noteCounter == ulong.MaxValue) _noteCounter = 0;
+            _noteCounter++;
+            if (key < region.LoKey || key > region.HiKey || midiVelocity < region.LoVel ||
+                midiVelocity > region.HiVel)
             {
-                var voice = _voices.First(a => a.Counter == _voices.Where(b => b.PlayingPreset != -1).Min(b => b.Counter));
-                voice.EndQuick(OutSampleRate);
-                voice.Stopped = true;
+                continue;
             }
 
-            // Play all matching regions.
-            var voicePlayIndex = _voicePlayIndex++;
-            foreach (var region in Presets[presetIndex].Regions)
+            Voice voice = null;
+            if (region.Group != 0)
             {
-                if (_noteCounter == ulong.MaxValue) _noteCounter = 0;
-                _noteCounter++;
-                if (key < region.LoKey || key > region.HiKey || midiVelocity < region.LoVel ||
-                    midiVelocity > region.HiVel)
+                foreach (var v in _voices)
                 {
-                    continue;
-                }
-
-                Voice voice = null;
-                if (region.Group != 0)
-                {
-                    foreach (var v in _voices)
+                    if (v.PlayingPreset == presetIndex && v.Region.Group == region.Group)
                     {
-                        if (v.PlayingPreset == presetIndex && v.Region.Group == region.Group)
-                        {
-                            v.EndQuick(OutSampleRate);
-                        }
-                        else if (v.PlayingPreset == -1 && voice == null)
-                        {
-                            voice = v;
-                        }
+                        v.EndQuick(OutSampleRate);
                     }
-                }
-                else
-                {
-                    foreach (var v in _voices.Where(v => v.PlayingPreset == -1))
+                    else if (v.PlayingPreset == -1 && voice == null)
                     {
                         voice = v;
                     }
                 }
-
-                if (voice == null)
-                {
-                    for (var i = 0; i < 4; i++)
-                    {
-                        var newVoice = new Voice
-                        {
-                            PlayingPreset = -1
-                        };
-                        _voices.Add(newVoice);
-                    }
-
-                    voice = _voices[_voices.Count - 4];
-                }
-
-                voice.Region = region;
-                voice.PlayingPreset = presetIndex;
-                voice.PlayingKey = key;
-                voice.PlayIndex = voicePlayIndex;
-                voice.NoteGainDb = GlobalGainDb - region.Attenuation - SynthHelper.GainToDecibels(1.0f / vel);
-
-                voice.Counter = _noteCounter;
-                voice.Stopped = false;
-
-                if (_channels != null)
-                {
-                    _channels.SetupVoice(this, voice);
-                }
-                else
-                {
-                    voice.CalcPitchRatio(0, OutSampleRate);
-                    // The SFZ spec is silent about the pan curve, but a 3dB pan law seems common. This sqrt() curve matches what Dimension LE does; Alchemy Free seems closer to sin(adjustedPan * pi/2).
-                    voice.PanFactorLeft = (float)Math.Sqrt(0.5f - region.Pan);
-                    voice.PanFactorRight = (float)Math.Sqrt(0.5f + region.Pan);
-                }
-
-                // Offset/end.
-                voice.SourceSamplePosition = region.Offset;
-
-                // Loop.
-                var doLoop = region.LoopMode != LoopMode.None && region.LoopStart < region.LoopEnd;
-                voice.LoopStart = doLoop ? region.LoopStart : 0;
-                voice.LoopEnd   = doLoop ? region.LoopEnd : 0;
-
-                // Setup envelopes.
-                voice.AmpEnv.Setup(region.AmpEnv, key, midiVelocity, true, OutSampleRate);
-                voice.ModEnv.Setup(region.ModEnv, key, midiVelocity, false, OutSampleRate);
-
-                // Setup lowpass filter.
-                var filterQDB = region.InitialFilterQ / 10.0f;
-                voice.LowPass.QInv   = 1.0 / Math.Pow(10.0, filterQDB / 20.0);
-                voice.LowPass.Z1     = voice.LowPass.Z2 = 0;
-                voice.LowPass.Active = region.InitialFilterFc <= 13500;
-                if (voice.LowPass.Active)
-                {
-                    voice.LowPass.Setup(SynthHelper.Cents2Hertz(region.InitialFilterFc) / OutSampleRate);
-                }
-
-                // Setup LFO filters.
-                voice.ModLfo.Setup(region.DelayModLFO, region.FreqModLFO, OutSampleRate);
-                voice.VibLfo.Setup(region.DelayVibLFO, region.FreqVibLFO, OutSampleRate);
-            }
-        }
-
-        /// <summary>
-        /// Start playing a note
-        /// </summary>
-        /// <param name="bank">instrument bank number (alternative to preset_index)</param>
-        /// <param name="presetNumber">preset number (alternative to preset_index)</param>
-        /// <param name="key">note value between 0 and 127 (60 being middle C)</param>
-        /// <param name="vel">velocity as a float between 0.0 (equal to note off) and 1.0 (full)</param>
-        /// <returns>returns false if preset does not exist, otherwise true</returns>
-        public bool BankNoteOn(int bank, int presetNumber, int key, float vel)
-        {
-            var presetIndex = GetPresetIndex(bank, presetNumber);
-            if (presetIndex == -1)
-            {
-                return false;
-            }
-
-            NoteOn(presetIndex, key, vel);
-            return true;
-        }
-
-        /// <summary>
-        /// Stop playing a note
-        /// </summary>
-        /// <param name="presetIndex"></param>
-        /// <param name="key"></param>
-        public void NoteOff(int presetIndex, int key)
-        {
-            Voice matchFirst = null;
-            Voice matchLast = null;
-            var matches = new FastList<Voice>();
-            foreach (var v in _voices)
-            {
-                if (v.PlayingPreset != presetIndex || v.PlayingKey != key ||
-                    v.AmpEnv.Segment >= VoiceEnvelopeSegment.Release)
-                {
-                }
-                else if (matchFirst == null || v.PlayIndex < matchFirst.PlayIndex)
-                {
-                    matchFirst = v;
-                    matchLast = v;
-                    matches.Add(v);
-                }
-                else if (v.PlayIndex == matchFirst.PlayIndex)
-                {
-                    matchLast = v;
-                    matches.Add(v);
-                }
-            }
-
-            if (matchFirst == null)
-            {
-                return;
-            }
-
-            foreach (var v in matches)
-            {
-                if (v != matchFirst && v != matchLast &&
-                    (v.PlayIndex != matchFirst.PlayIndex || v.PlayingPreset != presetIndex || v.PlayingKey != key ||
-                     v.AmpEnv.Segment >= VoiceEnvelopeSegment.Release))
-                {
-                    continue;
-                }
-
-                v.End(OutSampleRate);
-            }
-        }
-
-        /// <summary>
-        /// Stop playing a note
-        /// </summary>
-        /// <param name="bank"></param>
-        /// <param name="presetNumber"></param>
-        /// <param name="key"></param>
-        /// <returns>returns false if preset does not exist, otherwise true</returns>
-        public bool BankNoteOff(int bank, int presetNumber, int key)
-        {
-            var presetIndex = GetPresetIndex(bank, presetNumber);
-            if (presetIndex == -1)
-            {
-                return false;
-            }
-
-            NoteOff(presetIndex, key);
-            return true;
-        }
-
-        /// <summary>
-        /// Stop playing all notes (end with sustain and release)
-        /// </summary>
-        public void NoteOffAll(bool immediate)
-        {
-            foreach (var voice in _voices.Where(voice => voice.PlayingPreset != -1 && voice.AmpEnv.Segment < VoiceEnvelopeSegment.Release))
-            {
-                if (immediate)
-                {
-                    voice.EndQuick(OutSampleRate);
-                }
-                else
-                {
-                    voice.End(OutSampleRate);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Returns the number of active voices
-        /// </summary>
-        public int ActiveVoiceCount
-        {
-            get
-            {
-                return _voices.Count(v => v.PlayingPreset != -1 && v.Stopped != true);
-            }
-        }
-
-        private Channel ChannelInit(int channel)
-        {
-            if (_channels != null && channel < _channels.ChannelList.Count)
-            {
-                return _channels.ChannelList[channel];
-            }
-
-            _channels ??= new Channels();
-
-            for (var i = _channels.ChannelList.Count; i <= channel; i++)
-            {
-                var c = new Channel();
-                c.PresetIndex = c.Bank = 0;
-                c.PitchWheel = c.MidiPan = 8192;
-                c.MidiVolume = c.MidiExpression = 16383;
-                c.MidiRpn = 0xFFFF;
-                c.MidiData = 0;
-                c.PanOffset = 0.0f;
-                c.GainDb = 0.0f;
-                c.PitchRange = 2.0f;
-                c.Tuning = 0.0f;
-                c.MixVolume = 1;
-                _channels.ChannelList.Add(c);
-            }
-
-            return _channels.ChannelList[channel];
-        }
-
-        /// <summary>
-        /// Returns the preset index from a bank and preset number, or -1 if it does not exist in the loaded SoundFont
-        /// </summary>
-        /// <param name="bank"></param>
-        /// <param name="presetNumber"></param>
-        /// <returns></returns>
-        private int GetPresetIndex(int bank, int presetNumber)
-        {
-            for (var i = 0; i < Presets.Count; i++)
-            {
-                var preset = Presets[i];
-                if (preset.PresetNumber == presetNumber && preset.Bank == bank)
-                {
-                    return i;
-                }
-            }
-
-            return -1;
-        }
-
-        /// <summary>
-        /// Returns the name of a preset index &gt;= 0 and &lt; GetPresetName()
-        /// </summary>
-        /// <param name="presetIndex"></param>
-        /// <returns></returns>
-        public string GetPresetName(int presetIndex)
-        {
-            return presetIndex < 0 || presetIndex >= Presets.Count ? null : Presets[presetIndex].Name;
-        }
-
-        /// <summary>
-        /// Returns the name of a preset by bank and preset number
-        /// </summary>
-        /// <param name="bank"></param>
-        /// <param name="presetNumber"></param>
-        /// <returns></returns>
-        public string BankGetPresetName(int bank, int presetNumber)
-        {
-            return GetPresetName(GetPresetIndex(bank, presetNumber));
-        }
-
-        #region Higher level channel based functions
-
-        /// <summary>
-        /// Start playing a note on a channel
-        /// </summary>
-        /// <param name="channel">channel number</param>
-        /// <param name="key">note value between 0 and 127 (60 being middle C)</param>
-        /// <param name="vel">velocity as a float between 0.0 (equal to note off) and 1.0 (full)</param>
-        public void ChannelNoteOn(int channel, int key, float vel)
-        {
-            if (_channels == null || channel > _channels.ChannelList.Count)
-            {
-                return;
-            }
-
-            _channels.ActiveChannel = channel;
-            NoteOn(_channels.ChannelList[channel].PresetIndex, key, vel);
-        }
-
-        /// <summary>
-        /// Stop playing notes on a channel
-        /// </summary>
-        /// <param name="channel">channel number</param>
-        /// <param name="key">note value between 0 and 127 (60 being middle C)</param>
-        public void ChannelNoteOff(int channel, int key)
-        {
-            var matches = new FastList<Voice>();
-            Voice matchFirst = null;
-            Voice matchLast = null;
-            foreach (var v in _voices.Where(v => v.PlayingPreset != -1 && v.PlayingChannel == channel && v.PlayingKey == key &&
-                                                 v.AmpEnv.Segment < VoiceEnvelopeSegment.Release))
-            {
-                if (matchFirst == null || v.PlayIndex < matchFirst.PlayIndex)
-                {
-                    matchFirst = matchLast = v;
-                    matches.Add(v);
-                }
-                else if (v.PlayIndex == matchFirst.PlayIndex)
-                {
-                    matchLast = v;
-                    matches.Add(v);
-                }
-            }
-
-            if (matchFirst == null)
-            {
-                return;
-            }
-
-            foreach (var v in matches)
-            {
-                //Stop all voices with matching channel, key and the smallest play index which was enumerated above
-                if (v != matchFirst && v != matchLast &&
-                    (v.PlayIndex != matchFirst.PlayIndex || v.PlayingPreset == -1 || v.PlayingChannel != channel ||
-                     v.PlayingKey != key || v.AmpEnv.Segment >= VoiceEnvelopeSegment.Release))
-                {
-                    continue;
-                }
-
-                v.End(OutSampleRate);
-            }
-        }
-
-        /// <summary>
-        /// Stop playing all notes on a channel with sustain and release.
-        /// </summary>
-        /// <param name="channel">channel number</param>
-        public void ChannelNoteOffAll(int channel)
-        {
-            foreach (var v in _voices.Where(v => v.PlayingPreset != -1 && v.PlayingChannel == channel &&
-                                                 v.AmpEnv.Segment < VoiceEnvelopeSegment.Release))
-            {
-                v.End(OutSampleRate);
-            }
-        }
-
-        /// <summary>
-        /// Stop playing all notes on a channel immediately
-        /// </summary>
-        /// <param name="channel">channel number</param>
-        public void ChannelSoundsOffAll(int channel)
-        {
-            foreach (var v in _voices.Where(v => v.PlayingPreset != -1 && v.PlayingChannel == channel &&
-                                                 (v.AmpEnv.Segment < VoiceEnvelopeSegment.Release || v.AmpEnv.Parameters.Release == 0)))
-            {
-                v.EndQuick(OutSampleRate);
-            }
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="channel">channel number</param>
-        /// <param name="presetIndex">preset index &gt;= 0 and &lt; <see cref="PresetCount"/></param>
-        public void ChannelSetPresetIndex(int channel, int presetIndex)
-        {
-            ChannelInit(channel).PresetIndex = (ushort)presetIndex;
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="channel">channel number</param>
-        /// <param name="presetNumber">preset number (alternative to preset_index)</param>
-        /// <param name="midiDrums">false for normal channels, otherwise apply MIDI drum channel rules</param>
-        /// <returns>return false if preset does not exist, otherwise true</returns>
-        public bool ChannelSetPresetNumber(int channel, int presetNumber, bool midiDrums = false)
-        {
-            var c = ChannelInit(channel);
-            int presetIndex;
-            if (midiDrums)
-            {
-                presetIndex = GetPresetIndex(128 | (c.Bank & 0x7FFF), presetNumber);
-                if (presetIndex == -1)
-                {
-                    presetIndex = GetPresetIndex(128, presetNumber);
-                }
-
-                if (presetIndex == -1)
-                {
-                    presetIndex = GetPresetIndex(128, 0);
-                }
-
-                if (presetIndex == -1)
-                {
-                    presetIndex = GetPresetIndex(c.Bank & 0x7FF, presetNumber);
-                }
             }
             else
             {
-                presetIndex = GetPresetIndex(c.Bank & 0x7FF, presetNumber);
+                foreach (var v in _voices.Where(v => v.PlayingPreset == -1))
+                {
+                    voice = v;
+                }
             }
 
-            if (presetIndex == -1)
+            if (voice == null)
             {
-                presetIndex = GetPresetIndex(0, presetNumber);
+                for (var i = 0; i < 4; i++)
+                {
+                    var newVoice = new Voice
+                    {
+                        PlayingPreset = -1
+                    };
+                    _voices.Add(newVoice);
+                }
+
+                voice = _voices[_voices.Count - 4];
             }
 
-            if (presetIndex != -1)
+            voice.Region        = region;
+            voice.PlayingPreset = presetIndex;
+            voice.PlayingKey    = key;
+            voice.PlayIndex     = voicePlayIndex;
+            voice.NoteGainDb    = GlobalGainDb - region.Attenuation - SynthHelper.GainToDecibels(1.0f / vel);
+
+            voice.Counter = _noteCounter;
+            voice.Stopped = false;
+
+            if (_channels != null)
             {
-                c.PresetIndex = (ushort)presetIndex;
-                return true;
+                _channels.SetupVoice(this, voice);
+            }
+            else
+            {
+                voice.CalcPitchRatio(0, OutSampleRate);
+                // The SFZ spec is silent about the pan curve, but a 3dB pan law seems common. This sqrt() curve matches what Dimension LE does; Alchemy Free seems closer to sin(adjustedPan * pi/2).
+                voice.PanFactorLeft  = (float)Math.Sqrt(0.5f - region.Pan);
+                voice.PanFactorRight = (float)Math.Sqrt(0.5f + region.Pan);
             }
 
+            // Offset/end.
+            voice.SourceSamplePosition = region.Offset;
+
+            // Loop.
+            var doLoop = region.LoopMode != LoopMode.None && region.LoopStart < region.LoopEnd;
+            voice.LoopStart = doLoop ? region.LoopStart : 0;
+            voice.LoopEnd   = doLoop ? region.LoopEnd : 0;
+
+            // Setup envelopes.
+            voice.AmpEnv.Setup(region.AmpEnv, key, midiVelocity, true, OutSampleRate);
+            voice.ModEnv.Setup(region.ModEnv, key, midiVelocity, false, OutSampleRate);
+
+            // Setup lowpass filter.
+            var filterQDB = region.InitialFilterQ / 10.0f;
+            voice.LowPass.QInv   = 1.0 / Math.Pow(10.0, filterQDB / 20.0);
+            voice.LowPass.Z1     = voice.LowPass.Z2 = 0;
+            voice.LowPass.Active = region.InitialFilterFc <= 13500;
+            if (voice.LowPass.Active)
+            {
+                voice.LowPass.Setup(SynthHelper.Cents2Hertz(region.InitialFilterFc) / OutSampleRate);
+            }
+
+            // Setup LFO filters.
+            voice.ModLfo.Setup(region.DelayModLFO, region.FreqModLFO, OutSampleRate);
+            voice.VibLfo.Setup(region.DelayVibLFO, region.FreqVibLFO, OutSampleRate);
+        }
+    }
+
+    /// <summary>
+    /// Start playing a note
+    /// </summary>
+    /// <param name="bank">instrument bank number (alternative to preset_index)</param>
+    /// <param name="presetNumber">preset number (alternative to preset_index)</param>
+    /// <param name="key">note value between 0 and 127 (60 being middle C)</param>
+    /// <param name="vel">velocity as a float between 0.0 (equal to note off) and 1.0 (full)</param>
+    /// <returns>returns false if preset does not exist, otherwise true</returns>
+    public bool BankNoteOn(int bank, int presetNumber, int key, float vel)
+    {
+        var presetIndex = GetPresetIndex(bank, presetNumber);
+        if (presetIndex == -1)
+        {
             return false;
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="channel">channel number</param>
-        /// <param name="bank">instrument bank number (alternative to preset_index)</param>
-        public void ChannelSetBank(int channel, int bank)
+        NoteOn(presetIndex, key, vel);
+        return true;
+    }
+
+    /// <summary>
+    /// Stop playing a note
+    /// </summary>
+    /// <param name="presetIndex"></param>
+    /// <param name="key"></param>
+    public void NoteOff(int presetIndex, int key)
+    {
+        Voice matchFirst = null;
+        Voice matchLast = null;
+        var matches = new FastList<Voice>();
+        foreach (var v in _voices)
         {
-            ChannelInit(channel).Bank = (ushort)bank;
+            if (v.PlayingPreset != presetIndex || v.PlayingKey != key ||
+                v.AmpEnv.Segment >= VoiceEnvelopeSegment.Release)
+            {
+            }
+            else if (matchFirst == null || v.PlayIndex < matchFirst.PlayIndex)
+            {
+                matchFirst = v;
+                matchLast  = v;
+                matches.Add(v);
+            }
+            else if (v.PlayIndex == matchFirst.PlayIndex)
+            {
+                matchLast = v;
+                matches.Add(v);
+            }
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="channel">channel number</param>
-        /// <param name="bank">instrument bank number (alternative to preset_index)</param>
-        /// <param name="presetNumber">preset number (alternative to preset_index)</param>
-        /// <returns>return false if preset does not exist, otherwise true</returns>
-        public bool ChannelSetBankPreset(int channel, int bank, int presetNumber)
+        if (matchFirst == null)
         {
-            var c = ChannelInit(channel);
-            var presetIndex = GetPresetIndex(bank, presetNumber);
-            if (presetIndex == -1)
+            return;
+        }
+
+        foreach (var v in matches)
+        {
+            if (v != matchFirst && v != matchLast &&
+                (v.PlayIndex != matchFirst.PlayIndex || v.PlayingPreset != presetIndex || v.PlayingKey != key ||
+                 v.AmpEnv.Segment >= VoiceEnvelopeSegment.Release))
             {
-                return false;
+                continue;
             }
 
+            v.End(OutSampleRate);
+        }
+    }
+
+    /// <summary>
+    /// Stop playing a note
+    /// </summary>
+    /// <param name="bank"></param>
+    /// <param name="presetNumber"></param>
+    /// <param name="key"></param>
+    /// <returns>returns false if preset does not exist, otherwise true</returns>
+    public bool BankNoteOff(int bank, int presetNumber, int key)
+    {
+        var presetIndex = GetPresetIndex(bank, presetNumber);
+        if (presetIndex == -1)
+        {
+            return false;
+        }
+
+        NoteOff(presetIndex, key);
+        return true;
+    }
+
+    /// <summary>
+    /// Stop playing all notes (end with sustain and release)
+    /// </summary>
+    public void NoteOffAll(bool immediate)
+    {
+        foreach (var voice in _voices.Where(voice => voice.PlayingPreset != -1 && voice.AmpEnv.Segment < VoiceEnvelopeSegment.Release))
+        {
+            if (immediate)
+            {
+                voice.EndQuick(OutSampleRate);
+            }
+            else
+            {
+                voice.End(OutSampleRate);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns the number of active voices
+    /// </summary>
+    public int ActiveVoiceCount
+    {
+        get
+        {
+            return _voices.Count(v => v.PlayingPreset != -1 && v.Stopped != true);
+        }
+    }
+
+    private Channel ChannelInit(int channel)
+    {
+        if (_channels != null && channel < _channels.ChannelList.Count)
+        {
+            return _channels.ChannelList[channel];
+        }
+
+        _channels ??= new Channels();
+
+        for (var i = _channels.ChannelList.Count; i <= channel; i++)
+        {
+            var c = new Channel();
+            c.PresetIndex = c.Bank           = 0;
+            c.PitchWheel  = c.MidiPan        = 8192;
+            c.MidiVolume  = c.MidiExpression = 16383;
+            c.MidiRpn     = 0xFFFF;
+            c.MidiData    = 0;
+            c.PanOffset   = 0.0f;
+            c.GainDb      = 0.0f;
+            c.PitchRange  = 2.0f;
+            c.Tuning      = 0.0f;
+            c.MixVolume   = 1;
+            _channels.ChannelList.Add(c);
+        }
+
+        return _channels.ChannelList[channel];
+    }
+
+    /// <summary>
+    /// Returns the preset index from a bank and preset number, or -1 if it does not exist in the loaded SoundFont
+    /// </summary>
+    /// <param name="bank"></param>
+    /// <param name="presetNumber"></param>
+    /// <returns></returns>
+    private int GetPresetIndex(int bank, int presetNumber)
+    {
+        for (var i = 0; i < Presets.Count; i++)
+        {
+            var preset = Presets[i];
+            if (preset.PresetNumber == presetNumber && preset.Bank == bank)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Returns the name of a preset index &gt;= 0 and &lt; GetPresetName()
+    /// </summary>
+    /// <param name="presetIndex"></param>
+    /// <returns></returns>
+    public string GetPresetName(int presetIndex)
+    {
+        return presetIndex < 0 || presetIndex >= Presets.Count ? null : Presets[presetIndex].Name;
+    }
+
+    /// <summary>
+    /// Returns the name of a preset by bank and preset number
+    /// </summary>
+    /// <param name="bank"></param>
+    /// <param name="presetNumber"></param>
+    /// <returns></returns>
+    public string BankGetPresetName(int bank, int presetNumber)
+    {
+        return GetPresetName(GetPresetIndex(bank, presetNumber));
+    }
+
+    #region Higher level channel based functions
+
+    /// <summary>
+    /// Start playing a note on a channel
+    /// </summary>
+    /// <param name="channel">channel number</param>
+    /// <param name="key">note value between 0 and 127 (60 being middle C)</param>
+    /// <param name="vel">velocity as a float between 0.0 (equal to note off) and 1.0 (full)</param>
+    public void ChannelNoteOn(int channel, int key, float vel)
+    {
+        if (_channels == null || channel > _channels.ChannelList.Count)
+        {
+            return;
+        }
+
+        _channels.ActiveChannel = channel;
+        NoteOn(_channels.ChannelList[channel].PresetIndex, key, vel);
+    }
+
+    /// <summary>
+    /// Stop playing notes on a channel
+    /// </summary>
+    /// <param name="channel">channel number</param>
+    /// <param name="key">note value between 0 and 127 (60 being middle C)</param>
+    public void ChannelNoteOff(int channel, int key)
+    {
+        var matches = new FastList<Voice>();
+        Voice matchFirst = null;
+        Voice matchLast = null;
+        foreach (var v in _voices.Where(v => v.PlayingPreset != -1 && v.PlayingChannel == channel && v.PlayingKey == key &&
+                                             v.AmpEnv.Segment < VoiceEnvelopeSegment.Release))
+        {
+            if (matchFirst == null || v.PlayIndex < matchFirst.PlayIndex)
+            {
+                matchFirst = matchLast = v;
+                matches.Add(v);
+            }
+            else if (v.PlayIndex == matchFirst.PlayIndex)
+            {
+                matchLast = v;
+                matches.Add(v);
+            }
+        }
+
+        if (matchFirst == null)
+        {
+            return;
+        }
+
+        foreach (var v in matches)
+        {
+            //Stop all voices with matching channel, key and the smallest play index which was enumerated above
+            if (v != matchFirst && v != matchLast &&
+                (v.PlayIndex != matchFirst.PlayIndex || v.PlayingPreset == -1 || v.PlayingChannel != channel ||
+                 v.PlayingKey != key || v.AmpEnv.Segment >= VoiceEnvelopeSegment.Release))
+            {
+                continue;
+            }
+
+            v.End(OutSampleRate);
+        }
+    }
+
+    /// <summary>
+    /// Stop playing all notes on a channel with sustain and release.
+    /// </summary>
+    /// <param name="channel">channel number</param>
+    public void ChannelNoteOffAll(int channel)
+    {
+        foreach (var v in _voices.Where(v => v.PlayingPreset != -1 && v.PlayingChannel == channel &&
+                                             v.AmpEnv.Segment < VoiceEnvelopeSegment.Release))
+        {
+            v.End(OutSampleRate);
+        }
+    }
+
+    /// <summary>
+    /// Stop playing all notes on a channel immediately
+    /// </summary>
+    /// <param name="channel">channel number</param>
+    public void ChannelSoundsOffAll(int channel)
+    {
+        foreach (var v in _voices.Where(v => v.PlayingPreset != -1 && v.PlayingChannel == channel &&
+                                             (v.AmpEnv.Segment < VoiceEnvelopeSegment.Release || v.AmpEnv.Parameters.Release == 0)))
+        {
+            v.EndQuick(OutSampleRate);
+        }
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="channel">channel number</param>
+    /// <param name="presetIndex">preset index &gt;= 0 and &lt; <see cref="PresetCount"/></param>
+    public void ChannelSetPresetIndex(int channel, int presetIndex)
+    {
+        ChannelInit(channel).PresetIndex = (ushort)presetIndex;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="channel">channel number</param>
+    /// <param name="presetNumber">preset number (alternative to preset_index)</param>
+    /// <param name="midiDrums">false for normal channels, otherwise apply MIDI drum channel rules</param>
+    /// <returns>return false if preset does not exist, otherwise true</returns>
+    public bool ChannelSetPresetNumber(int channel, int presetNumber, bool midiDrums = false)
+    {
+        var c = ChannelInit(channel);
+        int presetIndex;
+        if (midiDrums)
+        {
+            presetIndex = GetPresetIndex(128 | (c.Bank & 0x7FFF), presetNumber);
+            if (presetIndex == -1)
+            {
+                presetIndex = GetPresetIndex(128, presetNumber);
+            }
+
+            if (presetIndex == -1)
+            {
+                presetIndex = GetPresetIndex(128, 0);
+            }
+
+            if (presetIndex == -1)
+            {
+                presetIndex = GetPresetIndex(c.Bank & 0x7FF, presetNumber);
+            }
+        }
+        else
+        {
+            presetIndex = GetPresetIndex(c.Bank & 0x7FF, presetNumber);
+        }
+
+        if (presetIndex == -1)
+        {
+            presetIndex = GetPresetIndex(0, presetNumber);
+        }
+
+        if (presetIndex != -1)
+        {
             c.PresetIndex = (ushort)presetIndex;
-            c.Bank = (ushort)bank;
             return true;
         }
 
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="channel">channel number</param>
-        /// <param name="pan">stereo panning value from 0.0 (left) to 1.0 (right) (default 0.5 center)</param>
-        public void ChannelSetPan(int channel, float pan)
+        return false;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="channel">channel number</param>
+    /// <param name="bank">instrument bank number (alternative to preset_index)</param>
+    public void ChannelSetBank(int channel, int bank)
+    {
+        ChannelInit(channel).Bank = (ushort)bank;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="channel">channel number</param>
+    /// <param name="bank">instrument bank number (alternative to preset_index)</param>
+    /// <param name="presetNumber">preset number (alternative to preset_index)</param>
+    /// <returns>return false if preset does not exist, otherwise true</returns>
+    public bool ChannelSetBankPreset(int channel, int bank, int presetNumber)
+    {
+        var c = ChannelInit(channel);
+        var presetIndex = GetPresetIndex(bank, presetNumber);
+        if (presetIndex == -1)
         {
-            foreach (var v in _voices)
+            return false;
+        }
+
+        c.PresetIndex = (ushort)presetIndex;
+        c.Bank        = (ushort)bank;
+        return true;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="channel">channel number</param>
+    /// <param name="pan">stereo panning value from 0.0 (left) to 1.0 (right) (default 0.5 center)</param>
+    public void ChannelSetPan(int channel, float pan)
+    {
+        foreach (var v in _voices)
+        {
+            if (v.PlayingChannel == channel && v.PlayingPreset != -1)
             {
-                if (v.PlayingChannel == channel && v.PlayingPreset != -1)
+                var newPan = v.Region.Pan + pan - 0.5f;
+                switch (newPan)
                 {
-                    var newPan = v.Region.Pan + pan - 0.5f;
-                    switch (newPan)
+                    case <= -0.5f:
+                        v.PanFactorLeft  = 1;
+                        v.PanFactorRight = 0;
+                        break;
+                    case >= 0.5f:
+                        v.PanFactorLeft  = 0;
+                        v.PanFactorRight = 1;
+                        break;
+                    default:
+                        v.PanFactorLeft  = (float)Math.Sqrt(0.5f - newPan);
+                        v.PanFactorRight = (float)Math.Sqrt(0.5f + newPan);
+                        break;
+                }
+            }
+        }
+
+        ChannelInit(channel).PanOffset = pan - 0.5f;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="channel">channel number</param>
+    /// <param name="volume">linear volume scale factor (default 1.0 full)</param>
+    public void ChannelSetVolume(int channel, float volume)
+    {
+        var c = ChannelInit(channel);
+        var gainDb = SynthHelper.GainToDecibels(volume);
+        var gainDBChange = gainDb - c.GainDb;
+        if (gainDBChange == 0)
+        {
+            return;
+        }
+
+        foreach (var v in _voices.Where(v => v.PlayingChannel == channel && v.PlayingPreset != -1))
+        {
+            v.NoteGainDb += gainDBChange;
+        }
+
+        c.GainDb = gainDb;
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="channel">channel number</param>
+    /// <param name="pitchWheel">pitch wheel position 0 to 16383 (default 8192 unpitched)</param>
+    public void ChannelSetPitchWheel(int channel, int pitchWheel)
+    {
+        var c = ChannelInit(channel);
+        if (c.PitchWheel == pitchWheel)
+        {
+            return;
+        }
+
+        c.PitchWheel = (ushort)pitchWheel;
+        ChannelApplyPitch(channel, c);
+    }
+
+    private void ChannelApplyPitch(int channel, Channel c)
+    {
+        var pitchShift = c.PitchWheel == 8192
+            ? c.Tuning
+            : c.PitchWheel / 16383.0f * c.PitchRange * 2f - c.PitchRange + c.Tuning;
+        foreach (var v in _voices.Where(v => v.PlayingChannel == channel && v.PlayingPreset != -1))
+        {
+            v.CalcPitchRatio(pitchShift, OutSampleRate);
+        }
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="channel">channel number</param>
+    /// <param name="pitchRange">range of the pitch wheel in semitones (default 2.0, total +/- 2 semitones)</param>
+    public void ChannelSetPitchRange(int channel, float pitchRange)
+    {
+        var c = ChannelInit(channel);
+        if (c.PitchRange == pitchRange)
+        {
+            return;
+        }
+
+        c.PitchRange = pitchRange;
+        if (c.PitchWheel != 8192)
+        {
+            ChannelApplyPitch(channel, c);
+        }
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="channel">channel number</param>
+    /// <param name="tuning">tuning of all playing voices in semitones (default 0.0, standard (A440) tuning)</param>
+    public void ChannelSetTuning(int channel, float tuning)
+    {
+        var c = ChannelInit(channel);
+        if (c.Tuning == tuning)
+        {
+            return;
+        }
+
+        c.Tuning = tuning;
+        ChannelApplyPitch(channel, c);
+    }
+
+    /// <summary>
+    /// Apply a MIDI control change to the channel (not all controllers are supported!)
+    /// </summary>
+    /// <param name="channel"></param>
+    /// <param name="controller"></param>
+    /// <param name="controlValue"></param>
+    public void ChannelMidiControl(int channel, int controller, int controlValue)
+    {
+        var c = ChannelInit(channel);
+        switch (controller)
+        {
+            case 5:   /*Portamento_Time_MSB*/
+            case 96:  /*DATA_BUTTON_INCREMENT*/
+            case 97:  /*DATA_BUTTON_DECREMENT*/
+            case 64:  /*HOLD_PEDAL*/
+            case 65:  /*Portamento*/
+            case 66:  /*SostenutoPedal */
+            case 122: /*LocalKeyboard */
+            case 124: /*OmniModeOff */
+            case 125: /*OmniModeon */
+            case 126: /*MonoMode */
+            case 127: /*PolyMode*/
+                return;
+
+            case 38 /*DATA_ENTRY_LSB*/:
+                c.MidiData = (ushort)((c.MidiData & 0x3F80) | controlValue);
+                switch (c.MidiRpn)
+                {
+                    case 0:
+                        ChannelSetPitchRange(channel, (c.MidiData >> 7) + 0.01f * (c.MidiData & 0x7F));
+                        break;
+                    case 1:
+                        ChannelSetTuning(channel, (int)c.Tuning + (c.MidiData - 8192.0f) / 8192.0f); //fine tune
+                        break;
+                    case 2:
+                        ChannelSetTuning(channel, controlValue - 64.0f + (c.Tuning - (int)c.Tuning)); //coarse tune
+                        break;
+                }
+
+                return;
+
+            case 7 /*VOLUME_MSB*/:
+                c.MidiVolume = (ushort)((c.MidiVolume & 0x7F) | (controlValue << 7));
+                //Raising to the power of 3 seems to result in a decent sounding volume curve for MIDI
+                ChannelSetVolume(channel,
+                    (float)Math.Pow(c.MidiVolume / 16383.0f * (c.MidiExpression / 16383.0f), 3.0f));
+                return;
+            case 39 /*VOLUME_LSB*/:
+                c.MidiVolume = (ushort)((c.MidiVolume & 0x3F80) | controlValue);
+                //Raising to the power of 3 seems to result in a decent sounding volume curve for MIDI
+                ChannelSetVolume(channel,
+                    (float)Math.Pow(c.MidiVolume / 16383.0f * (c.MidiExpression / 16383.0f), 3.0f));
+                return;
+            case 11 /*EXPRESSION_MSB*/:
+                c.MidiExpression = (ushort)((c.MidiExpression & 0x7F) | (controlValue << 7));
+                //Raising to the power of 3 seems to result in a decent sounding volume curve for MIDI
+                ChannelSetVolume(channel,
+                    (float)Math.Pow(c.MidiVolume / 16383.0f * (c.MidiExpression / 16383.0f), 3.0f));
+                return;
+            case 43 /*EXPRESSION_LSB*/:
+                c.MidiExpression = (ushort)((c.MidiExpression & 0x3F80) | controlValue);
+                //Raising to the power of 3 seems to result in a decent sounding volume curve for MIDI
+                ChannelSetVolume(channel,
+                    (float)Math.Pow(c.MidiVolume / 16383.0f * (c.MidiExpression / 16383.0f), 3.0f));
+                return;
+            case 10 /*PAN_MSB*/:
+                c.MidiPan = (ushort)((c.MidiPan & 0x7F) | (controlValue << 7));
+                ChannelSetPan(channel, c.MidiPan / 16383.0f);
+                return;
+            case 42 /*PAN_LSB*/:
+                c.MidiPan = (ushort)((c.MidiPan & 0x3F80) | controlValue);
+                ChannelSetPan(channel, c.MidiPan / 16383.0f);
+                return;
+            case 6 /*DATA_ENTRY_MSB*/:
+                c.MidiData = (ushort)((c.MidiData & 0x7F) | (controlValue << 7));
+                switch (c.MidiRpn)
+                {
+                    case 0:
+                        ChannelSetPitchRange(channel, (c.MidiData >> 7) + 0.01f * (c.MidiData & 0x7F));
+                        break;
+                    case 1:
+                        ChannelSetTuning(channel, (int)c.Tuning + (c.MidiData - 8192.0f) / 8192.0f); //fine tune
+                        break;
+                    case 2:
+                        ChannelSetTuning(channel, controlValue - 64.0f + (c.Tuning - (int)c.Tuning)); //coarse tune
+                        break;
+                }
+
+                return;
+            case 0 /*BANK_SELECT_MSB*/:
+                c.Bank = (ushort)(0x8000 | controlValue);
+                return; //bank select MSB alone acts like LSB
+            case 32 /*BANK_SELECT_LSB*/:
+                c.Bank = (ushort)(((c.Bank & 0x8000) != 0 ? (c.Bank & 0x7F) << 7 : 0) | controlValue);
+                return;
+            case 101 /*RPN_MSB*/:
+                c.MidiRpn = (ushort)(((c.MidiRpn == 0xFFFF ? 0 : c.MidiRpn) & 0x7F) | (controlValue << 7));
+                // TODO
+                return;
+            case 100 /*RPN_LSB*/:
+                c.MidiRpn = (ushort)(((c.MidiRpn == 0xFFFF ? 0 : c.MidiRpn) & 0x3F80) | controlValue);
+                // TODO
+                return;
+            case 98 /*NRPN_LSB*/:
+                c.MidiRpn = 0xFFFF;
+                // TODO
+                return;
+            case 99 /*NRPN_MSB*/:
+                c.MidiRpn = 0xFFFF;
+                // TODO
+                return;
+            case 120 /*ALL_SOUND_OFF*/:
+                ChannelSoundsOffAll(channel);
+                return;
+            case 123 /*ALL_NOTES_OFF*/:
+                ChannelNoteOffAll(channel);
+                return;
+            case 121 /*ALL_CTRL_OFF*/:
+                c.MidiVolume = c.MidiExpression = 16383;
+                c.MidiPan    = 8192;
+                c.Bank       = 0;
+                ChannelSetVolume(channel, 1);
+                ChannelSetPan(channel, 0.5f);
+                ChannelSetPitchRange(channel, 2);
+                // TODO
+                return;
+        }
+    }
+
+    /// <summary>
+    /// Gets the current preset index of the given channel.
+    /// </summary>
+    /// <param name="channel">The channel index</param>
+    /// <returns>The current preset index of the given channel.</returns>
+    public int ChannelGetPresetIndex(int channel)
+    {
+        return _channels != null && channel < _channels.ChannelList.Count
+            ? _channels.ChannelList[channel].PresetIndex
+            : 0;
+    }
+
+    /// <summary>
+    /// Gets the current bank of the given channel.
+    /// </summary>
+    /// <param name="channel">The channel index</param>
+    /// <returns>The current bank of the given channel.</returns>
+    public int ChannelGetPresetBank(int channel)
+    {
+        return _channels != null && channel < _channels.ChannelList.Count
+            ? _channels.ChannelList[channel].Bank & 0x7FFF
+            : 0;
+    }
+
+    /// <summary>
+    /// Gets the current pan of the given channel.
+    /// </summary>
+    /// <param name="channel">The channel index</param>
+    /// <returns>The current pan of the given channel.</returns>
+    public float ChannelGetPan(int channel)
+    {
+        return _channels != null && channel < _channels.ChannelList.Count
+            ? _channels.ChannelList[channel].PanOffset - 0.5f
+            : 0.5f;
+    }
+
+    /// <summary>
+    /// Gets the current volume of the given channel.
+    /// </summary>
+    /// <param name="channel">The channel index</param>
+    /// <returns>The current volune of the given channel.</returns>
+    public float ChannelGetVolume(int channel)
+    {
+        return _channels != null && channel < _channels.ChannelList.Count
+            ? SynthHelper.DecibelsToGain(_channels.ChannelList[channel].GainDb)
+            : 1.0f;
+    }
+
+    /// <summary>
+    /// Gets the current pitch wheel of the given channel.
+    /// </summary>
+    /// <param name="channel">The channel index</param>
+    /// <returns>The current pitch wheel of the given channel.</returns>
+    public int ChannelGetPitchWheel(int channel)
+    {
+        return _channels != null && channel < _channels.ChannelList.Count
+            ? _channels.ChannelList[channel].PitchWheel
+            : 8192;
+    }
+
+    /// <summary>
+    /// Gets the current pitch range of the given channel.
+    /// </summary>
+    /// <param name="channel">The channel index</param>
+    /// <returns>The current pitch range of the given channel.</returns>
+    public float ChannelGetPitchRange(int channel)
+    {
+        return _channels != null && channel < _channels.ChannelList.Count
+            ? _channels.ChannelList[channel].PitchRange
+            : 2.0f;
+    }
+
+    /// <summary>
+    /// Gets the current tuning of the given channel.
+    /// </summary>
+    /// <param name="channel">The channel index</param>
+    /// <returns>The current tuning of the given channel.</returns>
+    public float ChannelGetTuning(int channel)
+    {
+        return _channels != null && channel < _channels.ChannelList.Count
+            ? _channels.ChannelList[channel].Tuning
+            : 0.0f;
+    }
+
+    #endregion
+
+    #region Loading
+
+    public void LoadPresets(Hydra hydra, bool append)
+    {
+        List<Preset> newPresets = new (new Preset[hydra.Phdrs.Count - 1]);
+        for (double phdrIndex = 0;phdrIndex < hydra.Phdrs.Count - 1;phdrIndex++)
+        {
+            var phdr = hydra.Phdrs[(int)phdrIndex];
+            double regionIndex = 0;
+            var preset = newPresets[(int)phdrIndex] = new Preset();
+            preset.Name         = phdr.PresetName;
+            preset.Bank         = phdr.Bank;
+            preset.PresetNumber = phdr.Preset;
+            preset.FontSamples  = hydra.FontSamples;
+            double regionNum = 0;
+            for (double pbagIndex = phdr.PresetBagNdx;pbagIndex < hydra.Phdrs[(int)(phdrIndex + 1)].PresetBagNdx;pbagIndex++)
+            {
+                var pbag = hydra.Pbags[(int)pbagIndex];
+                double plokey = 0;
+                double phikey = 127;
+                double plovel = 0;
+                double phivel = 127;
+                for (double pgenIndex = pbag.GenNdx;pgenIndex < hydra.Pbags[(int)(pbagIndex + 1)].GenNdx;pgenIndex++)
+                {
+                    var pgen = hydra.Pgens[(int)pgenIndex];
+                    switch (pgen.GenOper)
                     {
-                        case <= -0.5f:
-                            v.PanFactorLeft  = 1;
-                            v.PanFactorRight = 0;
-                            break;
-                        case >= 0.5f:
-                            v.PanFactorLeft  = 0;
-                            v.PanFactorRight = 1;
-                            break;
-                        default:
-                            v.PanFactorLeft  = (float)Math.Sqrt(0.5f - newPan);
-                            v.PanFactorRight = (float)Math.Sqrt(0.5f + newPan);
-                            break;
+                        case HydraPgen.GenKeyRange:
+                            plokey = pgen.GenAmount.LowByteAmount;
+                            phikey = pgen.GenAmount.HighByteAmount;
+                            continue;
+                        case HydraPgen.GenVelRange:
+                            plovel = pgen.GenAmount.LowByteAmount;
+                            phivel = pgen.GenAmount.HighByteAmount;
+                            continue;
+                    }
+
+                    if (pgen.GenOper != HydraPgen.GenInstrument)
+                    {
+                        continue;
+                    }
+                    if (pgen.GenAmount.WordAmount >= hydra.Insts.Count)
+                    {
+                        continue;
+                    }
+                    var pinst = hydra.Insts[pgen.GenAmount.WordAmount];
+                    for (double ibagIndex = pinst.InstBagNdx;ibagIndex < hydra.Insts[pgen.GenAmount.WordAmount + 1].InstBagNdx;ibagIndex++)
+                    {
+                        var ibag = hydra.Ibags[(int)ibagIndex];
+                        double ilokey = 0;
+                        double ihikey = 127;
+                        double ilovel = 0;
+                        double ihivel = 127;
+                        for (double igenIndex = ibag.InstGenNdx;igenIndex < hydra.Ibags[(int)(ibagIndex + 1)].InstGenNdx;igenIndex++)
+                        {
+                            var igen = hydra.Igens[(int)igenIndex];
+                            switch (igen.GenOper)
+                            {
+                                case HydraPgen.GenKeyRange:
+                                    ilokey = igen.GenAmount.LowByteAmount;
+                                    ihikey = igen.GenAmount.HighByteAmount;
+                                    continue;
+                                case HydraPgen.GenVelRange:
+                                    ilovel = igen.GenAmount.LowByteAmount;
+                                    ihivel = igen.GenAmount.HighByteAmount;
+                                    continue;
+                                case 53 when ihikey >= plokey && ilokey <= phikey && ihivel >= plovel && ilovel <= phivel:
+                                    regionNum++;
+                                    break;
+                            }
+                        }
                     }
                 }
             }
-
-            ChannelInit(channel).PanOffset = pan - 0.5f;
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="channel">channel number</param>
-        /// <param name="volume">linear volume scale factor (default 1.0 full)</param>
-        public void ChannelSetVolume(int channel, float volume)
-        {
-            var c = ChannelInit(channel);
-            var gainDb = SynthHelper.GainToDecibels(volume);
-            var gainDBChange = gainDb - c.GainDb;
-            if (gainDBChange == 0)
+            preset.Regions = new Region[(int)regionNum];
+            var globalRegion = new Region();
+            globalRegion.Clear(true);
+            for (double pbagIndex = phdr.PresetBagNdx;pbagIndex < hydra.Phdrs[(int)(phdrIndex + 1)].PresetBagNdx;pbagIndex++)
             {
-                return;
-            }
-
-            foreach (var v in _voices.Where(v => v.PlayingChannel == channel && v.PlayingPreset != -1))
-            {
-                v.NoteGainDb += gainDBChange;
-            }
-
-            c.GainDb = gainDb;
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="channel">channel number</param>
-        /// <param name="pitchWheel">pitch wheel position 0 to 16383 (default 8192 unpitched)</param>
-        public void ChannelSetPitchWheel(int channel, int pitchWheel)
-        {
-            var c = ChannelInit(channel);
-            if (c.PitchWheel == pitchWheel)
-            {
-                return;
-            }
-
-            c.PitchWheel = (ushort)pitchWheel;
-            ChannelApplyPitch(channel, c);
-        }
-
-        private void ChannelApplyPitch(int channel, Channel c)
-        {
-            var pitchShift = c.PitchWheel == 8192
-                ? c.Tuning
-                : c.PitchWheel / 16383.0f * c.PitchRange * 2f - c.PitchRange + c.Tuning;
-            foreach (var v in _voices.Where(v => v.PlayingChannel == channel && v.PlayingPreset != -1))
-            {
-                v.CalcPitchRatio(pitchShift, OutSampleRate);
-            }
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="channel">channel number</param>
-        /// <param name="pitchRange">range of the pitch wheel in semitones (default 2.0, total +/- 2 semitones)</param>
-        public void ChannelSetPitchRange(int channel, float pitchRange)
-        {
-            var c = ChannelInit(channel);
-            if (c.PitchRange == pitchRange)
-            {
-                return;
-            }
-
-            c.PitchRange = pitchRange;
-            if (c.PitchWheel != 8192)
-            {
-                ChannelApplyPitch(channel, c);
-            }
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="channel">channel number</param>
-        /// <param name="tuning">tuning of all playing voices in semitones (default 0.0, standard (A440) tuning)</param>
-        public void ChannelSetTuning(int channel, float tuning)
-        {
-            var c = ChannelInit(channel);
-            if (c.Tuning == tuning)
-            {
-                return;
-            }
-
-            c.Tuning = tuning;
-            ChannelApplyPitch(channel, c);
-        }
-
-        /// <summary>
-        /// Apply a MIDI control change to the channel (not all controllers are supported!)
-        /// </summary>
-        /// <param name="channel"></param>
-        /// <param name="controller"></param>
-        /// <param name="controlValue"></param>
-        public void ChannelMidiControl(int channel, int controller, int controlValue)
-        {
-            var c = ChannelInit(channel);
-            switch (controller)
-            {
-                case 5: /*Portamento_Time_MSB*/
-                case 96: /*DATA_BUTTON_INCREMENT*/
-                case 97: /*DATA_BUTTON_DECREMENT*/
-                case 64: /*HOLD_PEDAL*/
-                case 65: /*Portamento*/
-                case 66: /*SostenutoPedal */
-                case 122: /*LocalKeyboard */
-                case 124: /*OmniModeOff */
-                case 125: /*OmniModeon */
-                case 126: /*MonoMode */
-                case 127: /*PolyMode*/
-                    return;
-
-                case 38 /*DATA_ENTRY_LSB*/:
-                    c.MidiData = (ushort)((c.MidiData & 0x3F80) | controlValue);
-                    switch (c.MidiRpn)
-                    {
-                        case 0:
-                            ChannelSetPitchRange(channel, (c.MidiData >> 7) + 0.01f * (c.MidiData & 0x7F));
-                            break;
-                        case 1:
-                            ChannelSetTuning(channel, (int)c.Tuning + (c.MidiData - 8192.0f) / 8192.0f); //fine tune
-                            break;
-                        case 2:
-                            ChannelSetTuning(channel, controlValue - 64.0f + (c.Tuning - (int)c.Tuning)); //coarse tune
-                            break;
-                    }
-
-                    return;
-
-                case 7 /*VOLUME_MSB*/:
-                    c.MidiVolume = (ushort)((c.MidiVolume & 0x7F) | (controlValue << 7));
-                    //Raising to the power of 3 seems to result in a decent sounding volume curve for MIDI
-                    ChannelSetVolume(channel,
-                        (float)Math.Pow(c.MidiVolume / 16383.0f * (c.MidiExpression / 16383.0f), 3.0f));
-                    return;
-                case 39 /*VOLUME_LSB*/:
-                    c.MidiVolume = (ushort)((c.MidiVolume & 0x3F80) | controlValue);
-                    //Raising to the power of 3 seems to result in a decent sounding volume curve for MIDI
-                    ChannelSetVolume(channel,
-                        (float)Math.Pow(c.MidiVolume / 16383.0f * (c.MidiExpression / 16383.0f), 3.0f));
-                    return;
-                case 11 /*EXPRESSION_MSB*/:
-                    c.MidiExpression = (ushort)((c.MidiExpression & 0x7F) | (controlValue << 7));
-                    //Raising to the power of 3 seems to result in a decent sounding volume curve for MIDI
-                    ChannelSetVolume(channel,
-                        (float)Math.Pow(c.MidiVolume / 16383.0f * (c.MidiExpression / 16383.0f), 3.0f));
-                    return;
-                case 43 /*EXPRESSION_LSB*/:
-                    c.MidiExpression = (ushort)((c.MidiExpression & 0x3F80) | controlValue);
-                    //Raising to the power of 3 seems to result in a decent sounding volume curve for MIDI
-                    ChannelSetVolume(channel,
-                        (float)Math.Pow(c.MidiVolume / 16383.0f * (c.MidiExpression / 16383.0f), 3.0f));
-                    return;
-                case 10 /*PAN_MSB*/:
-                    c.MidiPan = (ushort)((c.MidiPan & 0x7F) | (controlValue << 7));
-                    ChannelSetPan(channel, c.MidiPan / 16383.0f);
-                    return;
-                case 42 /*PAN_LSB*/:
-                    c.MidiPan = (ushort)((c.MidiPan & 0x3F80) | controlValue);
-                    ChannelSetPan(channel, c.MidiPan / 16383.0f);
-                    return;
-                case 6 /*DATA_ENTRY_MSB*/:
-                    c.MidiData = (ushort)((c.MidiData & 0x7F) | (controlValue << 7));
-                    switch (c.MidiRpn)
-                    {
-                        case 0:
-                            ChannelSetPitchRange(channel, (c.MidiData >> 7) + 0.01f * (c.MidiData & 0x7F));
-                            break;
-                        case 1:
-                            ChannelSetTuning(channel, (int)c.Tuning + (c.MidiData - 8192.0f) / 8192.0f); //fine tune
-                            break;
-                        case 2:
-                            ChannelSetTuning(channel, controlValue - 64.0f + (c.Tuning - (int)c.Tuning)); //coarse tune
-                            break;
-                    }
-
-                    return;
-                case 0 /*BANK_SELECT_MSB*/:
-                    c.Bank = (ushort)(0x8000 | controlValue);
-                    return; //bank select MSB alone acts like LSB
-                case 32 /*BANK_SELECT_LSB*/:
-                    c.Bank = (ushort)(((c.Bank & 0x8000) != 0 ? (c.Bank & 0x7F) << 7 : 0) | controlValue);
-                    return;
-                case 101 /*RPN_MSB*/:
-                    c.MidiRpn = (ushort)(((c.MidiRpn == 0xFFFF ? 0 : c.MidiRpn) & 0x7F) | (controlValue << 7));
-                    // TODO
-                    return;
-                case 100 /*RPN_LSB*/:
-                    c.MidiRpn = (ushort)(((c.MidiRpn == 0xFFFF ? 0 : c.MidiRpn) & 0x3F80) | controlValue);
-                    // TODO
-                    return;
-                case 98 /*NRPN_LSB*/:
-                    c.MidiRpn = 0xFFFF;
-                    // TODO
-                    return;
-                case 99 /*NRPN_MSB*/:
-                    c.MidiRpn = 0xFFFF;
-                    // TODO
-                    return;
-                case 120 /*ALL_SOUND_OFF*/:
-                    ChannelSoundsOffAll(channel);
-                    return;
-                case 123 /*ALL_NOTES_OFF*/:
-                    ChannelNoteOffAll(channel);
-                    return;
-                case 121 /*ALL_CTRL_OFF*/:
-                    c.MidiVolume = c.MidiExpression = 16383;
-                    c.MidiPan = 8192;
-                    c.Bank = 0;
-                    ChannelSetVolume(channel, 1);
-                    ChannelSetPan(channel, 0.5f);
-                    ChannelSetPitchRange(channel, 2);
-                    // TODO
-                    return;
-            }
-        }
-
-        /// <summary>
-        /// Gets the current preset index of the given channel.
-        /// </summary>
-        /// <param name="channel">The channel index</param>
-        /// <returns>The current preset index of the given channel.</returns>
-        public int ChannelGetPresetIndex(int channel)
-        {
-            return _channels != null && channel < _channels.ChannelList.Count
-                ? _channels.ChannelList[channel].PresetIndex
-                : 0;
-        }
-
-        /// <summary>
-        /// Gets the current bank of the given channel.
-        /// </summary>
-        /// <param name="channel">The channel index</param>
-        /// <returns>The current bank of the given channel.</returns>
-        public int ChannelGetPresetBank(int channel)
-        {
-            return _channels != null && channel < _channels.ChannelList.Count
-                ? _channels.ChannelList[channel].Bank & 0x7FFF
-                : 0;
-        }
-
-        /// <summary>
-        /// Gets the current pan of the given channel.
-        /// </summary>
-        /// <param name="channel">The channel index</param>
-        /// <returns>The current pan of the given channel.</returns>
-        public float ChannelGetPan(int channel)
-        {
-            return _channels != null && channel < _channels.ChannelList.Count
-                ? _channels.ChannelList[channel].PanOffset - 0.5f
-                : 0.5f;
-        }
-
-        /// <summary>
-        /// Gets the current volume of the given channel.
-        /// </summary>
-        /// <param name="channel">The channel index</param>
-        /// <returns>The current volune of the given channel.</returns>
-        public float ChannelGetVolume(int channel)
-        {
-            return _channels != null && channel < _channels.ChannelList.Count
-                ? SynthHelper.DecibelsToGain(_channels.ChannelList[channel].GainDb)
-                : 1.0f;
-        }
-
-        /// <summary>
-        /// Gets the current pitch wheel of the given channel.
-        /// </summary>
-        /// <param name="channel">The channel index</param>
-        /// <returns>The current pitch wheel of the given channel.</returns>
-        public int ChannelGetPitchWheel(int channel)
-        {
-            return _channels != null && channel < _channels.ChannelList.Count
-                ? _channels.ChannelList[channel].PitchWheel
-                : 8192;
-        }
-
-        /// <summary>
-        /// Gets the current pitch range of the given channel.
-        /// </summary>
-        /// <param name="channel">The channel index</param>
-        /// <returns>The current pitch range of the given channel.</returns>
-        public float ChannelGetPitchRange(int channel)
-        {
-            return _channels != null && channel < _channels.ChannelList.Count
-                ? _channels.ChannelList[channel].PitchRange
-                : 2.0f;
-        }
-
-        /// <summary>
-        /// Gets the current tuning of the given channel.
-        /// </summary>
-        /// <param name="channel">The channel index</param>
-        /// <returns>The current tuning of the given channel.</returns>
-        public float ChannelGetTuning(int channel)
-        {
-            return _channels != null && channel < _channels.ChannelList.Count
-                ? _channels.ChannelList[channel].Tuning
-                : 0.0f;
-        }
-
-        #endregion
-
-        #region Loading
-
-        public void LoadPresets(Hydra hydra, bool append)
-        {
-            List<Preset> newPresets = new (new Preset[hydra.Phdrs.Count - 1]);
-            for (double phdrIndex = 0;phdrIndex < hydra.Phdrs.Count - 1;phdrIndex++)
-            {
-                var phdr = hydra.Phdrs[(int)phdrIndex];
-                double regionIndex = 0;
-                var preset = newPresets[(int)phdrIndex] = new Preset();
-                preset.Name = phdr.PresetName;
-                preset.Bank = phdr.Bank;
-                preset.PresetNumber = phdr.Preset;
-                preset.FontSamples = hydra.FontSamples;
-                double regionNum = 0;
-                for (double pbagIndex = phdr.PresetBagNdx;pbagIndex < hydra.Phdrs[(int)(phdrIndex + 1)].PresetBagNdx;pbagIndex++)
+                var pbag = hydra.Pbags[(int)pbagIndex];
+                var presetRegion = new Region(globalRegion);
+                var hadGenInstrument = false;
+                for (double pgenIndex = pbag.GenNdx;pgenIndex < hydra.Pbags[(int)(pbagIndex + 1)].GenNdx;pgenIndex++)
                 {
-                    var pbag = hydra.Pbags[(int)pbagIndex];
-                    double plokey = 0;
-                    double phikey = 127;
-                    double plovel = 0;
-                    double phivel = 127;
-                    for (double pgenIndex = pbag.GenNdx;pgenIndex < hydra.Pbags[(int)(pbagIndex + 1)].GenNdx;pgenIndex++)
+                    var pgen = hydra.Pgens[(int)pgenIndex];
+                    if (pgen.GenOper == HydraPgen.GenInstrument)
                     {
-                        var pgen = hydra.Pgens[(int)pgenIndex];
-                        switch (pgen.GenOper)
-                        {
-                            case HydraPgen.GenKeyRange:
-                                plokey = pgen.GenAmount.LowByteAmount;
-                                phikey = pgen.GenAmount.HighByteAmount;
-                                continue;
-                            case HydraPgen.GenVelRange:
-                                plovel = pgen.GenAmount.LowByteAmount;
-                                phivel = pgen.GenAmount.HighByteAmount;
-                                continue;
-                        }
-
-                        if (pgen.GenOper != HydraPgen.GenInstrument)
+                        double whichInst = pgen.GenAmount.WordAmount;
+                        if (whichInst >= hydra.Insts.Count)
                         {
                             continue;
                         }
-                        if (pgen.GenAmount.WordAmount >= hydra.Insts.Count)
-                        {
-                            continue;
-                        }
-                        var pinst = hydra.Insts[pgen.GenAmount.WordAmount];
-                        for (double ibagIndex = pinst.InstBagNdx;ibagIndex < hydra.Insts[pgen.GenAmount.WordAmount + 1].InstBagNdx;ibagIndex++)
+                        var instRegion = new Region();
+                        instRegion.Clear(false);
+                        var inst = hydra.Insts[(int)whichInst];
+                        for (double ibagIndex = inst.InstBagNdx;ibagIndex < hydra.Insts[(int)(whichInst + 1)].InstBagNdx;ibagIndex++)
                         {
                             var ibag = hydra.Ibags[(int)ibagIndex];
-                            double ilokey = 0;
-                            double ihikey = 127;
-                            double ilovel = 0;
-                            double ihivel = 127;
+                            var zoneRegion = new Region(instRegion);
+                            var hadSampleId = false;
                             for (double igenIndex = ibag.InstGenNdx;igenIndex < hydra.Ibags[(int)(ibagIndex + 1)].InstGenNdx;igenIndex++)
                             {
                                 var igen = hydra.Igens[(int)igenIndex];
-                                switch (igen.GenOper)
+                                if (igen.GenOper == HydraPgen.GenSampleId)
                                 {
-                                    case HydraPgen.GenKeyRange:
-                                        ilokey = igen.GenAmount.LowByteAmount;
-                                        ihikey = igen.GenAmount.HighByteAmount;
-                                        continue;
-                                    case HydraPgen.GenVelRange:
-                                        ilovel = igen.GenAmount.LowByteAmount;
-                                        ihivel = igen.GenAmount.HighByteAmount;
-                                        continue;
-                                    case 53 when ihikey >= plokey && ilokey <= phikey && ihivel >= plovel && ilovel <= phivel:
-                                        regionNum++;
-                                        break;
-                                }
-                            }
-                        }
-                    }
-                }
-                preset.Regions = new Region[(int)regionNum];
-                var globalRegion = new Region();
-                globalRegion.Clear(true);
-                for (double pbagIndex = phdr.PresetBagNdx;pbagIndex < hydra.Phdrs[(int)(phdrIndex + 1)].PresetBagNdx;pbagIndex++)
-                {
-                    var pbag = hydra.Pbags[(int)pbagIndex];
-                    var presetRegion = new Region(globalRegion);
-                    var hadGenInstrument = false;
-                    for (double pgenIndex = pbag.GenNdx;pgenIndex < hydra.Pbags[(int)(pbagIndex + 1)].GenNdx;pgenIndex++)
-                    {
-                        var pgen = hydra.Pgens[(int)pgenIndex];
-                        if (pgen.GenOper == HydraPgen.GenInstrument)
-                        {
-                            double whichInst = pgen.GenAmount.WordAmount;
-                            if (whichInst >= hydra.Insts.Count)
-                            {
-                                continue;
-                            }
-                            var instRegion = new Region();
-                            instRegion.Clear(false);
-                            var inst = hydra.Insts[(int)whichInst];
-                            for (double ibagIndex = inst.InstBagNdx;ibagIndex < hydra.Insts[(int)(whichInst + 1)].InstBagNdx;ibagIndex++)
-                            {
-                                var ibag = hydra.Ibags[(int)ibagIndex];
-                                var zoneRegion = new Region(instRegion);
-                                var hadSampleId = false;
-                                for (double igenIndex = ibag.InstGenNdx;igenIndex < hydra.Ibags[(int)(ibagIndex + 1)].InstGenNdx;igenIndex++)
-                                {
-                                    var igen = hydra.Igens[(int)igenIndex];
-                                    if (igen.GenOper == HydraPgen.GenSampleId)
+                                    if (zoneRegion.HiKey < presetRegion.LoKey || zoneRegion.LoKey > presetRegion.HiKey)
                                     {
-                                        if (zoneRegion.HiKey < presetRegion.LoKey || zoneRegion.LoKey > presetRegion.HiKey)
-                                        {
-                                            continue;
-                                        }
-                                        if (zoneRegion.HiVel < presetRegion.LoVel || zoneRegion.LoVel > presetRegion.HiVel)
-                                        {
-                                            continue;
-                                        }
-                                        if (presetRegion.LoKey > zoneRegion.LoKey)
-                                        {
-                                            zoneRegion.LoKey = presetRegion.LoKey;
-                                        }
-                                        if (presetRegion.HiKey < zoneRegion.HiKey)
-                                        {
-                                            zoneRegion.HiKey = presetRegion.HiKey;
-                                        }
-                                        if (presetRegion.LoVel > zoneRegion.LoVel)
-                                        {
-                                            zoneRegion.LoVel = presetRegion.LoVel;
-                                        }
-                                        if (presetRegion.HiVel < zoneRegion.HiVel)
-                                        {
-                                            zoneRegion.HiVel = presetRegion.HiVel;
-                                        }
-                                        zoneRegion.Offset += presetRegion.Offset;
-                                        zoneRegion.End += presetRegion.End;
-                                        zoneRegion.LoopStart += presetRegion.LoopStart;
-                                        zoneRegion.LoopEnd += presetRegion.LoopEnd;
-                                        zoneRegion.Transpose += presetRegion.Transpose;
-                                        zoneRegion.Tune += presetRegion.Tune;
-                                        zoneRegion.PitchKeyTrack += presetRegion.PitchKeyTrack;
-                                        zoneRegion.Attenuation += presetRegion.Attenuation;
-                                        zoneRegion.Pan += presetRegion.Pan;
-                                        zoneRegion.AmpEnv.Delay += presetRegion.AmpEnv.Delay;
-                                        zoneRegion.AmpEnv.Attack += presetRegion.AmpEnv.Attack;
-                                        zoneRegion.AmpEnv.Hold += presetRegion.AmpEnv.Hold;
-                                        zoneRegion.AmpEnv.Decay += presetRegion.AmpEnv.Decay;
-                                        zoneRegion.AmpEnv.Sustain += presetRegion.AmpEnv.Sustain;
-                                        zoneRegion.AmpEnv.Release += presetRegion.AmpEnv.Release;
-                                        zoneRegion.ModEnv.Delay += presetRegion.ModEnv.Delay;
-                                        zoneRegion.ModEnv.Attack += presetRegion.ModEnv.Attack;
-                                        zoneRegion.ModEnv.Hold += presetRegion.ModEnv.Hold;
-                                        zoneRegion.ModEnv.Decay += presetRegion.ModEnv.Decay;
-                                        zoneRegion.ModEnv.Sustain += presetRegion.ModEnv.Sustain;
-                                        zoneRegion.ModEnv.Release += presetRegion.ModEnv.Release;
-                                        zoneRegion.InitialFilterQ += presetRegion.InitialFilterQ;
-                                        zoneRegion.InitialFilterFc += presetRegion.InitialFilterFc;
-                                        zoneRegion.ModEnvToPitch += presetRegion.ModEnvToPitch;
-                                        zoneRegion.ModEnvToFilterFc += presetRegion.ModEnvToFilterFc;
-                                        zoneRegion.DelayModLFO += presetRegion.DelayModLFO;
-                                        zoneRegion.FreqModLFO += presetRegion.FreqModLFO;
-                                        zoneRegion.ModLfoToPitch += presetRegion.ModLfoToPitch;
-                                        zoneRegion.ModLfoToFilterFc += presetRegion.ModLfoToFilterFc;
-                                        zoneRegion.ModLfoToVolume += presetRegion.ModLfoToVolume;
-                                        zoneRegion.DelayVibLFO += presetRegion.DelayVibLFO;
-                                        zoneRegion.FreqVibLFO += presetRegion.FreqVibLFO;
-                                        zoneRegion.VibLfoToPitch += presetRegion.VibLfoToPitch;
-                                        zoneRegion.AmpEnv.EnvToSecs(true);
-                                        zoneRegion.ModEnv.EnvToSecs(false);
-                                        zoneRegion.DelayModLFO = zoneRegion.DelayModLFO < -11950 ? 0 : SynthHelper.Timecents2Secs(zoneRegion.DelayModLFO);
-                                        zoneRegion.DelayVibLFO = zoneRegion.DelayVibLFO < -11950 ? 0 : SynthHelper.Timecents2Secs(zoneRegion.DelayVibLFO);
-                                        if (zoneRegion.Pan < -0.5)
-                                        {
-                                            zoneRegion.Pan = (float) -0.5;
-                                        }
-                                        else if (zoneRegion.Pan > 0.5)
-                                        {
-                                            zoneRegion.Pan = (float) 0.5;
-                                        }
-                                        if (zoneRegion.InitialFilterQ is < 1500 or > 13500)
-                                        {
-                                            zoneRegion.InitialFilterQ = 0;
-                                        }
-                                        var shdr = hydra.SHdrs[igen.GenAmount.WordAmount];
-                                        zoneRegion.Offset += shdr.Start;
-                                        zoneRegion.End += shdr.End;
-                                        zoneRegion.LoopStart += shdr.StartLoop;
-                                        zoneRegion.LoopEnd += shdr.EndLoop;
-                                        if (shdr.EndLoop > 0)
-                                        {
-                                            zoneRegion.LoopEnd -= 1;
-                                        }
-                                        if (zoneRegion.PitchKeyCenter == -1)
-                                        {
-                                            zoneRegion.PitchKeyCenter = shdr.OriginalPitch;
-                                        }
-                                        zoneRegion.Tune += shdr.PitchCorrection;
-                                        zoneRegion.SampleRate = shdr.SampleRate;
-                                        if (zoneRegion.End != 0 && zoneRegion.End < preset.FontSamples.Length)
-                                        {
-                                            zoneRegion.End++;
-                                        }
-                                        else 
-                                        {
-                                            zoneRegion.End = (uint) preset.FontSamples.Length;
-                                        }
-                                        preset.Regions[(int)regionIndex] = new Region(zoneRegion);
-                                        regionIndex++;
-                                        hadSampleId = true;
+                                        continue;
+                                    }
+                                    if (zoneRegion.HiVel < presetRegion.LoVel || zoneRegion.LoVel > presetRegion.HiVel)
+                                    {
+                                        continue;
+                                    }
+                                    if (presetRegion.LoKey > zoneRegion.LoKey)
+                                    {
+                                        zoneRegion.LoKey = presetRegion.LoKey;
+                                    }
+                                    if (presetRegion.HiKey < zoneRegion.HiKey)
+                                    {
+                                        zoneRegion.HiKey = presetRegion.HiKey;
+                                    }
+                                    if (presetRegion.LoVel > zoneRegion.LoVel)
+                                    {
+                                        zoneRegion.LoVel = presetRegion.LoVel;
+                                    }
+                                    if (presetRegion.HiVel < zoneRegion.HiVel)
+                                    {
+                                        zoneRegion.HiVel = presetRegion.HiVel;
+                                    }
+                                    zoneRegion.Offset           += presetRegion.Offset;
+                                    zoneRegion.End              += presetRegion.End;
+                                    zoneRegion.LoopStart        += presetRegion.LoopStart;
+                                    zoneRegion.LoopEnd          += presetRegion.LoopEnd;
+                                    zoneRegion.Transpose        += presetRegion.Transpose;
+                                    zoneRegion.Tune             += presetRegion.Tune;
+                                    zoneRegion.PitchKeyTrack    += presetRegion.PitchKeyTrack;
+                                    zoneRegion.Attenuation      += presetRegion.Attenuation;
+                                    zoneRegion.Pan              += presetRegion.Pan;
+                                    zoneRegion.AmpEnv.Delay     += presetRegion.AmpEnv.Delay;
+                                    zoneRegion.AmpEnv.Attack    += presetRegion.AmpEnv.Attack;
+                                    zoneRegion.AmpEnv.Hold      += presetRegion.AmpEnv.Hold;
+                                    zoneRegion.AmpEnv.Decay     += presetRegion.AmpEnv.Decay;
+                                    zoneRegion.AmpEnv.Sustain   += presetRegion.AmpEnv.Sustain;
+                                    zoneRegion.AmpEnv.Release   += presetRegion.AmpEnv.Release;
+                                    zoneRegion.ModEnv.Delay     += presetRegion.ModEnv.Delay;
+                                    zoneRegion.ModEnv.Attack    += presetRegion.ModEnv.Attack;
+                                    zoneRegion.ModEnv.Hold      += presetRegion.ModEnv.Hold;
+                                    zoneRegion.ModEnv.Decay     += presetRegion.ModEnv.Decay;
+                                    zoneRegion.ModEnv.Sustain   += presetRegion.ModEnv.Sustain;
+                                    zoneRegion.ModEnv.Release   += presetRegion.ModEnv.Release;
+                                    zoneRegion.InitialFilterQ   += presetRegion.InitialFilterQ;
+                                    zoneRegion.InitialFilterFc  += presetRegion.InitialFilterFc;
+                                    zoneRegion.ModEnvToPitch    += presetRegion.ModEnvToPitch;
+                                    zoneRegion.ModEnvToFilterFc += presetRegion.ModEnvToFilterFc;
+                                    zoneRegion.DelayModLFO      += presetRegion.DelayModLFO;
+                                    zoneRegion.FreqModLFO       += presetRegion.FreqModLFO;
+                                    zoneRegion.ModLfoToPitch    += presetRegion.ModLfoToPitch;
+                                    zoneRegion.ModLfoToFilterFc += presetRegion.ModLfoToFilterFc;
+                                    zoneRegion.ModLfoToVolume   += presetRegion.ModLfoToVolume;
+                                    zoneRegion.DelayVibLFO      += presetRegion.DelayVibLFO;
+                                    zoneRegion.FreqVibLFO       += presetRegion.FreqVibLFO;
+                                    zoneRegion.VibLfoToPitch    += presetRegion.VibLfoToPitch;
+                                    zoneRegion.AmpEnv.EnvToSecs(true);
+                                    zoneRegion.ModEnv.EnvToSecs(false);
+                                    zoneRegion.DelayModLFO = zoneRegion.DelayModLFO < -11950 ? 0 : SynthHelper.Timecents2Secs(zoneRegion.DelayModLFO);
+                                    zoneRegion.DelayVibLFO = zoneRegion.DelayVibLFO < -11950 ? 0 : SynthHelper.Timecents2Secs(zoneRegion.DelayVibLFO);
+                                    if (zoneRegion.Pan < -0.5)
+                                    {
+                                        zoneRegion.Pan = (float) -0.5;
+                                    }
+                                    else if (zoneRegion.Pan > 0.5)
+                                    {
+                                        zoneRegion.Pan = (float) 0.5;
+                                    }
+                                    if (zoneRegion.InitialFilterQ is < 1500 or > 13500)
+                                    {
+                                        zoneRegion.InitialFilterQ = 0;
+                                    }
+                                    var shdr = hydra.SHdrs[igen.GenAmount.WordAmount];
+                                    zoneRegion.Offset    += shdr.Start;
+                                    zoneRegion.End       += shdr.End;
+                                    zoneRegion.LoopStart += shdr.StartLoop;
+                                    zoneRegion.LoopEnd   += shdr.EndLoop;
+                                    if (shdr.EndLoop > 0)
+                                    {
+                                        zoneRegion.LoopEnd -= 1;
+                                    }
+                                    if (zoneRegion.PitchKeyCenter == -1)
+                                    {
+                                        zoneRegion.PitchKeyCenter = shdr.OriginalPitch;
+                                    }
+                                    zoneRegion.Tune       += shdr.PitchCorrection;
+                                    zoneRegion.SampleRate =  shdr.SampleRate;
+                                    if (zoneRegion.End != 0 && zoneRegion.End < preset.FontSamples.Length)
+                                    {
+                                        zoneRegion.End++;
                                     }
                                     else 
                                     {
-                                        zoneRegion.Operator(igen.GenOper, igen.GenAmount);
+                                        zoneRegion.End = (uint) preset.FontSamples.Length;
                                     }
+                                    preset.Regions[(int)regionIndex] = new Region(zoneRegion);
+                                    regionIndex++;
+                                    hadSampleId = true;
                                 }
-                                if (ibag == hydra.Ibags[inst.InstBagNdx] && !hadSampleId)
+                                else 
                                 {
-                                    instRegion = new Region(zoneRegion);
+                                    zoneRegion.Operator(igen.GenOper, igen.GenAmount);
                                 }
                             }
-                            hadGenInstrument = true;
+                            if (ibag == hydra.Ibags[inst.InstBagNdx] && !hadSampleId)
+                            {
+                                instRegion = new Region(zoneRegion);
+                            }
                         }
-                        else 
-                        {
-                            presetRegion.Operator(pgen.GenOper, pgen.GenAmount);
-                        }
+                        hadGenInstrument = true;
                     }
-                    if (pbag == hydra.Pbags[phdr.PresetBagNdx] && !hadGenInstrument)
+                    else 
                     {
-                        globalRegion = presetRegion;
+                        presetRegion.Operator(pgen.GenOper, pgen.GenAmount);
                     }
                 }
-            }
-            if (!append || Presets == null)
-            {
-                Presets = newPresets;
-            }
-            else 
-            {
-                foreach (var preset in newPresets)
+                if (pbag == hydra.Pbags[phdr.PresetBagNdx] && !hadGenInstrument)
                 {
-                    Presets.Add(preset);
+                    globalRegion = presetRegion;
                 }
             }
         }
-        #endregion
+        if (!append || Presets == null)
+        {
+            Presets = newPresets;
+        }
+        else 
+        {
+            foreach (var preset in newPresets)
+            {
+                Presets.Add(preset);
+            }
+        }
     }
+    #endregion
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Voice.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Voice.cs
@@ -36,7 +36,7 @@ using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Util;
 
 namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
 {
-    internal partial class Voice
+    internal class Voice
     {
         /// <summary>
         /// The lower this block size is the more accurate the effects are.
@@ -45,7 +45,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
         /// </summary>
         private const int RenderEffectSampleBLock = 4;
 
-        public bool Stopped { get; set; } = false;
+        public bool Stopped { get; set; }
 
         public int PlayingPreset { get; set; }
         public int PlayingKey { get; set; }
@@ -122,32 +122,32 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
             var outR = f.OutputMode == OutputMode.StereoUnweaved ? numSamples : -1;
 
             // Cache some values, to give them at least some chance of ending up in registers.
-            var updateModEnv = (region.ModEnvToPitch != 0 || region.ModEnvToFilterFc != 0);
-            var updateModLFO = (ModLfo.Delta > 0 && (region.ModLfoToPitch != 0 || region.ModLfoToFilterFc != 0 || region.ModLfoToVolume != 0));
-            var updateVibLFO = (VibLfo.Delta > 0 && (region.VibLfoToPitch != 0));
-            var isLooping = (LoopStart < LoopEnd);
+            var updateModEnv = region.ModEnvToPitch != 0 || region.ModEnvToFilterFc != 0;
+            var updateModLFO = ModLfo.Delta > 0 && (region.ModLfoToPitch != 0 || region.ModLfoToFilterFc != 0 || region.ModLfoToVolume != 0);
+            var updateVibLFO = VibLfo.Delta > 0 && region.VibLfoToPitch != 0;
+            var isLooping = LoopStart < LoopEnd;
             int tmpLoopStart = (int)LoopStart, tmpLoopEnd = (int)LoopEnd;
-            double tmpSampleEndDbl = (double)region.End, tmpLoopEndDbl = (double)tmpLoopEnd + 1.0;
+            double tmpSampleEndDbl = region.End, tmpLoopEndDbl = tmpLoopEnd + 1.0;
             var tmpSourceSamplePosition = SourceSamplePosition;
 
             var tmpLowpass = new VoiceLowPass(LowPass);
 
-            var dynamicLowpass = (region.ModLfoToFilterFc != 0 || region.ModEnvToFilterFc != 0);
+            var dynamicLowpass = region.ModLfoToFilterFc != 0 || region.ModEnvToFilterFc != 0;
             float tmpSampleRate, tmpInitialFilterFc, tmpModLfoToFilterFc, tmpModEnvToFilterFc;
 
-            var dynamicPitchRatio = (region.ModLfoToPitch != 0 || region.ModEnvToPitch != 0 || region.VibLfoToPitch != 0);
+            var dynamicPitchRatio = region.ModLfoToPitch != 0 || region.ModEnvToPitch != 0 || region.VibLfoToPitch != 0;
             double pitchRatio;
             float tmpModLfoToPitch, tmpVibLfoToPitch, tmpModEnvToPitch;
 
-            var dynamicGain = (region.ModLfoToVolume != 0);
+            var dynamicGain = region.ModLfoToVolume != 0;
             float noteGain = 0, tmpModLfoToVolume;
 
             if (dynamicLowpass)
             {
-                tmpSampleRate = f.OutSampleRate;
-                tmpInitialFilterFc = (float)region.InitialFilterFc;
-                tmpModLfoToFilterFc = (float)region.ModLfoToFilterFc;
-                tmpModEnvToFilterFc = (float)region.ModEnvToFilterFc;
+                tmpSampleRate       = f.OutSampleRate;
+                tmpInitialFilterFc  = region.InitialFilterFc;
+                tmpModLfoToFilterFc = region.ModLfoToFilterFc;
+                tmpModEnvToFilterFc = region.ModEnvToFilterFc;
             }
             else
             {
@@ -159,10 +159,10 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
 
             if (dynamicPitchRatio)
             {
-                pitchRatio = 0;
-                tmpModLfoToPitch = (float)region.ModLfoToPitch;
-                tmpVibLfoToPitch = (float)region.VibLfoToPitch;
-                tmpModEnvToPitch = (float)region.ModEnvToPitch;
+                pitchRatio       = 0;
+                tmpModLfoToPitch = region.ModLfoToPitch;
+                tmpVibLfoToPitch = region.VibLfoToPitch;
+                tmpModEnvToPitch = region.ModEnvToPitch;
             }
             else
             {
@@ -174,7 +174,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
 
             if (dynamicGain)
             {
-                tmpModLfoToVolume = (float)region.ModLfoToVolume * 0.1f;
+                tmpModLfoToVolume = region.ModLfoToVolume * 0.1f;
             }
             else
             {
@@ -184,14 +184,14 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
 
             while (numSamples > 0)
             {
-                float gainMono, gainLeft, gainRight;
-                var blockSamples = (numSamples > RenderEffectSampleBLock ? RenderEffectSampleBLock : numSamples);
+                float gainLeft, gainRight;
+                var blockSamples = numSamples > RenderEffectSampleBLock ? RenderEffectSampleBLock : numSamples;
                 numSamples -= blockSamples;
 
                 if (dynamicLowpass)
                 {
                     var fres = tmpInitialFilterFc + ModLfo.Level * tmpModLfoToFilterFc + ModEnv.Level * tmpModEnvToFilterFc;
-                    tmpLowpass.Active = (fres <= 13500.0f);
+                    tmpLowpass.Active = fres <= 13500.0f;
                     if (tmpLowpass.Active)
                     {
                         tmpLowpass.Setup(SynthHelper.Cents2Hertz(fres) / tmpSampleRate);
@@ -202,9 +202,9 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
                     pitchRatio = SynthHelper.Timecents2Secs(PitchInputTimecents + (ModLfo.Level * tmpModLfoToPitch + VibLfo.Level * tmpVibLfoToPitch + ModEnv.Level * tmpModEnvToPitch)) * PitchOutputFactor;
 
                 if (dynamicGain)
-                    noteGain = SynthHelper.DecibelsToGain(NoteGainDb + (ModLfo.Level * tmpModLfoToVolume));
+                    noteGain = SynthHelper.DecibelsToGain(NoteGainDb + ModLfo.Level * tmpModLfoToVolume);
 
-                gainMono = noteGain * AmpEnv.Level;
+                var gainMono = noteGain * AmpEnv.Level;
 
                 if (isMuted)
                 {
@@ -241,11 +241,11 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
                         while (blockSamples-- > 0 && tmpSourceSamplePosition < tmpSampleEndDbl)
                         {
                             var pos = (int)tmpSourceSamplePosition;
-                            var nextPos = (pos >= tmpLoopEnd && isLooping ? tmpLoopStart : pos + 1);
+                            var nextPos = pos >= tmpLoopEnd && isLooping ? tmpLoopStart : pos + 1;
 
                             // Simple linear interpolation.
                             var alpha = (float) tmpSourceSamplePosition - pos;
-                            var val = input[(int)(pos)] * (1 - alpha) + input[(int)(nextPos)] * alpha;
+                            var val = input[pos] * (1 - alpha) + input[nextPos] * alpha;
 
                             // Low-pass filter.
                             if (tmpLowpass.Active) val = tmpLowpass.Process(val);
@@ -257,7 +257,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
 
                             // Next sample.
                             tmpSourceSamplePosition += pitchRatio;
-                            if (tmpSourceSamplePosition >= tmpLoopEndDbl && isLooping) tmpSourceSamplePosition -= (tmpLoopEnd - tmpLoopStart + 1.0);
+                            if (tmpSourceSamplePosition >= tmpLoopEndDbl && isLooping) tmpSourceSamplePosition -= tmpLoopEnd - tmpLoopStart + 1.0;
                         }
                         break;
                     case OutputMode.StereoUnweaved:
@@ -266,10 +266,10 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
                         while (blockSamples-- > 0 && tmpSourceSamplePosition < tmpSampleEndDbl)
                         {
                             var pos = (int)tmpSourceSamplePosition;
-                            var nextPos = (int)(pos >= tmpLoopEnd && isLooping ? tmpLoopStart : pos + 1);
+                            var nextPos = pos >= tmpLoopEnd && isLooping ? tmpLoopStart : pos + 1;
 
                             // Simple linear interpolation.
-                            float alpha = (float)(tmpSourceSamplePosition - pos), val = (input[pos] * (1.0f - alpha) + input[nextPos] * alpha);
+                            float alpha = (float)(tmpSourceSamplePosition - pos), val = input[pos] * (1.0f - alpha) + input[nextPos] * alpha;
 
                             // Low-pass filter.
                             if (tmpLowpass.Active) val = tmpLowpass.Process(val);
@@ -281,17 +281,17 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
 
                             // Next sample.
                             tmpSourceSamplePosition += pitchRatio;
-                            if (tmpSourceSamplePosition >= tmpLoopEndDbl && isLooping) tmpSourceSamplePosition -= (tmpLoopEnd - tmpLoopStart + 1.0);
+                            if (tmpSourceSamplePosition >= tmpLoopEndDbl && isLooping) tmpSourceSamplePosition -= tmpLoopEnd - tmpLoopStart + 1.0;
                         }
                         break;
                     case OutputMode.Mono:
                         while (blockSamples-- > 0 && tmpSourceSamplePosition < tmpSampleEndDbl)
                         {
-                            int pos = (int)tmpSourceSamplePosition;
-                            int nextPos = (pos >= tmpLoopEnd && isLooping ? tmpLoopStart : pos + 1);
+                            var pos = (int)tmpSourceSamplePosition;
+                            var nextPos = pos >= tmpLoopEnd && isLooping ? tmpLoopStart : pos + 1;
 
                             // Simple linear interpolation.
-                            float alpha = (float)(tmpSourceSamplePosition - pos), val = (input[pos] * (1.0f - alpha) + input[nextPos] * alpha);
+                            float alpha = (float)(tmpSourceSamplePosition - pos), val = input[pos] * (1.0f - alpha) + input[nextPos] * alpha;
 
                             // Low-pass filter.
                             if (tmpLowpass.Active) val = tmpLowpass.Process(val);
@@ -301,7 +301,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
 
                             // Next sample.
                             tmpSourceSamplePosition += pitchRatio;
-                            if (tmpSourceSamplePosition >= tmpLoopEndDbl && isLooping) tmpSourceSamplePosition -= (tmpLoopEnd - tmpLoopStart + 1.0);
+                            if (tmpSourceSamplePosition >= tmpLoopEndDbl && isLooping) tmpSourceSamplePosition -= tmpLoopEnd - tmpLoopStart + 1.0;
                         }
                         break;
                 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Voice.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/Voice.cs
@@ -34,295 +34,294 @@
 
 using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Util;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis;
+
+internal class Voice
 {
-    internal class Voice
+    /// <summary>
+    /// The lower this block size is the more accurate the effects are.
+    /// Increasing the value significantly lowers the CPU usage of the voice rendering.
+    /// If LFO affects the low-pass filter it can be hearable even as low as 8.
+    /// </summary>
+    private const int RenderEffectSampleBLock = 4;
+
+    public bool Stopped { get; set; }
+
+    public int PlayingPreset { get; set; }
+    public int PlayingKey { get; set; }
+    public int PlayingChannel { get; set; }
+
+    public Region Region { get; set; }
+
+    public double PitchInputTimecents { get; set; }
+    public double PitchOutputFactor { get; set; }
+    public double SourceSamplePosition { get; set; }
+
+    public float NoteGainDb { get; set; }
+    public float PanFactorLeft { get; set; }
+    public float PanFactorRight { get; set; }
+
+    public uint PlayIndex { get; set; }
+    public uint LoopStart { get; set; }
+    public uint LoopEnd { get; set; }
+
+    public VoiceEnvelope AmpEnv { get; set; }
+    public VoiceEnvelope ModEnv { get; set; }
+
+    public VoiceLowPass LowPass { get; set; }
+    public VoiceLfo ModLfo { get; set; }
+    public VoiceLfo VibLfo { get; set; }
+
+    public float MixVolume { get; set; }
+
+    public ulong Counter { get; set; }
+
+    public Voice()
     {
-        /// <summary>
-        /// The lower this block size is the more accurate the effects are.
-        /// Increasing the value significantly lowers the CPU usage of the voice rendering.
-        /// If LFO affects the low-pass filter it can be hearable even as low as 8.
-        /// </summary>
-        private const int RenderEffectSampleBLock = 4;
+        AmpEnv  = new VoiceEnvelope();
+        ModEnv  = new VoiceEnvelope();
+        LowPass = new VoiceLowPass();
+        ModLfo  = new VoiceLfo();
+        VibLfo  = new VoiceLfo();
+    }
 
-        public bool Stopped { get; set; }
+    public void CalcPitchRatio(float pitchShift, float outSampleRate)
+    {
+        var note = PlayingKey + Region.Transpose + Region.Tune / 100.0;
+        var adjustedPitch = Region.PitchKeyCenter + (note - Region.PitchKeyCenter) * (Region.PitchKeyTrack / 100.0);
+        if (pitchShift != 0) adjustedPitch += pitchShift;
+        PitchInputTimecents = adjustedPitch * 100.0;
+        PitchOutputFactor = Region.SampleRate / (SynthHelper.Timecents2Secs(Region.PitchKeyCenter * 100.0) * outSampleRate);
+    }
 
-        public int PlayingPreset { get; set; }
-        public int PlayingKey { get; set; }
-        public int PlayingChannel { get; set; }
-
-        public Region Region { get; set; }
-
-        public double PitchInputTimecents { get; set; }
-        public double PitchOutputFactor { get; set; }
-        public double SourceSamplePosition { get; set; }
-
-        public float NoteGainDb { get; set; }
-        public float PanFactorLeft { get; set; }
-        public float PanFactorRight { get; set; }
-
-        public uint PlayIndex { get; set; }
-        public uint LoopStart { get; set; }
-        public uint LoopEnd { get; set; }
-
-        public VoiceEnvelope AmpEnv { get; set; }
-        public VoiceEnvelope ModEnv { get; set; }
-
-        public VoiceLowPass LowPass { get; set; }
-        public VoiceLfo ModLfo { get; set; }
-        public VoiceLfo VibLfo { get; set; }
-
-        public float MixVolume { get; set; }
-
-        public ulong Counter { get; set; }
-
-        public Voice()
+    public void End(float outSampleRate)
+    {
+        AmpEnv.NextSegment(VoiceEnvelopeSegment.Sustain, outSampleRate);
+        ModEnv.NextSegment(VoiceEnvelopeSegment.Sustain, outSampleRate);
+        if (Region.LoopMode == LoopMode.Sustain)
         {
-            AmpEnv = new VoiceEnvelope();
-            ModEnv = new VoiceEnvelope();
-            LowPass = new VoiceLowPass();
-            ModLfo = new VoiceLfo();
-            VibLfo = new VoiceLfo();
+            // Continue playing, but stop looping.
+            LoopEnd = LoopStart;
+        }
+    }
+
+    public void EndQuick(float outSampleRate)
+    {
+        AmpEnv.Parameters.Release = 0.0f;
+        AmpEnv.NextSegment(VoiceEnvelopeSegment.Sustain, outSampleRate);
+        ModEnv.Parameters.Release = 0.0f;
+        ModEnv.NextSegment(VoiceEnvelopeSegment.Sustain, outSampleRate);
+    }
+
+    public void Render(TinySoundFont f, float[] outputBuffer, int offset, int numSamples, bool isMuted)
+    {
+        var region = Region;
+        var preset = f.Presets![PlayingPreset];
+        var input = preset.FontSamples;
+        var outL = 0;
+        var outR = f.OutputMode == OutputMode.StereoUnweaved ? numSamples : -1;
+
+        // Cache some values, to give them at least some chance of ending up in registers.
+        var updateModEnv = region.ModEnvToPitch != 0 || region.ModEnvToFilterFc != 0;
+        var updateModLFO = ModLfo.Delta > 0 && (region.ModLfoToPitch != 0 || region.ModLfoToFilterFc != 0 || region.ModLfoToVolume != 0);
+        var updateVibLFO = VibLfo.Delta > 0 && region.VibLfoToPitch != 0;
+        var isLooping = LoopStart < LoopEnd;
+        int tmpLoopStart = (int)LoopStart, tmpLoopEnd = (int)LoopEnd;
+        double tmpSampleEndDbl = region.End, tmpLoopEndDbl = tmpLoopEnd + 1.0;
+        var tmpSourceSamplePosition = SourceSamplePosition;
+
+        var tmpLowpass = new VoiceLowPass(LowPass);
+
+        var dynamicLowpass = region.ModLfoToFilterFc != 0 || region.ModEnvToFilterFc != 0;
+        float tmpSampleRate, tmpInitialFilterFc, tmpModLfoToFilterFc, tmpModEnvToFilterFc;
+
+        var dynamicPitchRatio = region.ModLfoToPitch != 0 || region.ModEnvToPitch != 0 || region.VibLfoToPitch != 0;
+        double pitchRatio;
+        float tmpModLfoToPitch, tmpVibLfoToPitch, tmpModEnvToPitch;
+
+        var dynamicGain = region.ModLfoToVolume != 0;
+        float noteGain = 0, tmpModLfoToVolume;
+
+        if (dynamicLowpass)
+        {
+            tmpSampleRate       = f.OutSampleRate;
+            tmpInitialFilterFc  = region.InitialFilterFc;
+            tmpModLfoToFilterFc = region.ModLfoToFilterFc;
+            tmpModEnvToFilterFc = region.ModEnvToFilterFc;
+        }
+        else
+        {
+            tmpSampleRate       = 0;
+            tmpInitialFilterFc  = 0;
+            tmpModLfoToFilterFc = 0;
+            tmpModEnvToFilterFc = 0;
         }
 
-        public void CalcPitchRatio(float pitchShift, float outSampleRate)
+        if (dynamicPitchRatio)
         {
-            var note = PlayingKey + Region.Transpose + Region.Tune / 100.0;
-            var adjustedPitch = Region.PitchKeyCenter + (note - Region.PitchKeyCenter) * (Region.PitchKeyTrack / 100.0);
-            if (pitchShift != 0) adjustedPitch += pitchShift;
-            PitchInputTimecents = adjustedPitch * 100.0;
-            PitchOutputFactor = Region.SampleRate / (SynthHelper.Timecents2Secs(Region.PitchKeyCenter * 100.0) * outSampleRate);
+            pitchRatio       = 0;
+            tmpModLfoToPitch = region.ModLfoToPitch;
+            tmpVibLfoToPitch = region.VibLfoToPitch;
+            tmpModEnvToPitch = region.ModEnvToPitch;
+        }
+        else
+        {
+            pitchRatio       = SynthHelper.Timecents2Secs(PitchInputTimecents) * PitchOutputFactor;
+            tmpModLfoToPitch = 0;
+            tmpVibLfoToPitch = 0;
+            tmpModEnvToPitch = 0;
         }
 
-        public void End(float outSampleRate)
+        if (dynamicGain)
         {
-            AmpEnv.NextSegment(VoiceEnvelopeSegment.Sustain, outSampleRate);
-            ModEnv.NextSegment(VoiceEnvelopeSegment.Sustain, outSampleRate);
-            if (Region.LoopMode == LoopMode.Sustain)
-            {
-                // Continue playing, but stop looping.
-                LoopEnd = LoopStart;
-            }
+            tmpModLfoToVolume = region.ModLfoToVolume * 0.1f;
+        }
+        else
+        {
+            noteGain          = SynthHelper.DecibelsToGain(NoteGainDb);
+            tmpModLfoToVolume = 0;
         }
 
-        public void EndQuick(float outSampleRate)
+        while (numSamples > 0)
         {
-            AmpEnv.Parameters.Release = 0.0f;
-            AmpEnv.NextSegment(VoiceEnvelopeSegment.Sustain, outSampleRate);
-            ModEnv.Parameters.Release = 0.0f;
-            ModEnv.NextSegment(VoiceEnvelopeSegment.Sustain, outSampleRate);
-        }
-
-        public void Render(TinySoundFont f, float[] outputBuffer, int offset, int numSamples, bool isMuted)
-        {
-            var region = Region;
-            var preset = f.Presets![PlayingPreset];
-            var input = preset.FontSamples;
-            var outL = 0;
-            var outR = f.OutputMode == OutputMode.StereoUnweaved ? numSamples : -1;
-
-            // Cache some values, to give them at least some chance of ending up in registers.
-            var updateModEnv = region.ModEnvToPitch != 0 || region.ModEnvToFilterFc != 0;
-            var updateModLFO = ModLfo.Delta > 0 && (region.ModLfoToPitch != 0 || region.ModLfoToFilterFc != 0 || region.ModLfoToVolume != 0);
-            var updateVibLFO = VibLfo.Delta > 0 && region.VibLfoToPitch != 0;
-            var isLooping = LoopStart < LoopEnd;
-            int tmpLoopStart = (int)LoopStart, tmpLoopEnd = (int)LoopEnd;
-            double tmpSampleEndDbl = region.End, tmpLoopEndDbl = tmpLoopEnd + 1.0;
-            var tmpSourceSamplePosition = SourceSamplePosition;
-
-            var tmpLowpass = new VoiceLowPass(LowPass);
-
-            var dynamicLowpass = region.ModLfoToFilterFc != 0 || region.ModEnvToFilterFc != 0;
-            float tmpSampleRate, tmpInitialFilterFc, tmpModLfoToFilterFc, tmpModEnvToFilterFc;
-
-            var dynamicPitchRatio = region.ModLfoToPitch != 0 || region.ModEnvToPitch != 0 || region.VibLfoToPitch != 0;
-            double pitchRatio;
-            float tmpModLfoToPitch, tmpVibLfoToPitch, tmpModEnvToPitch;
-
-            var dynamicGain = region.ModLfoToVolume != 0;
-            float noteGain = 0, tmpModLfoToVolume;
+            float gainLeft, gainRight;
+            var blockSamples = numSamples > RenderEffectSampleBLock ? RenderEffectSampleBLock : numSamples;
+            numSamples -= blockSamples;
 
             if (dynamicLowpass)
             {
-                tmpSampleRate       = f.OutSampleRate;
-                tmpInitialFilterFc  = region.InitialFilterFc;
-                tmpModLfoToFilterFc = region.ModLfoToFilterFc;
-                tmpModEnvToFilterFc = region.ModEnvToFilterFc;
-            }
-            else
-            {
-                tmpSampleRate = 0;
-                tmpInitialFilterFc = 0;
-                tmpModLfoToFilterFc = 0;
-                tmpModEnvToFilterFc = 0;
+                var fres = tmpInitialFilterFc + ModLfo.Level * tmpModLfoToFilterFc + ModEnv.Level * tmpModEnvToFilterFc;
+                tmpLowpass.Active = fres <= 13500.0f;
+                if (tmpLowpass.Active)
+                {
+                    tmpLowpass.Setup(SynthHelper.Cents2Hertz(fres) / tmpSampleRate);
+                }
             }
 
             if (dynamicPitchRatio)
-            {
-                pitchRatio       = 0;
-                tmpModLfoToPitch = region.ModLfoToPitch;
-                tmpVibLfoToPitch = region.VibLfoToPitch;
-                tmpModEnvToPitch = region.ModEnvToPitch;
-            }
-            else
-            {
-                pitchRatio = SynthHelper.Timecents2Secs(PitchInputTimecents) * PitchOutputFactor;
-                tmpModLfoToPitch = 0;
-                tmpVibLfoToPitch = 0;
-                tmpModEnvToPitch = 0;
-            }
+                pitchRatio = SynthHelper.Timecents2Secs(PitchInputTimecents + (ModLfo.Level * tmpModLfoToPitch + VibLfo.Level * tmpVibLfoToPitch + ModEnv.Level * tmpModEnvToPitch)) * PitchOutputFactor;
 
             if (dynamicGain)
+                noteGain = SynthHelper.DecibelsToGain(NoteGainDb + ModLfo.Level * tmpModLfoToVolume);
+
+            var gainMono = noteGain * AmpEnv.Level;
+
+            if (isMuted)
             {
-                tmpModLfoToVolume = region.ModLfoToVolume * 0.1f;
+                gainMono = 0;
             }
             else
             {
-                noteGain = SynthHelper.DecibelsToGain(NoteGainDb);
-                tmpModLfoToVolume = 0;
+                gainMono *= MixVolume;
             }
 
-            while (numSamples > 0)
+            // Update EG.
+            AmpEnv.Process(blockSamples, f.OutSampleRate);
+            if (updateModEnv)
             {
-                float gainLeft, gainRight;
-                var blockSamples = numSamples > RenderEffectSampleBLock ? RenderEffectSampleBLock : numSamples;
-                numSamples -= blockSamples;
+                ModEnv.Process(blockSamples, f.OutSampleRate);
+            }
 
-                if (dynamicLowpass)
-                {
-                    var fres = tmpInitialFilterFc + ModLfo.Level * tmpModLfoToFilterFc + ModEnv.Level * tmpModEnvToFilterFc;
-                    tmpLowpass.Active = fres <= 13500.0f;
-                    if (tmpLowpass.Active)
+            // Update LFOs.
+            if (updateModLFO)
+            {
+                ModLfo.Process(blockSamples);
+            }
+
+            if (updateVibLFO)
+            {
+                VibLfo.Process(blockSamples);
+            }
+
+            switch (f.OutputMode)
+            {
+                case OutputMode.StereoInterleaved:
+                    gainLeft  = gainMono * PanFactorLeft;
+                    gainRight = gainMono * PanFactorRight;
+                    while (blockSamples-- > 0 && tmpSourceSamplePosition < tmpSampleEndDbl)
                     {
-                        tmpLowpass.Setup(SynthHelper.Cents2Hertz(fres) / tmpSampleRate);
+                        var pos = (int)tmpSourceSamplePosition;
+                        var nextPos = pos >= tmpLoopEnd && isLooping ? tmpLoopStart : pos + 1;
+
+                        // Simple linear interpolation.
+                        var alpha = (float) tmpSourceSamplePosition - pos;
+                        var val = input[pos] * (1 - alpha) + input[nextPos] * alpha;
+
+                        // Low-pass filter.
+                        if (tmpLowpass.Active) val = tmpLowpass.Process(val);
+
+                        outputBuffer[offset + outL] += val * gainLeft;
+                        outL++;
+                        outputBuffer[offset + outL] += val * gainRight;
+                        outL++;
+
+                        // Next sample.
+                        tmpSourceSamplePosition += pitchRatio;
+                        if (tmpSourceSamplePosition >= tmpLoopEndDbl && isLooping) tmpSourceSamplePosition -= tmpLoopEnd - tmpLoopStart + 1.0;
                     }
-                }
+                    break;
+                case OutputMode.StereoUnweaved:
+                    gainLeft  = gainMono * PanFactorLeft;
+                    gainRight = gainMono * PanFactorRight;
+                    while (blockSamples-- > 0 && tmpSourceSamplePosition < tmpSampleEndDbl)
+                    {
+                        var pos = (int)tmpSourceSamplePosition;
+                        var nextPos = pos >= tmpLoopEnd && isLooping ? tmpLoopStart : pos + 1;
 
-                if (dynamicPitchRatio)
-                    pitchRatio = SynthHelper.Timecents2Secs(PitchInputTimecents + (ModLfo.Level * tmpModLfoToPitch + VibLfo.Level * tmpVibLfoToPitch + ModEnv.Level * tmpModEnvToPitch)) * PitchOutputFactor;
+                        // Simple linear interpolation.
+                        float alpha = (float)(tmpSourceSamplePosition - pos), val = input[pos] * (1.0f - alpha) + input[nextPos] * alpha;
 
-                if (dynamicGain)
-                    noteGain = SynthHelper.DecibelsToGain(NoteGainDb + ModLfo.Level * tmpModLfoToVolume);
+                        // Low-pass filter.
+                        if (tmpLowpass.Active) val = tmpLowpass.Process(val);
 
-                var gainMono = noteGain * AmpEnv.Level;
+                        outputBuffer[offset + outL] += val * gainLeft;
+                        outL++;
+                        outputBuffer[offset + outR] += val * gainRight;
+                        outR++;
 
-                if (isMuted)
-                {
-                    gainMono = 0;
-                }
-                else
-                {
-                    gainMono *= MixVolume;
-                }
+                        // Next sample.
+                        tmpSourceSamplePosition += pitchRatio;
+                        if (tmpSourceSamplePosition >= tmpLoopEndDbl && isLooping) tmpSourceSamplePosition -= tmpLoopEnd - tmpLoopStart + 1.0;
+                    }
+                    break;
+                case OutputMode.Mono:
+                    while (blockSamples-- > 0 && tmpSourceSamplePosition < tmpSampleEndDbl)
+                    {
+                        var pos = (int)tmpSourceSamplePosition;
+                        var nextPos = pos >= tmpLoopEnd && isLooping ? tmpLoopStart : pos + 1;
 
-                // Update EG.
-                AmpEnv.Process(blockSamples, f.OutSampleRate);
-                if (updateModEnv)
-                {
-                    ModEnv.Process(blockSamples, f.OutSampleRate);
-                }
+                        // Simple linear interpolation.
+                        float alpha = (float)(tmpSourceSamplePosition - pos), val = input[pos] * (1.0f - alpha) + input[nextPos] * alpha;
 
-                // Update LFOs.
-                if (updateModLFO)
-                {
-                    ModLfo.Process(blockSamples);
-                }
+                        // Low-pass filter.
+                        if (tmpLowpass.Active) val = tmpLowpass.Process(val);
 
-                if (updateVibLFO)
-                {
-                    VibLfo.Process(blockSamples);
-                }
+                        outputBuffer[offset + outL] = val * gainMono;
+                        outL++;
 
-                switch (f.OutputMode)
-                {
-                    case OutputMode.StereoInterleaved:
-                        gainLeft = gainMono * PanFactorLeft;
-                        gainRight = gainMono * PanFactorRight;
-                        while (blockSamples-- > 0 && tmpSourceSamplePosition < tmpSampleEndDbl)
-                        {
-                            var pos = (int)tmpSourceSamplePosition;
-                            var nextPos = pos >= tmpLoopEnd && isLooping ? tmpLoopStart : pos + 1;
-
-                            // Simple linear interpolation.
-                            var alpha = (float) tmpSourceSamplePosition - pos;
-                            var val = input[pos] * (1 - alpha) + input[nextPos] * alpha;
-
-                            // Low-pass filter.
-                            if (tmpLowpass.Active) val = tmpLowpass.Process(val);
-
-                            outputBuffer[offset + outL] += val * gainLeft;
-                            outL++;
-                            outputBuffer[offset + outL] += val * gainRight;
-                            outL++;
-
-                            // Next sample.
-                            tmpSourceSamplePosition += pitchRatio;
-                            if (tmpSourceSamplePosition >= tmpLoopEndDbl && isLooping) tmpSourceSamplePosition -= tmpLoopEnd - tmpLoopStart + 1.0;
-                        }
-                        break;
-                    case OutputMode.StereoUnweaved:
-                        gainLeft = gainMono * PanFactorLeft;
-                        gainRight = gainMono * PanFactorRight;
-                        while (blockSamples-- > 0 && tmpSourceSamplePosition < tmpSampleEndDbl)
-                        {
-                            var pos = (int)tmpSourceSamplePosition;
-                            var nextPos = pos >= tmpLoopEnd && isLooping ? tmpLoopStart : pos + 1;
-
-                            // Simple linear interpolation.
-                            float alpha = (float)(tmpSourceSamplePosition - pos), val = input[pos] * (1.0f - alpha) + input[nextPos] * alpha;
-
-                            // Low-pass filter.
-                            if (tmpLowpass.Active) val = tmpLowpass.Process(val);
-
-                            outputBuffer[offset + outL] += val * gainLeft;
-                            outL++;
-                            outputBuffer[offset + outR] += val * gainRight;
-                            outR++;
-
-                            // Next sample.
-                            tmpSourceSamplePosition += pitchRatio;
-                            if (tmpSourceSamplePosition >= tmpLoopEndDbl && isLooping) tmpSourceSamplePosition -= tmpLoopEnd - tmpLoopStart + 1.0;
-                        }
-                        break;
-                    case OutputMode.Mono:
-                        while (blockSamples-- > 0 && tmpSourceSamplePosition < tmpSampleEndDbl)
-                        {
-                            var pos = (int)tmpSourceSamplePosition;
-                            var nextPos = pos >= tmpLoopEnd && isLooping ? tmpLoopStart : pos + 1;
-
-                            // Simple linear interpolation.
-                            float alpha = (float)(tmpSourceSamplePosition - pos), val = input[pos] * (1.0f - alpha) + input[nextPos] * alpha;
-
-                            // Low-pass filter.
-                            if (tmpLowpass.Active) val = tmpLowpass.Process(val);
-
-                            outputBuffer[offset + outL] = val * gainMono;
-                            outL++;
-
-                            // Next sample.
-                            tmpSourceSamplePosition += pitchRatio;
-                            if (tmpSourceSamplePosition >= tmpLoopEndDbl && isLooping) tmpSourceSamplePosition -= tmpLoopEnd - tmpLoopStart + 1.0;
-                        }
-                        break;
-                }
-
-                if (tmpSourceSamplePosition >= tmpSampleEndDbl || AmpEnv.Segment == VoiceEnvelopeSegment.Done)
-                {
-                    Kill();
-                    return;
-                }
+                        // Next sample.
+                        tmpSourceSamplePosition += pitchRatio;
+                        if (tmpSourceSamplePosition >= tmpLoopEndDbl && isLooping) tmpSourceSamplePosition -= tmpLoopEnd - tmpLoopStart + 1.0;
+                    }
+                    break;
             }
 
-            SourceSamplePosition = tmpSourceSamplePosition;
-            if (tmpLowpass.Active || dynamicLowpass)
+            if (tmpSourceSamplePosition >= tmpSampleEndDbl || AmpEnv.Segment == VoiceEnvelopeSegment.Done)
             {
-                LowPass = tmpLowpass;
+                Kill();
+                return;
             }
         }
 
-        public void Kill()
+        SourceSamplePosition = tmpSourceSamplePosition;
+        if (tmpLowpass.Active || dynamicLowpass)
         {
-            PlayingPreset = -1;
+            LowPass = tmpLowpass;
         }
+    }
+
+    public void Kill()
+    {
+        PlayingPreset = -1;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/VoiceEnvelope.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/VoiceEnvelope.cs
@@ -76,11 +76,11 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
                         SamplesUntilNextSegment = (int)(Parameters.Attack * outSampleRate);
                         if (SamplesUntilNextSegment > 0)
                         {
-                            if (!this.IsAmpEnv)
+                            if (!IsAmpEnv)
                             {
                                 //mod env attack duration scales with velocity (velocity of 1 is full duration, max velocity is 0.125 times duration)
                                 SamplesUntilNextSegment =
-                                    (int)(Parameters.Attack * ((145 - this.MidiVelocity) / 144.0f) * outSampleRate);
+                                    (int)(Parameters.Attack * ((145 - MidiVelocity) / 144.0f) * outSampleRate);
                             }
 
                             Segment = VoiceEnvelopeSegment.Attack;
@@ -113,7 +113,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
                         {
                             Segment = VoiceEnvelopeSegment.Decay;
                             Level = 1.0f;
-                            if (this.IsAmpEnv)
+                            if (IsAmpEnv)
                             {
                                 // I don't truly understand this; just following what LinuxSampler does.
                                 var mysterySlope = (float)(-9.226 / SamplesUntilNextSegment);
@@ -154,7 +154,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
                         Segment = VoiceEnvelopeSegment.Release;
                         SamplesUntilNextSegment =
                             (int)((Parameters.Release <= 0 ? FastReleaseTime : Parameters.Release) * outSampleRate);
-                        if (this.IsAmpEnv)
+                        if (IsAmpEnv)
                         {
                             // I don't truly understand this; just following what LinuxSampler does.
                             var mysterySlope = (float)(-9.226 / SamplesUntilNextSegment);
@@ -209,7 +209,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
             if (Slope > 0)
             {
                 if (SegmentIsExponential) Level *= (float)Math.Pow(Slope, numSamples);
-                else Level += (Slope * numSamples);
+                else Level += Slope * numSamples;
             }
 
             if ((SamplesUntilNextSegment -= numSamples) <= 0)

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/VoiceEnvelope.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/VoiceEnvelope.cs
@@ -35,187 +35,186 @@
 using System;
 using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Util;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis;
+
+internal class VoiceEnvelope
 {
-    internal class VoiceEnvelope
+    private const float FastReleaseTime = 0.01f;
+    public float Level { get; set; }
+    public float Slope { get; set; }
+
+    public int SamplesUntilNextSegment { get; set; }
+
+    public VoiceEnvelopeSegment Segment { get; set; }
+    public short MidiVelocity { get; set; }
+
+    public Envelope Parameters { get; set; }
+
+    public bool SegmentIsExponential { get; set; }
+    public bool IsAmpEnv { get; set; }
+
+    public void NextSegment(VoiceEnvelopeSegment activeSegment, float outSampleRate)
     {
-        private const float FastReleaseTime = 0.01f;
-        public float Level { get; set; }
-        public float Slope { get; set; }
-
-        public int SamplesUntilNextSegment { get; set; }
-
-        public VoiceEnvelopeSegment Segment { get; set; }
-        public short MidiVelocity { get; set; }
-
-        public Envelope Parameters { get; set; }
-
-        public bool SegmentIsExponential { get; set; }
-        public bool IsAmpEnv { get; set; }
-
-        public void NextSegment(VoiceEnvelopeSegment activeSegment, float outSampleRate)
+        while (true) // if segment is handled, method will return
         {
-            while (true) // if segment is handled, method will return
+            switch (activeSegment)
             {
-                switch (activeSegment)
-                {
-                    case VoiceEnvelopeSegment.None:
-                        SamplesUntilNextSegment = (int)(Parameters.Delay * outSampleRate);
-                        if (SamplesUntilNextSegment > 0)
-                        {
-                            Segment = VoiceEnvelopeSegment.Delay;
-                            SegmentIsExponential = false;
-                            Level = 0.0f;
-                            Slope = 0.0f;
-                            return;
-                        }
-                        activeSegment = VoiceEnvelopeSegment.Delay;
-                        break;
-
-                    case VoiceEnvelopeSegment.Delay:
-                        SamplesUntilNextSegment = (int)(Parameters.Attack * outSampleRate);
-                        if (SamplesUntilNextSegment > 0)
-                        {
-                            if (!IsAmpEnv)
-                            {
-                                //mod env attack duration scales with velocity (velocity of 1 is full duration, max velocity is 0.125 times duration)
-                                SamplesUntilNextSegment =
-                                    (int)(Parameters.Attack * ((145 - MidiVelocity) / 144.0f) * outSampleRate);
-                            }
-
-                            Segment = VoiceEnvelopeSegment.Attack;
-                            SegmentIsExponential = false;
-                            Level = 0.0f;
-                            Slope = 1.0f / SamplesUntilNextSegment;
-                            return;
-                        }
-
-                        activeSegment = VoiceEnvelopeSegment.Attack;
-                        break;
-
-                    case VoiceEnvelopeSegment.Attack:
-                        SamplesUntilNextSegment = (int)(Parameters.Hold * outSampleRate);
-                        if (SamplesUntilNextSegment > 0)
-                        {
-                            Segment = VoiceEnvelopeSegment.Hold;
-                            SegmentIsExponential = false;
-                            Level = 1.0f;
-                            Slope = 0.0f;
-                            return;
-                        }
-
-                        activeSegment = VoiceEnvelopeSegment.Hold;
-                        break;
-
-                    case VoiceEnvelopeSegment.Hold:
-                        SamplesUntilNextSegment = (int)(Parameters.Decay * outSampleRate);
-                        if (SamplesUntilNextSegment > 0)
-                        {
-                            Segment = VoiceEnvelopeSegment.Decay;
-                            Level = 1.0f;
-                            if (IsAmpEnv)
-                            {
-                                // I don't truly understand this; just following what LinuxSampler does.
-                                var mysterySlope = (float)(-9.226 / SamplesUntilNextSegment);
-                                Slope = (float)Math.Exp(mysterySlope);
-                                SegmentIsExponential = true;
-                                if (Parameters.Sustain > 0.0f)
-                                {
-                                    // Again, this is following LinuxSampler's example, which is similar to
-                                    // SF2-style decay, where "decay" specifies the time it would take to
-                                    // get to zero, not to the sustain level.  The SFZ spec is not that
-                                    // specific about what "decay" means, so perhaps it's really supposed
-                                    // to specify the time to reach the sustain level.
-                                    SamplesUntilNextSegment = (int)(Math.Log(Parameters.Sustain) / mysterySlope);
-                                }
-                            }
-                            else
-                            {
-                                Slope = (float)(-1.0 / SamplesUntilNextSegment);
-                                SamplesUntilNextSegment =
-                                    (int)(Parameters.Decay * (1.0f - Parameters.Sustain) * outSampleRate);
-                                SegmentIsExponential = false;
-                            }
-
-                            return;
-                        }
-
-                        activeSegment = VoiceEnvelopeSegment.Decay;
-                        break;
-
-                    case VoiceEnvelopeSegment.Decay:
-                        Segment = VoiceEnvelopeSegment.Sustain;
-                        Level = Parameters.Sustain;
-                        Slope = 0.0f;
-                        SamplesUntilNextSegment = 0x7FFFFFFF;
+                case VoiceEnvelopeSegment.None:
+                    SamplesUntilNextSegment = (int)(Parameters.Delay * outSampleRate);
+                    if (SamplesUntilNextSegment > 0)
+                    {
+                        Segment              = VoiceEnvelopeSegment.Delay;
                         SegmentIsExponential = false;
+                        Level                = 0.0f;
+                        Slope                = 0.0f;
                         return;
-                    case VoiceEnvelopeSegment.Sustain:
-                        Segment = VoiceEnvelopeSegment.Release;
-                        SamplesUntilNextSegment =
-                            (int)((Parameters.Release <= 0 ? FastReleaseTime : Parameters.Release) * outSampleRate);
+                    }
+                    activeSegment = VoiceEnvelopeSegment.Delay;
+                    break;
+
+                case VoiceEnvelopeSegment.Delay:
+                    SamplesUntilNextSegment = (int)(Parameters.Attack * outSampleRate);
+                    if (SamplesUntilNextSegment > 0)
+                    {
+                        if (!IsAmpEnv)
+                        {
+                            //mod env attack duration scales with velocity (velocity of 1 is full duration, max velocity is 0.125 times duration)
+                            SamplesUntilNextSegment =
+                                (int)(Parameters.Attack * ((145 - MidiVelocity) / 144.0f) * outSampleRate);
+                        }
+
+                        Segment              = VoiceEnvelopeSegment.Attack;
+                        SegmentIsExponential = false;
+                        Level                = 0.0f;
+                        Slope                = 1.0f / SamplesUntilNextSegment;
+                        return;
+                    }
+
+                    activeSegment = VoiceEnvelopeSegment.Attack;
+                    break;
+
+                case VoiceEnvelopeSegment.Attack:
+                    SamplesUntilNextSegment = (int)(Parameters.Hold * outSampleRate);
+                    if (SamplesUntilNextSegment > 0)
+                    {
+                        Segment              = VoiceEnvelopeSegment.Hold;
+                        SegmentIsExponential = false;
+                        Level                = 1.0f;
+                        Slope                = 0.0f;
+                        return;
+                    }
+
+                    activeSegment = VoiceEnvelopeSegment.Hold;
+                    break;
+
+                case VoiceEnvelopeSegment.Hold:
+                    SamplesUntilNextSegment = (int)(Parameters.Decay * outSampleRate);
+                    if (SamplesUntilNextSegment > 0)
+                    {
+                        Segment = VoiceEnvelopeSegment.Decay;
+                        Level   = 1.0f;
                         if (IsAmpEnv)
                         {
                             // I don't truly understand this; just following what LinuxSampler does.
                             var mysterySlope = (float)(-9.226 / SamplesUntilNextSegment);
-                            Slope = (float)Math.Exp(mysterySlope);
+                            Slope                = (float)Math.Exp(mysterySlope);
                             SegmentIsExponential = true;
+                            if (Parameters.Sustain > 0.0f)
+                            {
+                                // Again, this is following LinuxSampler's example, which is similar to
+                                // SF2-style decay, where "decay" specifies the time it would take to
+                                // get to zero, not to the sustain level.  The SFZ spec is not that
+                                // specific about what "decay" means, so perhaps it's really supposed
+                                // to specify the time to reach the sustain level.
+                                SamplesUntilNextSegment = (int)(Math.Log(Parameters.Sustain) / mysterySlope);
+                            }
                         }
                         else
                         {
-                            Slope = -Level / SamplesUntilNextSegment;
+                            Slope = (float)(-1.0 / SamplesUntilNextSegment);
+                            SamplesUntilNextSegment =
+                                (int)(Parameters.Decay * (1.0f - Parameters.Sustain) * outSampleRate);
                             SegmentIsExponential = false;
                         }
 
                         return;
-                    case VoiceEnvelopeSegment.Release:
-                    default:
-                        Segment = VoiceEnvelopeSegment.Done;
+                    }
+
+                    activeSegment = VoiceEnvelopeSegment.Decay;
+                    break;
+
+                case VoiceEnvelopeSegment.Decay:
+                    Segment                 = VoiceEnvelopeSegment.Sustain;
+                    Level                   = Parameters.Sustain;
+                    Slope                   = 0.0f;
+                    SamplesUntilNextSegment = 0x7FFFFFFF;
+                    SegmentIsExponential    = false;
+                    return;
+                case VoiceEnvelopeSegment.Sustain:
+                    Segment = VoiceEnvelopeSegment.Release;
+                    SamplesUntilNextSegment =
+                        (int)((Parameters.Release <= 0 ? FastReleaseTime : Parameters.Release) * outSampleRate);
+                    if (IsAmpEnv)
+                    {
+                        // I don't truly understand this; just following what LinuxSampler does.
+                        var mysterySlope = (float)(-9.226 / SamplesUntilNextSegment);
+                        Slope                = (float)Math.Exp(mysterySlope);
+                        SegmentIsExponential = true;
+                    }
+                    else
+                    {
+                        Slope                = -Level / SamplesUntilNextSegment;
                         SegmentIsExponential = false;
-                        Level = Slope = 0.0f;
-                        SamplesUntilNextSegment = 0x7FFFFFF;
-                        return;
-                }
+                    }
+
+                    return;
+                case VoiceEnvelopeSegment.Release:
+                default:
+                    Segment                 = VoiceEnvelopeSegment.Done;
+                    SegmentIsExponential    = false;
+                    Level                   = Slope = 0.0f;
+                    SamplesUntilNextSegment = 0x7FFFFFF;
+                    return;
             }
         }
+    }
 
-        public void Setup(
-            Envelope newParameters,
-            int midiNoteNumber,
-            int midiVelocity,
-            bool isAmpEnv,
-            float outSampleRate)
+    public void Setup(
+        Envelope newParameters,
+        int midiNoteNumber,
+        int midiVelocity,
+        bool isAmpEnv,
+        float outSampleRate)
+    {
+        Parameters = new Envelope(newParameters);
+        if (Parameters.KeynumToHold > 0)
         {
-            Parameters = new Envelope(newParameters);
-            if (Parameters.KeynumToHold > 0)
-            {
-                Parameters.Hold += Parameters.KeynumToHold * (60.0f - midiNoteNumber);
-                Parameters.Hold = Parameters.Hold < -10000.0f ? 0.0f : SynthHelper.Timecents2Secs(Parameters.Hold);
-            }
-
-            if (Parameters.KeynumToDecay > 0)
-            {
-                Parameters.Decay += Parameters.KeynumToDecay * (60.0f - midiNoteNumber);
-                Parameters.Decay = Parameters.Decay < -10000.0f ? 0.0f : SynthHelper.Timecents2Secs(Parameters.Decay);
-            }
-
-            MidiVelocity = (short)midiVelocity;
-            IsAmpEnv = isAmpEnv;
-            NextSegment(VoiceEnvelopeSegment.None, outSampleRate);
+            Parameters.Hold += Parameters.KeynumToHold * (60.0f - midiNoteNumber);
+            Parameters.Hold =  Parameters.Hold < -10000.0f ? 0.0f : SynthHelper.Timecents2Secs(Parameters.Hold);
         }
 
-        public void Process(int numSamples, float outSampleRate)
+        if (Parameters.KeynumToDecay > 0)
         {
-            if (Slope > 0)
-            {
-                if (SegmentIsExponential) Level *= (float)Math.Pow(Slope, numSamples);
-                else Level += Slope * numSamples;
-            }
+            Parameters.Decay += Parameters.KeynumToDecay * (60.0f - midiNoteNumber);
+            Parameters.Decay =  Parameters.Decay < -10000.0f ? 0.0f : SynthHelper.Timecents2Secs(Parameters.Decay);
+        }
 
-            if ((SamplesUntilNextSegment -= numSamples) <= 0)
-            {
-                NextSegment(Segment, outSampleRate);
-            }
+        MidiVelocity = (short)midiVelocity;
+        IsAmpEnv     = isAmpEnv;
+        NextSegment(VoiceEnvelopeSegment.None, outSampleRate);
+    }
+
+    public void Process(int numSamples, float outSampleRate)
+    {
+        if (Slope > 0)
+        {
+            if (SegmentIsExponential) Level *= (float)Math.Pow(Slope, numSamples);
+            else Level                      += Slope * numSamples;
+        }
+
+        if ((SamplesUntilNextSegment -= numSamples) <= 0)
+        {
+            NextSegment(Segment, outSampleRate);
         }
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/VoiceEnvelopeSegment.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/VoiceEnvelopeSegment.cs
@@ -31,16 +31,15 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
  * USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis;
+
+internal enum VoiceEnvelopeSegment
 {
-    internal enum VoiceEnvelopeSegment
-    {
-        None,
-        Delay,
-        Attack,
-        Hold,
-        Decay,
-        Sustain,
-        Release, Done
-    }
+    None,
+    Delay,
+    Attack,
+    Hold,
+    Decay,
+    Sustain,
+    Release, Done
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/VoiceLfo.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/VoiceLfo.cs
@@ -45,8 +45,8 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
         public void Setup(float delay, int freqCents, float outSampleRate)
         {
             SamplesUntil = (int)(delay * outSampleRate);
-            Delta = (4.0f * SynthHelper.Cents2Hertz(freqCents) / outSampleRate);
-            Level = 0;
+            Delta        = 4.0f * SynthHelper.Cents2Hertz(freqCents) / outSampleRate;
+            Level        = 0;
         }
 
         public void Process(int blockSamples)
@@ -57,15 +57,16 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
                 return;
             }
             Level += Delta * blockSamples;
-            if (Level > 1.0f)
+            switch (Level)
             {
-                Delta = -Delta;
-                Level = 2.0f - Level;
-            }
-            else if (Level < -1.0f)
-            {
-                Delta = -Delta;
-                Level = -2.0f - Level;
+                case > 1.0f:
+                    Delta = -Delta;
+                    Level = 2.0f - Level;
+                    break;
+                case < -1.0f:
+                    Delta = -Delta;
+                    Level = -2.0f - Level;
+                    break;
             }
         }
     }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/VoiceLfo.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/VoiceLfo.cs
@@ -34,40 +34,39 @@
 
 using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Util;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis;
+
+internal class VoiceLfo
 {
-    internal class VoiceLfo
+    public int SamplesUntil { get; set; }
+    public float Level { get; set; }
+    public float Delta { get; set; }
+
+    public void Setup(float delay, int freqCents, float outSampleRate)
     {
-        public int SamplesUntil { get; set; }
-        public float Level { get; set; }
-        public float Delta { get; set; }
+        SamplesUntil = (int)(delay * outSampleRate);
+        Delta        = 4.0f * SynthHelper.Cents2Hertz(freqCents) / outSampleRate;
+        Level        = 0;
+    }
 
-        public void Setup(float delay, int freqCents, float outSampleRate)
+    public void Process(int blockSamples)
+    {
+        if (SamplesUntil > blockSamples)
         {
-            SamplesUntil = (int)(delay * outSampleRate);
-            Delta        = 4.0f * SynthHelper.Cents2Hertz(freqCents) / outSampleRate;
-            Level        = 0;
+            SamplesUntil -= blockSamples;
+            return;
         }
-
-        public void Process(int blockSamples)
+        Level += Delta * blockSamples;
+        switch (Level)
         {
-            if (SamplesUntil > blockSamples)
-            {
-                SamplesUntil -= blockSamples;
-                return;
-            }
-            Level += Delta * blockSamples;
-            switch (Level)
-            {
-                case > 1.0f:
-                    Delta = -Delta;
-                    Level = 2.0f - Level;
-                    break;
-                case < -1.0f:
-                    Delta = -Delta;
-                    Level = -2.0f - Level;
-                    break;
-            }
+            case > 1.0f:
+                Delta = -Delta;
+                Level = 2.0f - Level;
+                break;
+            case < -1.0f:
+                Delta = -Delta;
+                Level = -2.0f - Level;
+                break;
         }
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/VoiceLowPass.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Synthesis/VoiceLowPass.cs
@@ -34,52 +34,51 @@
 
 using System;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Synthesis;
+
+internal class VoiceLowPass
 {
-    internal class VoiceLowPass
+    public double QInv { get; set; }
+    public double A0 { get; set; }
+    public double A1 { get; set; }
+    public double B1 { get; set; }
+    public double B2 { get; set; }
+    public double Z1 { get; set; }
+    public double Z2 { get; set; }
+    public bool Active { get; set; }
+
+    public VoiceLowPass()
     {
-        public double QInv { get; set; }
-        public double A0 { get; set; }
-        public double A1 { get; set; }
-        public double B1 { get; set; }
-        public double B2 { get; set; }
-        public double Z1 { get; set; }
-        public double Z2 { get; set; }
-        public bool Active { get; set; }
+    }
 
-        public VoiceLowPass()
-        {
-        }
+    public VoiceLowPass(VoiceLowPass other)
+    {
+        QInv   = other.QInv;
+        A0     = other.A0;
+        A1     = other.A1;
+        B1     = other.B1;
+        B2     = other.B2;
+        Z1     = other.Z1;
+        Z2     = other.Z2;
+        Active = other.Active;
+    }
 
-        public VoiceLowPass(VoiceLowPass other)
-        {
-            QInv = other.QInv;
-            A0 = other.A0;
-            A1 = other.A1;
-            B1 = other.B1;
-            B2 = other.B2;
-            Z1 = other.Z1;
-            Z2 = other.Z2;
-            Active = other.Active;
-        }
+    public void Setup(float fc)
+    {
+        // Lowpass filter from http://www.earlevel.com/main/2012/11/26/biquad-c-source-code/
+        double k = Math.Tan(Math.PI * fc), KK = k * k;
+        var norm = 1 / (1 + k * QInv + KK);
+        A0 = KK * norm;
+        A1 = 2 * A0;
+        B1 = 2 * (KK - 1) * norm;
+        B2 = (1 - k * QInv + KK) * norm;
+    }
 
-        public void Setup(float fc)
-        {
-            // Lowpass filter from http://www.earlevel.com/main/2012/11/26/biquad-c-source-code/
-            double k = Math.Tan(Math.PI * fc), KK = k * k;
-            var norm = 1 / (1 + k * QInv + KK);
-            A0 = KK * norm;
-            A1 = 2 * A0;
-            B1 = 2 * (KK - 1) * norm;
-            B2 = (1 - k * QInv + KK) * norm;
-        }
-
-        public float Process(float input)
-        {
-            var output = input * A0 + Z1;
-            Z1 = input * A1 + Z2 -B1 * output;
-            Z2 = input * A0 - B2 * output;
-            return (float)output;
-        }
+    public float Process(float input)
+    {
+        var output = input * A0 + Z1;
+        Z1 = input * A1 + Z2 -B1 * output;
+        Z2 = input * A0 - B2 * output;
+        return (float)output;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Util/SynthConstants.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Util/SynthConstants.cs
@@ -31,19 +31,18 @@
  * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
  * USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Util
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Util;
+
+internal static class SynthConstants
 {
-    internal static class SynthConstants
-    {
-        public const int AudioChannels = 2;
+    public const int AudioChannels = 2;
 
-        public const float MinVolume = 0f;
-        public const float MaxVolume = 1f;
+    public const float MinVolume = 0f;
+    public const float MaxVolume = 1f;
 
-        public const byte MinProgram = 0;
-        public const byte MaxProgram = 127;
+    public const byte MinProgram = 0;
+    public const byte MaxProgram = 127;
 
-        public const double MinPlaybackSpeed = 0.125;
-        public const double MaxPlaybackSpeed = 8;
-    }
+    public const double MinPlaybackSpeed = 0.125;
+    public const double MaxPlaybackSpeed = 8;
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Util/SynthHelper.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Util/SynthHelper.cs
@@ -26,7 +26,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Util
 
         public static float GainToDecibels(float gain)
         {
-            return (gain <= .00001f ? -100f : (float)(20.0 * Math.Log10(gain)));
+            return gain <= .00001f ? -100f : (float)(20.0 * Math.Log10(gain));
         }
 
         public static float Cents2Hertz(float cents)
@@ -41,12 +41,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Util
                 return min;
             }
 
-            if (value >= max)
-            {
-                return max;
-            }
-
-            return value;
+            return value >= max ? max : value;
         }
 
         public static double ClampD(double value, double min, double max)
@@ -56,12 +51,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Util
                 return min;
             }
 
-            if (value >= max)
-            {
-                return max;
-            }
-
-            return value;
+            return value >= max ? max : value;
         }
 
         public static float ClampF(float value, float min, float max)
@@ -71,12 +61,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Util
                 return min;
             }
 
-            if (value >= max)
-            {
-                return max;
-            }
-
-            return value;
+            return value >= max ? max : value;
         }
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Util/SynthHelper.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Audio/Synth/Util/SynthHelper.cs
@@ -5,63 +5,62 @@
 
 using System;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Util
+namespace BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Util;
+
+internal static class SynthHelper
 {
-    internal static class SynthHelper
+    public static float Timecents2Secs(float timecents)
     {
-        public static float Timecents2Secs(float timecents)
-        {
-            return (float)Math.Pow(2f, timecents / 1200f);
-        }
+        return (float)Math.Pow(2f, timecents / 1200f);
+    }
 
-        public static double Timecents2Secs(double timecents)
-        {
-            return Math.Pow(2.0, timecents / 1200.0);
-        }
+    public static double Timecents2Secs(double timecents)
+    {
+        return Math.Pow(2.0, timecents / 1200.0);
+    }
 
-        public static float DecibelsToGain(float db)
-        {
-            return db > -100f ? (float)Math.Pow(10.0f, db * 0.05f) : 0;
-        }
+    public static float DecibelsToGain(float db)
+    {
+        return db > -100f ? (float)Math.Pow(10.0f, db * 0.05f) : 0;
+    }
 
-        public static float GainToDecibels(float gain)
-        {
-            return gain <= .00001f ? -100f : (float)(20.0 * Math.Log10(gain));
-        }
+    public static float GainToDecibels(float gain)
+    {
+        return gain <= .00001f ? -100f : (float)(20.0 * Math.Log10(gain));
+    }
 
-        public static float Cents2Hertz(float cents)
-        {
-            return 8.176f * (float)Math.Pow(2.0f, cents / 1200.0f);
-        }
+    public static float Cents2Hertz(float cents)
+    {
+        return 8.176f * (float)Math.Pow(2.0f, cents / 1200.0f);
+    }
         
-        public static byte ClampB(byte value, byte min, byte max)
+    public static byte ClampB(byte value, byte min, byte max)
+    {
+        if (value <= min)
         {
-            if (value <= min)
-            {
-                return min;
-            }
-
-            return value >= max ? max : value;
+            return min;
         }
 
-        public static double ClampD(double value, double min, double max)
-        {
-            if (value <= min)
-            {
-                return min;
-            }
+        return value >= max ? max : value;
+    }
 
-            return value >= max ? max : value;
+    public static double ClampD(double value, double min, double max)
+    {
+        if (value <= min)
+        {
+            return min;
         }
 
-        public static float ClampF(float value, float min, float max)
-        {
-            if (value <= min)
-            {
-                return min;
-            }
+        return value >= max ? max : value;
+    }
 
-            return value >= max ? max : value;
+    public static float ClampF(float value, float min, float max)
+    {
+        if (value <= min)
+        {
+            return min;
         }
+
+        return value >= max ? max : value;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Collections/FastDictionary.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Collections/FastDictionary.cs
@@ -7,73 +7,72 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Collections
+namespace BardMusicPlayer.Siren.AlphaTab.Collections;
+
+/// <summary>
+/// Represents a collection of key-value pairs. 
+/// </summary>
+/// <typeparam name="TKey"></typeparam>
+/// <typeparam name="TValue"></typeparam>
+internal class FastDictionary<TKey, TValue> : IEnumerable<TKey>
 {
+    private readonly Dictionary<TKey, TValue> _dictionary;
+
     /// <summary>
-    /// Represents a collection of key-value pairs. 
+    /// Initializes a new instance of the <see cref="FastDictionary{TKey, TValue}"/> class.
     /// </summary>
-    /// <typeparam name="TKey"></typeparam>
-    /// <typeparam name="TValue"></typeparam>
-    internal class FastDictionary<TKey, TValue> : IEnumerable<TKey>
+    public FastDictionary()
     {
-        private readonly Dictionary<TKey, TValue> _dictionary;
+        _dictionary = new Dictionary<TKey, TValue>();
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FastDictionary{TKey, TValue}"/> class.
-        /// </summary>
-        public FastDictionary()
-        {
-            _dictionary = new Dictionary<TKey, TValue>();
-        }
+    /// <summary>
+    /// Gets or sets the value at the specified index.
+    /// </summary>
+    /// <param name="index">The key to access the item.</param>
+    /// <returns>The value stored at the specified index.</returns>
+    [IndexerName("Item")]
+    public TValue this[TKey index]
+    {
+        get => _dictionary[index];
+        set => _dictionary[index] = value;
+    }
 
-        /// <summary>
-        /// Gets or sets the value at the specified index.
-        /// </summary>
-        /// <param name="index">The key to access the item.</param>
-        /// <returns>The value stored at the specified index.</returns>
-        [IndexerName("Item")]
-        public TValue this[TKey index]
-        {
-            get => _dictionary[index];
-            set => _dictionary[index] = value;
-        }
+    /// <summary>
+    /// Gets the number of elements stored in this dictionary
+    /// </summary>
+    public int Count => _dictionary.Count;
 
-        /// <summary>
-        /// Gets the number of elements stored in this dictionary
-        /// </summary>
-        public int Count => _dictionary.Count;
+    /// <inheritdoc />
+    public IEnumerator<TKey> GetEnumerator()
+    {
+        return _dictionary.Keys.GetEnumerator();
+    }
 
-        /// <inheritdoc />
-        public IEnumerator<TKey> GetEnumerator()
-        {
-            return _dictionary.Keys.GetEnumerator();
-        }
+    /// <summary>
+    /// Removes the value with the specified key.
+    /// </summary>
+    /// <param name="key">The key to remove from the dictionary. </param>
+    public void Remove(TKey key)
+    {
+        _dictionary.Remove(key);
+    }
 
-        /// <summary>
-        /// Removes the value with the specified key.
-        /// </summary>
-        /// <param name="key">The key to remove from the dictionary. </param>
-        public void Remove(TKey key)
-        {
-            _dictionary.Remove(key);
-        }
+    /// <summary>
+    /// Determines whether the dictionary container contains the specified key.
+    /// </summary>
+    /// <param name="key">The key to check the existence for.</param>
+    /// <returns>
+    ///   <c>true</c> if the specified key is contained; otherwise, <c>false</c>.
+    /// </returns>
+    public bool ContainsKey(TKey key)
+    {
+        return _dictionary.ContainsKey(key);
+    }
 
-        /// <summary>
-        /// Determines whether the dictionary container contains the specified key.
-        /// </summary>
-        /// <param name="key">The key to check the existence for.</param>
-        /// <returns>
-        ///   <c>true</c> if the specified key is contained; otherwise, <c>false</c>.
-        /// </returns>
-        public bool ContainsKey(TKey key)
-        {
-            return _dictionary.ContainsKey(key);
-        }
-
-        /// <inheritdoc />
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Collections/FastList.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Collections/FastList.cs
@@ -8,137 +8,136 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Collections
+namespace BardMusicPlayer.Siren.AlphaTab.Collections;
+
+/// <summary>
+/// Represents a strongly typed list of elements. 
+/// </summary>
+/// <typeparam name="T">The type fo the elements</typeparam>
+/// <seealso cref="System.Collections.Generic.IEnumerable{T}" />
+internal class FastList<T> : IEnumerable<T>
 {
+    private readonly List<T> _list;
+
     /// <summary>
-    /// Represents a strongly typed list of elements. 
+    /// Initializes a new instance of the <see cref="FastList{T}" /> class.
     /// </summary>
-    /// <typeparam name="T">The type fo the elements</typeparam>
-    /// <seealso cref="System.Collections.Generic.IEnumerable{T}" />
-    internal class FastList<T> : IEnumerable<T>
+    public FastList()
     {
-        private readonly List<T> _list;
+        _list = new List<T>();
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FastList{T}" /> class.
-        /// </summary>
-        public FastList()
-        {
-            _list = new List<T>();
-        }
+    private FastList(IEnumerable<T> collection)
+    {
+        _list = new List<T>(collection);
+    }
 
-        private FastList(IEnumerable<T> collection)
-        {
-            _list = new List<T>(collection);
-        }
+    /// <summary>
+    /// Gets the number of elements contained in the list.
+    /// </summary>
+    public int Count => _list.Count;
 
-        /// <summary>
-        /// Gets the number of elements contained in the list.
-        /// </summary>
-        public int Count => _list.Count;
+    /// <summary>
+    /// Gets or sets the value at the specified index.
+    /// </summary>
+    /// <param name="index">The index of which item to access.</param>
+    /// <returns>The item located at the specified index. </returns>
+    [IndexerName("Item")]
+    public T this[int index]
+    {
+        get => _list[index];
+        set => _list[index] = value;
+    }
 
-        /// <summary>
-        /// Gets or sets the value at the specified index.
-        /// </summary>
-        /// <param name="index">The index of which item to access.</param>
-        /// <returns>The item located at the specified index. </returns>
-        [IndexerName("Item")]
-        public T this[int index]
-        {
-            get => _list[index];
-            set => _list[index] = value;
-        }
+    /// <summary>
+    /// Adds the specified item to the list. 
+    /// </summary>
+    /// <param name="item">The item to be added.</param>
+    public void Add(T item)
+    {
+        _list.Add(item);
+    }
 
-        /// <summary>
-        /// Adds the specified item to the list. 
-        /// </summary>
-        /// <param name="item">The item to be added.</param>
-        public void Add(T item)
-        {
-            _list.Add(item);
-        }
+    /// <summary>
+    /// Sorts the elements in the list using the specified comparison.
+    /// </summary>
+    /// <param name="comparison">The comparison to use when comparing elements for sorting.</param>
+    public void Sort(Comparison<T> comparison)
+    {
+        _list.Sort(comparison);
+    }
 
-        /// <summary>
-        /// Sorts the elements in the list using the specified comparison.
-        /// </summary>
-        /// <param name="comparison">The comparison to use when comparing elements for sorting.</param>
-        public void Sort(Comparison<T> comparison)
-        {
-            _list.Sort(comparison);
-        }
+    /// <summary>
+    /// Clones this instance.
+    /// </summary>
+    /// <returns></returns>
+    public FastList<T> Clone()
+    {
+        return new FastList<T>(this);
+    }
 
-        /// <summary>
-        /// Clones this instance.
-        /// </summary>
-        /// <returns></returns>
-        public FastList<T> Clone()
-        {
-            return new FastList<T>(this);
-        }
+    /// <summary>
+    /// Removes the item at the specified index. 
+    /// </summary>
+    /// <param name="index">The index to remove.</param>
+    public void RemoveAt(int index)
+    {
+        _list.RemoveAt(index);
+    }
 
-        /// <summary>
-        /// Removes the item at the specified index. 
-        /// </summary>
-        /// <param name="index">The index to remove.</param>
-        public void RemoveAt(int index)
-        {
-            _list.RemoveAt(index);
-        }
+    /// <summary>
+    /// Converts the current list into an array of all elements. 
+    /// </summary>
+    /// <returns>An array containing all elements. </returns>
+    public T[] ToArray()
+    {
+        return _list.ToArray();
+    }
 
-        /// <summary>
-        /// Converts the current list into an array of all elements. 
-        /// </summary>
-        /// <returns>An array containing all elements. </returns>
-        public T[] ToArray()
-        {
-            return _list.ToArray();
-        }
+    /// <inheritdoc />
+    public IEnumerator<T> GetEnumerator()
+    {
+        return _list.GetEnumerator();
+    }
 
-        /// <inheritdoc />
-        public IEnumerator<T> GetEnumerator()
-        {
-            return _list.GetEnumerator();
-        }
+    /// <summary>
+    /// Searches for the given item in the list and returns the index. 
+    /// </summary>
+    /// <param name="item">The item to search</param>
+    /// <returns>The index at which the specified item was found, or -1 if the item is not contained in the list.</returns>
+    public int IndexOf(T item)
+    {
+        return _list.IndexOf(item);
+    }
 
-        /// <summary>
-        /// Searches for the given item in the list and returns the index. 
-        /// </summary>
-        /// <param name="item">The item to search</param>
-        /// <returns>The index at which the specified item was found, or -1 if the item is not contained in the list.</returns>
-        public int IndexOf(T item)
-        {
-            return _list.IndexOf(item);
-        }
+    /// <summary>
+    /// Reverses the items in the list
+    /// </summary>
+    public void Reverse()
+    {
+        _list.Reverse();
+    }
 
-        /// <summary>
-        /// Reverses the items in the list
-        /// </summary>
-        public void Reverse()
-        {
-            _list.Reverse();
-        }
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+    /// <summary>
+    /// Inserts an element at the specified index. 
+    /// </summary>
+    /// <param name="insertPos">The index at which the item should be inserted</param>
+    /// <param name="item">The item to insert.</param>
+    public void InsertAt(int insertPos, T item)
+    {
+        _list.Insert(insertPos, item);
+    }
 
-        /// <summary>
-        /// Inserts an element at the specified index. 
-        /// </summary>
-        /// <param name="insertPos">The index at which the item should be inserted</param>
-        /// <param name="item">The item to insert.</param>
-        public void InsertAt(int insertPos, T item)
-        {
-            _list.Insert(insertPos, item);
-        }
-
-        /// <summary>
-        /// Remove all elements from the list.
-        /// </summary>
-        public void Clear()
-        {
-            _list.Clear();
-        }
+    /// <summary>
+    /// Remove all elements from the list.
+    /// </summary>
+    public void Clear()
+    {
+        _list.Clear();
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Collections/StringBuilder.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Collections/StringBuilder.cs
@@ -3,25 +3,24 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Collections
+namespace BardMusicPlayer.Siren.AlphaTab.Collections;
+
+internal class StringBuilder
 {
-    internal class StringBuilder
+    private readonly System.Text.StringBuilder _sb;
+
+    public StringBuilder()
     {
-        private readonly System.Text.StringBuilder _sb;
+        _sb = new System.Text.StringBuilder();
+    }
 
-        public StringBuilder()
-        {
-            _sb = new System.Text.StringBuilder();
-        }
+    public void AppendChar(int i)
+    {
+        _sb.Append(Platform.StringFromCharCode(i));
+    }
 
-        public void AppendChar(int i)
-        {
-            _sb.Append(Platform.StringFromCharCode(i));
-        }
-
-        public override string ToString()
-        {
-            return _sb.ToString();
-        }
+    public override string ToString()
+    {
+        return _sb.ToString();
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/IO/ByteBuffer.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/IO/ByteBuffer.cs
@@ -7,7 +7,7 @@ using System;
 
 namespace BardMusicPlayer.Siren.AlphaTab.IO
 {
-    internal class ByteBuffer : IWriteable, IReadable
+    internal sealed class ByteBuffer : IWriteable, IReadable
     {
         private byte[] _buffer;
         private int _capacity;
@@ -16,7 +16,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.IO
 
         public int Position { get; set; }
 
-        public virtual byte[] GetBuffer()
+        public byte[] GetBuffer()
         {
             return _buffer;
         }
@@ -24,21 +24,25 @@ namespace BardMusicPlayer.Siren.AlphaTab.IO
 
         public static ByteBuffer Empty()
         {
-            return WithCapactiy(0);
+            return WithCapacity(0);
         }
 
-        public static ByteBuffer WithCapactiy(int capacity)
+        public static ByteBuffer WithCapacity(int capacity)
         {
-            var buffer = new ByteBuffer();
-            buffer._buffer = new byte[capacity];
-            buffer._capacity = capacity;
+            var buffer = new ByteBuffer
+            {
+                _buffer   = new byte[capacity],
+                _capacity = capacity
+            };
             return buffer;
         }
 
         public static ByteBuffer FromBuffer(byte[] data)
         {
-            var buffer = new ByteBuffer();
-            buffer._buffer = data;
+            var buffer = new ByteBuffer
+            {
+                _buffer = data
+            };
             buffer._capacity = buffer.Length = data.Length;
             return buffer;
         }
@@ -99,22 +103,23 @@ namespace BardMusicPlayer.Siren.AlphaTab.IO
                 n = count;
             }
 
-            if (n <= 0)
+            switch (n)
             {
-                return 0;
-            }
-
-            if (n <= 8)
-            {
-                var byteCount = n;
-                while (--byteCount >= 0)
+                case <= 0:
+                    return 0;
+                case <= 8:
                 {
-                    buffer[offset + byteCount] = _buffer[Position + byteCount];
+                    var byteCount = n;
+                    while (--byteCount >= 0)
+                    {
+                        buffer[offset + byteCount] = _buffer[Position + byteCount];
+                    }
+
+                    break;
                 }
-            }
-            else
-            {
-                Platform.BlockCopy(_buffer, Position, buffer, offset, n);
+                default:
+                    Platform.BlockCopy(_buffer, Position, buffer, offset, n);
+                    break;
             }
 
             Position += n;
@@ -183,7 +188,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.IO
             return ToArray();
         }
 
-        public virtual byte[] ToArray()
+        public byte[] ToArray()
         {
             var copy = new byte[Length];
             Platform.BlockCopy(_buffer, 0, copy, 0, Length);

--- a/BardMusicPlayer.Siren/AlphaTab/IO/IOHelper.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/IO/IOHelper.cs
@@ -54,12 +54,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.IO
             }
 
             var t = s.ToString();
-            if (z >= 0)
-            {
-                return t.Substring(0, z);
-            }
-
-            return t;
+            return z >= 0 ? t.Substring(0, z) : t;
         }
 
 

--- a/BardMusicPlayer.Siren/AlphaTab/IO/IOHelper.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/IO/IOHelper.cs
@@ -5,58 +5,57 @@
 
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 
-namespace BardMusicPlayer.Siren.AlphaTab.IO
+namespace BardMusicPlayer.Siren.AlphaTab.IO;
+
+internal static class IOHelper
 {
-    internal static class IOHelper
+
+    public static uint ReadUInt32LE(this IReadable input)
     {
+        var ch1 = input.ReadByte();
+        var ch2 = input.ReadByte();
+        var ch3 = input.ReadByte();
+        var ch4 = input.ReadByte();
 
-        public static uint ReadUInt32LE(this IReadable input)
+        return Platform.ToUInt32((ch4 << 24) | (ch3 << 16) | (ch2 << 8) | ch1);
+    }
+
+    public static ushort ReadUInt16LE(this IReadable input)
+    {
+        var ch1 = input.ReadByte();
+        var ch2 = input.ReadByte();
+
+        return Platform.ToUInt16((ch2 << 8) | ch1);
+    }
+
+    public static short ReadInt16LE(this IReadable input)
+    {
+        var ch1 = input.ReadByte();
+        var ch2 = input.ReadByte();
+
+        return Platform.ToInt16((ch2 << 8) | ch1);
+    }
+
+
+
+    public static string Read8BitStringLength(this IReadable input, int length)
+    {
+        var s = new StringBuilder();
+        var z = -1;
+        for (var i = 0; i < length; i++)
         {
-            var ch1 = input.ReadByte();
-            var ch2 = input.ReadByte();
-            var ch3 = input.ReadByte();
-            var ch4 = input.ReadByte();
-
-            return Platform.ToUInt32((ch4 << 24) | (ch3 << 16) | (ch2 << 8) | ch1);
-        }
-
-        public static ushort ReadUInt16LE(this IReadable input)
-        {
-            var ch1 = input.ReadByte();
-            var ch2 = input.ReadByte();
-
-            return Platform.ToUInt16((ch2 << 8) | ch1);
-        }
-
-        public static short ReadInt16LE(this IReadable input)
-        {
-            var ch1 = input.ReadByte();
-            var ch2 = input.ReadByte();
-
-            return Platform.ToInt16((ch2 << 8) | ch1);
-        }
-
-
-
-        public static string Read8BitStringLength(this IReadable input, int length)
-        {
-            var s = new StringBuilder();
-            var z = -1;
-            for (var i = 0; i < length; i++)
+            var c = input.ReadByte();
+            if (c == 0 && z == -1)
             {
-                var c = input.ReadByte();
-                if (c == 0 && z == -1)
-                {
-                    z = i;
-                }
-
-                s.AppendChar(c);
+                z = i;
             }
 
-            var t = s.ToString();
-            return z >= 0 ? t.Substring(0, z) : t;
+            s.AppendChar(c);
         }
 
-
+        var t = s.ToString();
+        return z >= 0 ? t.Substring(0, z) : t;
     }
+
+
 }

--- a/BardMusicPlayer.Siren/AlphaTab/IO/IReadable.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/IO/IReadable.cs
@@ -3,53 +3,52 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.IO
+namespace BardMusicPlayer.Siren.AlphaTab.IO;
+
+/// <summary>
+/// Represents a stream of binary data that can be read from. 
+/// </summary>
+internal interface IReadable
 {
     /// <summary>
-    /// Represents a stream of binary data that can be read from. 
+    /// Gets or sets the current read position relative in the stream. 
     /// </summary>
-    internal interface IReadable
-    {
-        /// <summary>
-        /// Gets or sets the current read position relative in the stream. 
-        /// </summary>
-        int Position { get; set; }
+    int Position { get; set; }
 
-        /// <summary>
-        /// Gets the total number of bytes contained in the stream. 
-        /// </summary>
-        int Length { get; }
+    /// <summary>
+    /// Gets the total number of bytes contained in the stream. 
+    /// </summary>
+    int Length { get; }
 
-        /// <summary>
-        /// Resets the stream for reading the data from the beginning. 
-        /// </summary>
-        void Reset();
+    /// <summary>
+    /// Resets the stream for reading the data from the beginning. 
+    /// </summary>
+    void Reset();
 
-        /// <summary>
-        /// Skip the given number of bytes. 
-        /// </summary>
-        /// <param name="offset">The number of bytes to skip. </param>
-        void Skip(int offset);
+    /// <summary>
+    /// Skip the given number of bytes. 
+    /// </summary>
+    /// <param name="offset">The number of bytes to skip. </param>
+    void Skip(int offset);
 
-        /// <summary>
-        /// Read a single byte from the data stream. 
-        /// </summary>
-        /// <returns>The value of the next byte or -1 if there is no more data. </returns>
-        int ReadByte();
+    /// <summary>
+    /// Read a single byte from the data stream. 
+    /// </summary>
+    /// <returns>The value of the next byte or -1 if there is no more data. </returns>
+    int ReadByte();
 
-        /// <summary>
-        /// Reads the given number of bytes from the stream into the given buffer. 
-        /// </summary>
-        /// <param name="buffer">The buffer to fill. </param>
-        /// <param name="offset">The offset in the buffer where to start writing. </param>
-        /// <param name="count">The number of bytes to read. </param>
-        /// <returns></returns>
-        int Read(byte[] buffer, int offset, int count);
+    /// <summary>
+    /// Reads the given number of bytes from the stream into the given buffer. 
+    /// </summary>
+    /// <param name="buffer">The buffer to fill. </param>
+    /// <param name="offset">The offset in the buffer where to start writing. </param>
+    /// <param name="count">The number of bytes to read. </param>
+    /// <returns></returns>
+    int Read(byte[] buffer, int offset, int count);
 
-        /// <summary>
-        /// Reads the remaining data. 
-        /// </summary>
-        /// <returns></returns>
-        byte[] ReadAll();
-    }
+    /// <summary>
+    /// Reads the remaining data. 
+    /// </summary>
+    /// <returns></returns>
+    byte[] ReadAll();
 }

--- a/BardMusicPlayer.Siren/AlphaTab/IO/IWriteable.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/IO/IWriteable.cs
@@ -3,25 +3,24 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.IO
+namespace BardMusicPlayer.Siren.AlphaTab.IO;
+
+/// <summary>
+/// Represents a writer where binary data can be written to. 
+/// </summary>
+internal interface IWriteable
 {
     /// <summary>
-    /// Represents a writer where binary data can be written to. 
+    /// Write a single byte to the stream. 
     /// </summary>
-    internal interface IWriteable
-    {
-        /// <summary>
-        /// Write a single byte to the stream. 
-        /// </summary>
-        /// <param name="value">The value to write.</param>
-        void WriteByte(byte value);
+    /// <param name="value">The value to write.</param>
+    void WriteByte(byte value);
 
-        /// <summary>
-        /// Write data from the given buffer. 
-        /// </summary>
-        /// <param name="buffer">The buffer to get the data from. </param>
-        /// <param name="offset">The offset where to start reading the data.</param>
-        /// <param name="count">The number of bytes to write</param>
-        void Write(byte[] buffer, int offset, int count);
-    }
+    /// <summary>
+    /// Write data from the given buffer. 
+    /// </summary>
+    /// <param name="buffer">The buffer to get the data from. </param>
+    /// <param name="offset">The offset where to start reading the data.</param>
+    /// <param name="count">The number of bytes to write</param>
+    void Write(byte[] buffer, int offset, int count);
 }

--- a/BardMusicPlayer.Siren/AlphaTab/ManagedThreadAlphaSynthWorkerApi.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/ManagedThreadAlphaSynthWorkerApi.cs
@@ -9,84 +9,83 @@ using System.Threading;
 using BardMusicPlayer.Siren.AlphaTab.Audio.Synth;
 using BardMusicPlayer.Siren.AlphaTab.Util;
 
-namespace BardMusicPlayer.Siren.AlphaTab
+namespace BardMusicPlayer.Siren.AlphaTab;
+
+internal class ManagedThreadAlphaSynthWorkerApi : AlphaSynthWorkerApiBase
 {
-    internal class ManagedThreadAlphaSynthWorkerApi : AlphaSynthWorkerApiBase
+    private readonly Action<Action> _uiInvoke;
+    private readonly Thread _workerThread;
+    private BlockingCollection<Action> _workerQueue;
+    private CancellationTokenSource _workerCancellationToken;
+    private readonly ManualResetEventSlim _threadStartedEvent;
+
+    public ManagedThreadAlphaSynthWorkerApi(ISynthOutput output, LogLevel logLevel, Action<Action> uiInvoke)
+        : base(output, logLevel)
     {
-        private readonly Action<Action> _uiInvoke;
-        private readonly Thread _workerThread;
-        private BlockingCollection<Action> _workerQueue;
-        private CancellationTokenSource _workerCancellationToken;
-        private readonly ManualResetEventSlim _threadStartedEvent;
+        _uiInvoke = uiInvoke;
 
-        public ManagedThreadAlphaSynthWorkerApi(ISynthOutput output, LogLevel logLevel, Action<Action> uiInvoke)
-            : base(output, logLevel)
+        _threadStartedEvent      = new ManualResetEventSlim(false);
+        _workerQueue             = new BlockingCollection<Action>();
+        _workerCancellationToken = new CancellationTokenSource();
+
+        _workerThread = new Thread(DoWork)
         {
-            _uiInvoke = uiInvoke;
+            IsBackground = true
+        };
+        _workerThread.Start();
 
-            _threadStartedEvent = new ManualResetEventSlim(false);
-            _workerQueue = new BlockingCollection<Action>();
-            _workerCancellationToken = new CancellationTokenSource();
+        _threadStartedEvent.Wait();
+        _workerQueue.Add(Initialize);
+        _threadStartedEvent.Dispose();
+        _threadStartedEvent = null;
+    }
 
-            _workerThread              = new Thread(DoWork)
+    public override void Destroy()
+    {
+        _workerCancellationToken.Cancel();
+        _workerThread.Join();
+    }
+
+    protected override void DispatchOnUiThread(Action action)
+    {
+        _uiInvoke(action);
+    }
+
+    private bool CheckAccess()
+    {
+        return Thread.CurrentThread == _workerThread;
+    }
+
+    protected override void DispatchOnWorkerThread(Action action)
+    {
+        if (CheckAccess())
+        {
+            action();
+        }
+        else
+        {
+            _workerQueue.Add(action);
+        }
+    }
+
+    private void DoWork()
+    {
+        try
+        {
+            _threadStartedEvent.Set();
+            while (_workerQueue.TryTake(out var action, Timeout.Infinite, _workerCancellationToken.Token))
             {
-                IsBackground = true
-            };
-            _workerThread.Start();
+                if (_workerCancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
 
-            _threadStartedEvent.Wait();
-            _workerQueue.Add(Initialize);
-            _threadStartedEvent.Dispose();
-            _threadStartedEvent = null;
-        }
-
-        public override void Destroy()
-        {
-            _workerCancellationToken.Cancel();
-            _workerThread.Join();
-        }
-
-        protected override void DispatchOnUiThread(Action action)
-        {
-            _uiInvoke(action);
-        }
-
-        private bool CheckAccess()
-        {
-            return Thread.CurrentThread == _workerThread;
-        }
-
-        protected override void DispatchOnWorkerThread(Action action)
-        {
-            if (CheckAccess())
-            {
                 action();
             }
-            else
-            {
-                _workerQueue.Add(action);
-            }
         }
-
-        private void DoWork()
+        catch (OperationCanceledException)
         {
-            try
-            {
-                _threadStartedEvent.Set();
-                while (_workerQueue.TryTake(out var action, Timeout.Infinite, _workerCancellationToken.Token))
-                {
-                    if (_workerCancellationToken.IsCancellationRequested)
-                    {
-                        break;
-                    }
-
-                    action();
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                // Ignored
-            }
+            // Ignored
         }
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/ManagedThreadAlphaSynthWorkerApi.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/ManagedThreadAlphaSynthWorkerApi.cs
@@ -28,8 +28,10 @@ namespace BardMusicPlayer.Siren.AlphaTab
             _workerQueue = new BlockingCollection<Action>();
             _workerCancellationToken = new CancellationTokenSource();
 
-            _workerThread = new Thread(DoWork);
-            _workerThread.IsBackground = true;
+            _workerThread              = new Thread(DoWork)
+            {
+                IsBackground = true
+            };
             _workerThread.Start();
 
             _threadStartedEvent.Wait();

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Bar.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Bar.cs
@@ -3,6 +3,7 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
+using System.Linq;
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 
 namespace BardMusicPlayer.Siren.AlphaTab.Model
@@ -126,17 +127,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
 
         internal int CalculateDuration()
         {
-            var duration = 0;
-            foreach (var voice in Voices)
-            {
-                var voiceDuration = voice.CalculateDuration();
-                if (voiceDuration > duration)
-                {
-                    duration = voiceDuration;
-                }
-            }
-
-            return duration;
+            return Voices.Select(voice => voice.CalculateDuration()).Prepend(0).Max();
         }
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Bar.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Bar.cs
@@ -6,128 +6,127 @@
 using System.Linq;
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// A bar is a single block within a track, also known as Measure.
+/// </summary>
+internal class Bar
 {
     /// <summary>
-    /// A bar is a single block within a track, also known as Measure.
+    /// This is a global counter for all beats. We use it
+    /// at several locations for lookup tables.
     /// </summary>
-    internal class Bar
+    private static int _globalBarId;
+
+    /// <summary>
+    /// Gets or sets the unique id of this bar.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the zero-based index of this bar within the staff.
+    /// </summary>
+    public int Index { get; set; }
+
+    /// <summary>
+    /// Gets or sets the next bar that comes after this bar.
+    /// </summary>
+    public Bar NextBar { get; set; }
+
+    /// <summary>
+    /// Gets or sets the previous bar that comes before this bar.
+    /// </summary>
+    public Bar PreviousBar { get; set; }
+
+    /// <summary>
+    /// Gets or sets the clef on this bar.
+    /// </summary>
+    public Clef Clef { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ottava applied to the clef.
+    /// </summary>
+    public Ottavia ClefOttava { get; set; }
+
+    /// <summary>
+    /// Gets or sets the reference to the parent staff.
+    /// </summary>
+    public Staff Staff { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of voices contained in this bar.
+    /// </summary>
+    public FastList<Voice> Voices { get; set; }
+
+    /// <summary>
+    /// Gets or sets the simile mark on this bar.
+    /// </summary>
+    public SimileMark SimileMark { get; set; }
+
+    /// <summary>
+    /// Gets the masterbar for this bar.
+    /// </summary>
+    public MasterBar MasterBar => Staff.Track.Score.MasterBars[Index];
+
+    /// <summary>
+    /// Gets a value indicating whether all voices in this bar are empty and therefore the whole bar is empty.
+    /// </summary>
+    public bool IsEmpty
     {
-        /// <summary>
-        /// This is a global counter for all beats. We use it
-        /// at several locations for lookup tables.
-        /// </summary>
-        private static int _globalBarId;
-
-        /// <summary>
-        /// Gets or sets the unique id of this bar.
-        /// </summary>
-        public int Id { get; set; }
-
-        /// <summary>
-        /// Gets or sets the zero-based index of this bar within the staff.
-        /// </summary>
-        public int Index { get; set; }
-
-        /// <summary>
-        /// Gets or sets the next bar that comes after this bar.
-        /// </summary>
-        public Bar NextBar { get; set; }
-
-        /// <summary>
-        /// Gets or sets the previous bar that comes before this bar.
-        /// </summary>
-        public Bar PreviousBar { get; set; }
-
-        /// <summary>
-        /// Gets or sets the clef on this bar.
-        /// </summary>
-        public Clef Clef { get; set; }
-
-        /// <summary>
-        /// Gets or sets the ottava applied to the clef.
-        /// </summary>
-        public Ottavia ClefOttava { get; set; }
-
-        /// <summary>
-        /// Gets or sets the reference to the parent staff.
-        /// </summary>
-        public Staff Staff { get; set; }
-
-        /// <summary>
-        /// Gets or sets the list of voices contained in this bar.
-        /// </summary>
-        public FastList<Voice> Voices { get; set; }
-
-        /// <summary>
-        /// Gets or sets the simile mark on this bar.
-        /// </summary>
-        public SimileMark SimileMark { get; set; }
-
-        /// <summary>
-        /// Gets the masterbar for this bar.
-        /// </summary>
-        public MasterBar MasterBar => Staff.Track.Score.MasterBars[Index];
-
-        /// <summary>
-        /// Gets a value indicating whether all voices in this bar are empty and therefore the whole bar is empty.
-        /// </summary>
-        public bool IsEmpty
-        {
-            get
-            {
-                for (int i = 0, j = Voices.Count; i < j; i++)
-                {
-                    if (!Voices[i].IsEmpty)
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Bar"/> class.
-        /// </summary>
-        public Bar()
-        {
-            Id = _globalBarId++;
-            Voices = new FastList<Voice>();
-            Clef = Clef.G2;
-            ClefOttava = Ottavia.Regular;
-            SimileMark = SimileMark.None;
-        }
-
-        internal static void CopyTo(Bar src, Bar dst)
-        {
-            dst.Id = src.Id;
-            dst.Index = src.Index;
-            dst.Clef = src.Clef;
-            dst.ClefOttava = src.ClefOttava;
-            dst.SimileMark = src.SimileMark;
-        }
-
-        internal void AddVoice(Voice voice)
-        {
-            voice.Bar = this;
-            voice.Index = Voices.Count;
-            Voices.Add(voice);
-        }
-
-        internal void Finish()
+        get
         {
             for (int i = 0, j = Voices.Count; i < j; i++)
             {
-                var voice = Voices[i];
-                voice.Finish();
+                if (!Voices[i].IsEmpty)
+                {
+                    return false;
+                }
             }
-        }
 
-        internal int CalculateDuration()
-        {
-            return Voices.Select(voice => voice.CalculateDuration()).Prepend(0).Max();
+            return true;
         }
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Bar"/> class.
+    /// </summary>
+    public Bar()
+    {
+        Id         = _globalBarId++;
+        Voices     = new FastList<Voice>();
+        Clef       = Clef.G2;
+        ClefOttava = Ottavia.Regular;
+        SimileMark = SimileMark.None;
+    }
+
+    internal static void CopyTo(Bar src, Bar dst)
+    {
+        dst.Id         = src.Id;
+        dst.Index      = src.Index;
+        dst.Clef       = src.Clef;
+        dst.ClefOttava = src.ClefOttava;
+        dst.SimileMark = src.SimileMark;
+    }
+
+    internal void AddVoice(Voice voice)
+    {
+        voice.Bar   = this;
+        voice.Index = Voices.Count;
+        Voices.Add(voice);
+    }
+
+    internal void Finish()
+    {
+        for (int i = 0, j = Voices.Count; i < j; i++)
+        {
+            var voice = Voices[i];
+            voice.Finish();
+        }
+    }
+
+    internal int CalculateDuration()
+    {
+        return Voices.Select(voice => voice.CalculateDuration()).Prepend(0).Max();
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Beat.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Beat.cs
@@ -7,874 +7,873 @@ using BardMusicPlayer.Siren.AlphaTab.Audio;
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 using BardMusicPlayer.Siren.AlphaTab.Util;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// A beat is a single block within a bar. A beat is a combination
+/// of several notes played at the same time.
+/// </summary>
+internal class Beat
 {
     /// <summary>
-    /// A beat is a single block within a bar. A beat is a combination
-    /// of several notes played at the same time.
+    /// This is a global counter for all beats. We use it
+    /// at several locations for lookup tables.
     /// </summary>
-    internal class Beat
+    private static int _globalBeatId;
+
+    /// <summary>
+    /// Gets or sets the unique id of this beat.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the zero-based index of this beat within the voice.
+    /// </summary>
+    public int Index { get; set; }
+
+    /// <summary>
+    /// Gets or sets the previous beat within the whole song.
+    /// </summary>
+    public Beat PreviousBeat { get; set; }
+
+    /// <summary>
+    /// Gets or sets the next beat within the whole song.
+    /// </summary>
+    public Beat NextBeat { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this beat is the last beat in the voice.
+    /// </summary>
+    public bool IsLastOfVoice => Index == Voice.Beats.Count - 1;
+
+    /// <summary>
+    /// Gets or sets the reference to the parent voice this beat belongs to.
+    /// </summary>
+    public Voice Voice { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of notes contained in this beat.
+    /// </summary>
+    public FastList<Note> Notes { get; set; }
+
+    /// <summary>
+    /// Gets the lookup where the notes per string are registered.
+    /// If this staff contains string based notes this lookup allows fast access.
+    /// </summary>
+    public FastDictionary<int, Note> NoteStringLookup { get; }
+
+    /// <summary>
+    /// Gets the lookup where the notes per value are registered.
+    /// If this staff contains string based notes this lookup allows fast access.
+    /// </summary>
+    public FastDictionary<int, Note> NoteValueLookup { get; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this beat is considered empty.
+    /// </summary>
+    public bool IsEmpty { get; set; }
+
+    /// <summary>
+    /// Gets or sets which whammy bar style should be used for this bar.
+    /// </summary>
+    public BendStyle WhammyStyle { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ottava applied to this beat.
+    /// </summary>
+    public Ottavia Ottava { get; set; }
+
+    /// <summary>
+    /// Gets or sets the fermata applied to this beat.
+    /// </summary>
+    public Fermata Fermata { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this beat starts a legato slur.
+    /// </summary>
+    public bool IsLegatoOrigin { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this beat ends a legato slur.
+    /// </summary>
+    public bool IsLegatoDestination => PreviousBeat is { IsLegatoOrigin: true };
+
+    /// <summary>
+    /// Gets or sets the note with the lowest pitch in this beat. Only visible notes are considered.
+    /// </summary>
+    public Note MinNote { get; set; }
+
+    /// <summary>
+    /// Gets or sets the note with the highest pitch in this beat. Only visible notes are considered.
+    /// </summary>
+    public Note MaxNote { get; set; }
+
+    /// <summary>
+    /// Gets or sets the note with the highest string number in this beat. Only visible notes are considered.
+    /// </summary>
+    public Note MaxStringNote { get; set; }
+
+    /// <summary>
+    /// Gets or sets the note with the lowest string number in this beat. Only visible notes are considered.
+    /// </summary>
+    public Note MinStringNote { get; set; }
+
+    /// <summary>
+    /// Gets or sets the duration of this beat.
+    /// </summary>
+    public Duration Duration { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this beat is considered as rest.
+    /// </summary>
+    public bool IsRest => IsEmpty || Notes.Count == 0;
+
+    /// <summary>
+    /// Gets or sets whether any note in this beat has a let-ring applied.
+    /// </summary>
+    public bool IsLetRing { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether any note in this beat has a palm-mute paplied.
+    /// </summary>
+    public bool IsPalmMute { get; set; }
+
+
+    /// <summary>
+    /// Gets or sets the number of dots applied to the duration of this beat.
+    /// </summary>
+    public int Dots { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this beat is fade-in.
+    /// </summary>
+    public bool FadeIn { get; set; }
+
+    /// <summary>
+    /// Gets or sets the lyrics shown on this beat.
+    /// </summary>
+    public string[] Lyrics { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the beat is played in rasgueado style.
+    /// </summary>
+    public bool HasRasgueado { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the notes on this beat are played with a pop-style (bass).
+    /// </summary>
+    public bool Pop { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the notes on this beat are played with a slap-style (bass).
+    /// </summary>
+    public bool Slap { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the notes on this beat are played with a tap-style (bass).
+    /// </summary>
+    public bool Tap { get; set; }
+
+    /// <summary>
+    /// Gets or sets the text annotation shown on this beat.
+    /// </summary>
+    public string Text { get; set; }
+
+    /// <summary>
+    /// Gets or sets the brush type applied to the notes of this beat.
+    /// </summary>
+    public BrushType BrushType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the duration of the brush between the notes in midi ticks.
+    /// </summary>
+    public int BrushDuration { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tuplet denominator.
+    /// </summary>re
+    public int TupletDenominator { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tuplet numerator.
+    /// </summary>
+    public int TupletNumerator { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether there is a tuplet applied to the duration of this beat.
+    /// </summary>
+    public bool HasTuplet =>
+        !(TupletDenominator == -1 && TupletNumerator == -1) &&
+        !(TupletDenominator == 1 && TupletNumerator == 1);
+
+    public TupletGroup TupletGroup { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this beat continues a whammy effect.
+    /// </summary>
+    public bool IsContinuedWhammy { get; set; }
+
+    /// <summary>
+    /// Gets or sets the whammy bar style of this beat.
+    /// </summary>
+    public WhammyType WhammyBarType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the points defining the whammy bar usage.
+    /// </summary>
+    public FastList<BendPoint> WhammyBarPoints { get; set; }
+
+    /// <summary>
+    /// Gets or sets the highest point with for the highest whammy bar value.
+    /// </summary>
+    public BendPoint MaxWhammyPoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the highest point with for the lowest whammy bar value.
+    /// </summary>
+    public BendPoint MinWhammyPoint { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether a whammy bar is used on this beat.
+    /// </summary>
+    public bool HasWhammyBar => WhammyBarType != WhammyType.None;
+
+    /// <summary>
+    /// Gets or sets the vibrato effect used on this beat.
+    /// </summary>
+    public VibratoType Vibrato { get; set; }
+
+    /// <summary>
+    /// Gets or sets the ID of the chord used on this beat.
+    /// </summary>
+    public string ChordId { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether a chord is used on this beat.
+    /// </summary>
+    public bool HasChord => ChordId != null;
+
+    /// <summary>
+    /// Gets the chord used on this beat.
+    /// </summary>
+    public Chord Chord => Voice.Bar.Staff.Chords[ChordId];
+
+    /// <summary>
+    /// Gets or sets the grace style of this beat.
+    /// </summary>
+    public GraceType GraceType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the pickstroke applied on this beat.
+    /// </summary>
+    public PickStroke PickStroke { get; set; }
+
+    /// <summary>
+    /// Gets whether a tremolo effect is played on this beat.
+    /// </summary>
+    public bool IsTremolo => TremoloSpeed != null;
+
+    /// <summary>
+    /// Gets or sets the speed of the tremolo effect.
+    /// </summary>
+    public Duration? TremoloSpeed { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether a crescendo/decrescendo is applied on this beat.
+    /// </summary>
+    public CrescendoType Crescendo { get; set; }
+
+    /// <summary>
+    /// The timeline position of the voice within the current bar as it is displayed. (unit: midi ticks)
+    /// </summary>
+    /// <remarks>
+    /// This might differ from the actual playback time due to special grace types.
+    /// </remarks>
+    public int DisplayStart { get; set; }
+
+    /// <summary>
+    /// The timeline position of the voice within the current bar as it is played. (unit: midi ticks)
+    /// </summary>
+    /// <remarks>
+    /// This might differ from the actual playback time due to special grace types.
+    /// </remarks>
+    public int PlaybackStart { get; set; }
+
+    /// <summary>
+    /// Gets or sets the duration that is used for the display of this beat. It defines the size/width of the beat in
+    /// the music sheet. (unit: midi ticks).
+    /// </summary>
+    public int DisplayDuration { get; set; }
+
+    /// <summary>
+    /// Gets or sets the duration that the note is played during the audio generation.
+    /// </summary>
+    public int PlaybackDuration { get; set; }
+
+    /// <summary>
+    /// Gets the absolute display start time within the song.
+    /// </summary>
+    public int AbsoluteDisplayStart => Voice.Bar.MasterBar.Start + DisplayStart;
+
+    /// <summary>
+    /// Gets the absolute playback start time within the song.
+    /// </summary>
+    public int AbsolutePlaybackStart => Voice.Bar.MasterBar.Start + PlaybackStart;
+
+    /// <summary>
+    /// Gets or sets the dynamics applied to this beat.
+    /// </summary>
+    public DynamicValue Dynamics { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the beam direction should be inverted.
+    /// </summary>
+    public bool InvertBeamDirection { get; set; }
+
+    internal bool IsEffectSlurOrigin { get; set; }
+    internal bool IsEffectSlurDestination => EffectSlurOrigin != null;
+    internal Beat EffectSlurOrigin { get; set; }
+    internal Beat EffectSlurDestination { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Beat"/> class.
+    /// </summary>
+    public Beat()
     {
-        /// <summary>
-        /// This is a global counter for all beats. We use it
-        /// at several locations for lookup tables.
-        /// </summary>
-        private static int _globalBeatId;
+        Id                  = _globalBeatId++;
+        WhammyBarType       = WhammyType.None;
+        WhammyBarPoints     = new FastList<BendPoint>();
+        Notes               = new FastList<Note>();
+        BrushType           = BrushType.None;
+        Vibrato             = VibratoType.None;
+        GraceType           = GraceType.None;
+        PickStroke          = PickStroke.None;
+        Duration            = Duration.Quarter;
+        TremoloSpeed        = null;
+        Dots                = 0;
+        DisplayStart        = 0;
+        DisplayDuration     = 0;
+        PlaybackStart       = 0;
+        PlaybackDuration    = 0;
+        TupletDenominator   = -1;
+        TupletNumerator     = -1;
+        Dynamics            = DynamicValue.F;
+        Crescendo           = CrescendoType.None;
+        InvertBeamDirection = false;
+        Ottava              = Ottavia.Regular;
+        NoteStringLookup    = new FastDictionary<int, Note>();
+        NoteValueLookup     = new FastDictionary<int, Note>();
+        WhammyStyle         = BendStyle.Default;
+    }
 
-        /// <summary>
-        /// Gets or sets the unique id of this beat.
-        /// </summary>
-        public int Id { get; set; }
-
-        /// <summary>
-        /// Gets or sets the zero-based index of this beat within the voice.
-        /// </summary>
-        public int Index { get; set; }
-
-        /// <summary>
-        /// Gets or sets the previous beat within the whole song.
-        /// </summary>
-        public Beat PreviousBeat { get; set; }
-
-        /// <summary>
-        /// Gets or sets the next beat within the whole song.
-        /// </summary>
-        public Beat NextBeat { get; set; }
-
-        /// <summary>
-        /// Gets a value indicating whether this beat is the last beat in the voice.
-        /// </summary>
-        public bool IsLastOfVoice => Index == Voice.Beats.Count - 1;
-
-        /// <summary>
-        /// Gets or sets the reference to the parent voice this beat belongs to.
-        /// </summary>
-        public Voice Voice { get; set; }
-
-        /// <summary>
-        /// Gets or sets the list of notes contained in this beat.
-        /// </summary>
-        public FastList<Note> Notes { get; set; }
-
-        /// <summary>
-        /// Gets the lookup where the notes per string are registered.
-        /// If this staff contains string based notes this lookup allows fast access.
-        /// </summary>
-        public FastDictionary<int, Note> NoteStringLookup { get; }
-
-        /// <summary>
-        /// Gets the lookup where the notes per value are registered.
-        /// If this staff contains string based notes this lookup allows fast access.
-        /// </summary>
-        public FastDictionary<int, Note> NoteValueLookup { get; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this beat is considered empty.
-        /// </summary>
-        public bool IsEmpty { get; set; }
-
-        /// <summary>
-        /// Gets or sets which whammy bar style should be used for this bar.
-        /// </summary>
-        public BendStyle WhammyStyle { get; set; }
-
-        /// <summary>
-        /// Gets or sets the ottava applied to this beat.
-        /// </summary>
-        public Ottavia Ottava { get; set; }
-
-        /// <summary>
-        /// Gets or sets the fermata applied to this beat.
-        /// </summary>
-        public Fermata Fermata { get; set; }
-
-        /// <summary>
-        /// Gets a value indicating whether this beat starts a legato slur.
-        /// </summary>
-        public bool IsLegatoOrigin { get; set; }
-
-        /// <summary>
-        /// Gets a value indicating whether this beat ends a legato slur.
-        /// </summary>
-        public bool IsLegatoDestination => PreviousBeat is { IsLegatoOrigin: true };
-
-        /// <summary>
-        /// Gets or sets the note with the lowest pitch in this beat. Only visible notes are considered.
-        /// </summary>
-        public Note MinNote { get; set; }
-
-        /// <summary>
-        /// Gets or sets the note with the highest pitch in this beat. Only visible notes are considered.
-        /// </summary>
-        public Note MaxNote { get; set; }
-
-        /// <summary>
-        /// Gets or sets the note with the highest string number in this beat. Only visible notes are considered.
-        /// </summary>
-        public Note MaxStringNote { get; set; }
-
-        /// <summary>
-        /// Gets or sets the note with the lowest string number in this beat. Only visible notes are considered.
-        /// </summary>
-        public Note MinStringNote { get; set; }
-
-        /// <summary>
-        /// Gets or sets the duration of this beat.
-        /// </summary>
-        public Duration Duration { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether this beat is considered as rest.
-        /// </summary>
-        public bool IsRest => IsEmpty || Notes.Count == 0;
-
-        /// <summary>
-        /// Gets or sets whether any note in this beat has a let-ring applied.
-        /// </summary>
-        public bool IsLetRing { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether any note in this beat has a palm-mute paplied.
-        /// </summary>
-        public bool IsPalmMute { get; set; }
-
-
-        /// <summary>
-        /// Gets or sets the number of dots applied to the duration of this beat.
-        /// </summary>
-        public int Dots { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this beat is fade-in.
-        /// </summary>
-        public bool FadeIn { get; set; }
-
-        /// <summary>
-        /// Gets or sets the lyrics shown on this beat.
-        /// </summary>
-        public string[] Lyrics { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the beat is played in rasgueado style.
-        /// </summary>
-        public bool HasRasgueado { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the notes on this beat are played with a pop-style (bass).
-        /// </summary>
-        public bool Pop { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the notes on this beat are played with a slap-style (bass).
-        /// </summary>
-        public bool Slap { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the notes on this beat are played with a tap-style (bass).
-        /// </summary>
-        public bool Tap { get; set; }
-
-        /// <summary>
-        /// Gets or sets the text annotation shown on this beat.
-        /// </summary>
-        public string Text { get; set; }
-
-        /// <summary>
-        /// Gets or sets the brush type applied to the notes of this beat.
-        /// </summary>
-        public BrushType BrushType { get; set; }
-
-        /// <summary>
-        /// Gets or sets the duration of the brush between the notes in midi ticks.
-        /// </summary>
-        public int BrushDuration { get; set; }
-
-        /// <summary>
-        /// Gets or sets the tuplet denominator.
-        /// </summary>re
-        public int TupletDenominator { get; set; }
-
-        /// <summary>
-        /// Gets or sets the tuplet numerator.
-        /// </summary>
-        public int TupletNumerator { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether there is a tuplet applied to the duration of this beat.
-        /// </summary>
-        public bool HasTuplet =>
-            !(TupletDenominator == -1 && TupletNumerator == -1) &&
-            !(TupletDenominator == 1 && TupletNumerator == 1);
-
-        public TupletGroup TupletGroup { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether this beat continues a whammy effect.
-        /// </summary>
-        public bool IsContinuedWhammy { get; set; }
-
-        /// <summary>
-        /// Gets or sets the whammy bar style of this beat.
-        /// </summary>
-        public WhammyType WhammyBarType { get; set; }
-
-        /// <summary>
-        /// Gets or sets the points defining the whammy bar usage.
-        /// </summary>
-        public FastList<BendPoint> WhammyBarPoints { get; set; }
-
-        /// <summary>
-        /// Gets or sets the highest point with for the highest whammy bar value.
-        /// </summary>
-        public BendPoint MaxWhammyPoint { get; set; }
-
-        /// <summary>
-        /// Gets or sets the highest point with for the lowest whammy bar value.
-        /// </summary>
-        public BendPoint MinWhammyPoint { get; set; }
-
-        /// <summary>
-        /// Gets a value indicating whether a whammy bar is used on this beat.
-        /// </summary>
-        public bool HasWhammyBar => WhammyBarType != WhammyType.None;
-
-        /// <summary>
-        /// Gets or sets the vibrato effect used on this beat.
-        /// </summary>
-        public VibratoType Vibrato { get; set; }
-
-        /// <summary>
-        /// Gets or sets the ID of the chord used on this beat.
-        /// </summary>
-        public string ChordId { get; set; }
-
-        /// <summary>
-        /// Gets a value indicating whether a chord is used on this beat.
-        /// </summary>
-        public bool HasChord => ChordId != null;
-
-        /// <summary>
-        /// Gets the chord used on this beat.
-        /// </summary>
-        public Chord Chord => Voice.Bar.Staff.Chords[ChordId];
-
-        /// <summary>
-        /// Gets or sets the grace style of this beat.
-        /// </summary>
-        public GraceType GraceType { get; set; }
-
-        /// <summary>
-        /// Gets or sets the pickstroke applied on this beat.
-        /// </summary>
-        public PickStroke PickStroke { get; set; }
-
-        /// <summary>
-        /// Gets whether a tremolo effect is played on this beat.
-        /// </summary>
-        public bool IsTremolo => TremoloSpeed != null;
-
-        /// <summary>
-        /// Gets or sets the speed of the tremolo effect.
-        /// </summary>
-        public Duration? TremoloSpeed { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether a crescendo/decrescendo is applied on this beat.
-        /// </summary>
-        public CrescendoType Crescendo { get; set; }
-
-        /// <summary>
-        /// The timeline position of the voice within the current bar as it is displayed. (unit: midi ticks)
-        /// </summary>
-        /// <remarks>
-        /// This might differ from the actual playback time due to special grace types.
-        /// </remarks>
-        public int DisplayStart { get; set; }
-
-        /// <summary>
-        /// The timeline position of the voice within the current bar as it is played. (unit: midi ticks)
-        /// </summary>
-        /// <remarks>
-        /// This might differ from the actual playback time due to special grace types.
-        /// </remarks>
-        public int PlaybackStart { get; set; }
-
-        /// <summary>
-        /// Gets or sets the duration that is used for the display of this beat. It defines the size/width of the beat in
-        /// the music sheet. (unit: midi ticks).
-        /// </summary>
-        public int DisplayDuration { get; set; }
-
-        /// <summary>
-        /// Gets or sets the duration that the note is played during the audio generation.
-        /// </summary>
-        public int PlaybackDuration { get; set; }
-
-        /// <summary>
-        /// Gets the absolute display start time within the song.
-        /// </summary>
-        public int AbsoluteDisplayStart => Voice.Bar.MasterBar.Start + DisplayStart;
-
-        /// <summary>
-        /// Gets the absolute playback start time within the song.
-        /// </summary>
-        public int AbsolutePlaybackStart => Voice.Bar.MasterBar.Start + PlaybackStart;
-
-        /// <summary>
-        /// Gets or sets the dynamics applied to this beat.
-        /// </summary>
-        public DynamicValue Dynamics { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the beam direction should be inverted.
-        /// </summary>
-        public bool InvertBeamDirection { get; set; }
-
-        internal bool IsEffectSlurOrigin { get; set; }
-        internal bool IsEffectSlurDestination => EffectSlurOrigin != null;
-        internal Beat EffectSlurOrigin { get; set; }
-        internal Beat EffectSlurDestination { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Beat"/> class.
-        /// </summary>
-        public Beat()
+    internal static void CopyTo(Beat src, Beat dst)
+    {
+        dst.Id       = src.Id;
+        dst.Index    = src.Index;
+        dst.IsEmpty  = src.IsEmpty;
+        dst.Duration = src.Duration;
+        dst.Dots     = src.Dots;
+        dst.FadeIn   = src.FadeIn;
+        if (src.Lyrics != null)
         {
-            Id = _globalBeatId++;
-            WhammyBarType = WhammyType.None;
-            WhammyBarPoints = new FastList<BendPoint>();
-            Notes = new FastList<Note>();
-            BrushType = BrushType.None;
-            Vibrato = VibratoType.None;
-            GraceType = GraceType.None;
-            PickStroke = PickStroke.None;
-            Duration = Duration.Quarter;
-            TremoloSpeed = null;
-            Dots = 0;
-            DisplayStart = 0;
-            DisplayDuration = 0;
-            PlaybackStart = 0;
-            PlaybackDuration = 0;
-            TupletDenominator = -1;
-            TupletNumerator = -1;
-            Dynamics = DynamicValue.F;
-            Crescendo = CrescendoType.None;
-            InvertBeamDirection = false;
-            Ottava = Ottavia.Regular;
-            NoteStringLookup = new FastDictionary<int, Note>();
-            NoteValueLookup = new FastDictionary<int, Note>();
-            WhammyStyle = BendStyle.Default;
+            dst.Lyrics = new string[src.Lyrics.Length];
+            for (var i = 0; i < src.Lyrics.Length; i++)
+            {
+                dst.Lyrics[i] = src.Lyrics[i];
+            }
         }
 
-        internal static void CopyTo(Beat src, Beat dst)
+        dst.Pop                 = src.Pop;
+        dst.HasRasgueado        = src.HasRasgueado;
+        dst.Slap                = src.Slap;
+        dst.Tap                 = src.Tap;
+        dst.Text                = src.Text;
+        dst.BrushType           = src.BrushType;
+        dst.BrushDuration       = src.BrushDuration;
+        dst.TupletDenominator   = src.TupletDenominator;
+        dst.TupletNumerator     = src.TupletNumerator;
+        dst.Vibrato             = src.Vibrato;
+        dst.ChordId             = src.ChordId;
+        dst.GraceType           = src.GraceType;
+        dst.PickStroke          = src.PickStroke;
+        dst.TremoloSpeed        = src.TremoloSpeed;
+        dst.Crescendo           = src.Crescendo;
+        dst.DisplayStart        = src.DisplayStart;
+        dst.DisplayDuration     = src.DisplayDuration;
+        dst.PlaybackStart       = src.PlaybackStart;
+        dst.PlaybackDuration    = src.PlaybackDuration;
+        dst.Dynamics            = src.Dynamics;
+        dst.IsLegatoOrigin      = src.IsLegatoOrigin;
+        dst.InvertBeamDirection = src.InvertBeamDirection;
+        dst.WhammyBarType       = src.WhammyBarType;
+        dst.IsContinuedWhammy   = src.IsContinuedWhammy;
+        dst.Ottava              = src.Ottava;
+        dst.WhammyStyle         = src.WhammyStyle;
+    }
+
+    internal Beat Clone()
+    {
+        var beat = new Beat();
+        var id = beat.Id;
+        for (int i = 0, j = WhammyBarPoints.Count; i < j; i++)
         {
-            dst.Id = src.Id;
-            dst.Index = src.Index;
-            dst.IsEmpty = src.IsEmpty;
-            dst.Duration = src.Duration;
-            dst.Dots = src.Dots;
-            dst.FadeIn = src.FadeIn;
-            if (src.Lyrics != null)
+            beat.AddWhammyBarPoint(WhammyBarPoints[i].Clone());
+        }
+
+        for (int i = 0, j = Notes.Count; i < j; i++)
+        {
+            beat.AddNoteInternal(Notes[i].Clone(), Notes[i].RealValue);
+        }
+
+        CopyTo(this, beat);
+
+
+        beat.Id = id;
+        return beat;
+    }
+
+    internal void AddWhammyBarPoint(BendPoint point)
+    {
+        WhammyBarPoints.Add(point);
+        if (MaxWhammyPoint == null || point.Value > MaxWhammyPoint.Value)
+        {
+            MaxWhammyPoint = point;
+        }
+
+        if (MinWhammyPoint == null || point.Value < MinWhammyPoint.Value)
+        {
+            MinWhammyPoint = point;
+        }
+
+        if (WhammyBarType == WhammyType.None)
+        {
+            WhammyBarType = WhammyType.Custom;
+        }
+    }
+
+    internal void RemoveWhammyBarPoint(int index)
+    {
+        // check index
+        if (index < 0 || index >= WhammyBarPoints.Count)
+        {
+            return;
+        }
+
+        // remove point
+        WhammyBarPoints.RemoveAt(index);
+        var point = WhammyBarPoints[index];
+
+        // update maxWhammy point if required
+        if (point == MaxWhammyPoint)
+        {
+            MaxWhammyPoint = null;
+            foreach (var currentPoint in WhammyBarPoints)
             {
-                dst.Lyrics = new string[src.Lyrics.Length];
-                for (var i = 0; i < src.Lyrics.Length; i++)
+                if (MaxWhammyPoint == null || currentPoint.Value > MaxWhammyPoint.Value)
                 {
-                    dst.Lyrics[i] = src.Lyrics[i];
-                }
-            }
-
-            dst.Pop = src.Pop;
-            dst.HasRasgueado = src.HasRasgueado;
-            dst.Slap = src.Slap;
-            dst.Tap = src.Tap;
-            dst.Text = src.Text;
-            dst.BrushType = src.BrushType;
-            dst.BrushDuration = src.BrushDuration;
-            dst.TupletDenominator = src.TupletDenominator;
-            dst.TupletNumerator = src.TupletNumerator;
-            dst.Vibrato = src.Vibrato;
-            dst.ChordId = src.ChordId;
-            dst.GraceType = src.GraceType;
-            dst.PickStroke = src.PickStroke;
-            dst.TremoloSpeed = src.TremoloSpeed;
-            dst.Crescendo = src.Crescendo;
-            dst.DisplayStart = src.DisplayStart;
-            dst.DisplayDuration = src.DisplayDuration;
-            dst.PlaybackStart = src.PlaybackStart;
-            dst.PlaybackDuration = src.PlaybackDuration;
-            dst.Dynamics = src.Dynamics;
-            dst.IsLegatoOrigin = src.IsLegatoOrigin;
-            dst.InvertBeamDirection = src.InvertBeamDirection;
-            dst.WhammyBarType = src.WhammyBarType;
-            dst.IsContinuedWhammy = src.IsContinuedWhammy;
-            dst.Ottava = src.Ottava;
-            dst.WhammyStyle = src.WhammyStyle;
-        }
-
-        internal Beat Clone()
-        {
-            var beat = new Beat();
-            var id = beat.Id;
-            for (int i = 0, j = WhammyBarPoints.Count; i < j; i++)
-            {
-                beat.AddWhammyBarPoint(WhammyBarPoints[i].Clone());
-            }
-
-            for (int i = 0, j = Notes.Count; i < j; i++)
-            {
-                beat.AddNoteInternal(Notes[i].Clone(), Notes[i].RealValue);
-            }
-
-            CopyTo(this, beat);
-
-
-            beat.Id = id;
-            return beat;
-        }
-
-        internal void AddWhammyBarPoint(BendPoint point)
-        {
-            WhammyBarPoints.Add(point);
-            if (MaxWhammyPoint == null || point.Value > MaxWhammyPoint.Value)
-            {
-                MaxWhammyPoint = point;
-            }
-
-            if (MinWhammyPoint == null || point.Value < MinWhammyPoint.Value)
-            {
-                MinWhammyPoint = point;
-            }
-
-            if (WhammyBarType == WhammyType.None)
-            {
-                WhammyBarType = WhammyType.Custom;
-            }
-        }
-
-        internal void RemoveWhammyBarPoint(int index)
-        {
-            // check index
-            if (index < 0 || index >= WhammyBarPoints.Count)
-            {
-                return;
-            }
-
-            // remove point
-            WhammyBarPoints.RemoveAt(index);
-            var point = WhammyBarPoints[index];
-
-            // update maxWhammy point if required
-            if (point == MaxWhammyPoint)
-            {
-                MaxWhammyPoint = null;
-                foreach (var currentPoint in WhammyBarPoints)
-                {
-                    if (MaxWhammyPoint == null || currentPoint.Value > MaxWhammyPoint.Value)
-                    {
-                        MaxWhammyPoint = currentPoint;
-                    }
-                }
-            }
-
-            if (point == MinWhammyPoint)
-            {
-                MinWhammyPoint = null;
-                foreach (var currentPoint in WhammyBarPoints)
-                {
-                    if (MinWhammyPoint == null || currentPoint.Value < MinWhammyPoint.Value)
-                    {
-                        MinWhammyPoint = currentPoint;
-                    }
+                    MaxWhammyPoint = currentPoint;
                 }
             }
         }
 
-        internal void AddNote(Note note)
+        if (point == MinWhammyPoint)
         {
-            AddNoteInternal(note);
-        }
-
-        private void AddNoteInternal(Note note, int realValue = -1)
-        {
-            note.Beat = this;
-            note.Index = Notes.Count;
-            Notes.Add(note);
-            if (note.IsStringed)
+            MinWhammyPoint = null;
+            foreach (var currentPoint in WhammyBarPoints)
             {
-                NoteStringLookup[note.String] = note;
-            }
-
-            if (realValue == -1)
-            {
-                realValue = note.RealValue;
-            }
-
-            NoteValueLookup[realValue] = note;
-        }
-
-        internal void RemoveNote(Note note)
-        {
-            var index = Notes.IndexOf(note);
-            if (index >= 0)
-            {
-                Notes.RemoveAt(index);
+                if (MinWhammyPoint == null || currentPoint.Value < MinWhammyPoint.Value)
+                {
+                    MinWhammyPoint = currentPoint;
+                }
             }
         }
+    }
+
+    internal void AddNote(Note note)
+    {
+        AddNoteInternal(note);
+    }
+
+    private void AddNoteInternal(Note note, int realValue = -1)
+    {
+        note.Beat  = this;
+        note.Index = Notes.Count;
+        Notes.Add(note);
+        if (note.IsStringed)
+        {
+            NoteStringLookup[note.String] = note;
+        }
+
+        if (realValue == -1)
+        {
+            realValue = note.RealValue;
+        }
+
+        NoteValueLookup[realValue] = note;
+    }
+
+    internal void RemoveNote(Note note)
+    {
+        var index = Notes.IndexOf(note);
+        if (index >= 0)
+        {
+            Notes.RemoveAt(index);
+        }
+    }
 
      
 
-        internal Note GetNoteOnString(int @string)
+    internal Note GetNoteOnString(int @string)
+    {
+        return NoteStringLookup.ContainsKey(@string) ? NoteStringLookup[@string] : null;
+    }
+
+    private int CalculateDuration()
+    {
+        var ticks = Duration.ToTicks();
+        switch (Dots)
         {
-            return NoteStringLookup.ContainsKey(@string) ? NoteStringLookup[@string] : null;
+            case 2:
+                ticks = MidiUtils.ApplyDot(ticks, true);
+                break;
+            case 1:
+                ticks = MidiUtils.ApplyDot(ticks, false);
+                break;
         }
 
-        private int CalculateDuration()
+        if (TupletDenominator > 0 && TupletNumerator >= 0)
         {
-            var ticks = Duration.ToTicks();
-            switch (Dots)
-            {
-                case 2:
-                    ticks = MidiUtils.ApplyDot(ticks, true);
-                    break;
-                case 1:
-                    ticks = MidiUtils.ApplyDot(ticks, false);
-                    break;
-            }
-
-            if (TupletDenominator > 0 && TupletNumerator >= 0)
-            {
-                ticks = MidiUtils.ApplyTuplet(ticks, TupletNumerator, TupletDenominator);
-            }
-
-            return ticks;
+            ticks = MidiUtils.ApplyTuplet(ticks, TupletNumerator, TupletDenominator);
         }
 
-        internal void UpdateDurations()
+        return ticks;
+    }
+
+    internal void UpdateDurations()
+    {
+        var ticks = CalculateDuration();
+        PlaybackDuration = ticks;
+        DisplayDuration  = ticks;
+
+        switch (GraceType)
         {
-            var ticks = CalculateDuration();
-            PlaybackDuration = ticks;
-            DisplayDuration = ticks;
-
-            switch (GraceType)
-            {
-                case GraceType.BeforeBeat:
-                case GraceType.OnBeat:
-                    switch (Duration)
-                    {
-                        case Duration.Sixteenth:
-                            PlaybackDuration = Duration.SixtyFourth.ToTicks();
-                            break;
-                        case Duration.ThirtySecond:
-                            PlaybackDuration = Duration.OneHundredTwentyEighth.ToTicks();
-                            break;
-                        case Duration.Eighth:
-                        default:
-                            PlaybackDuration = Duration.ThirtySecond.ToTicks();
-                            break;
-                    }
-
-                    break;
-                case GraceType.BendGrace:
-                    PlaybackDuration /= 2;
-                    break;
-                default:
-
-                    var previous = PreviousBeat;
-                    if (previous is { GraceType: GraceType.BendGrace })
-                    {
-                        PlaybackDuration = previous.PlaybackDuration;
-                    }
-                    else
-                    {
-                        while (previous is { GraceType: GraceType.OnBeat })
-                        {
-                            // if the previous beat is a on-beat grace it steals the duration from this beat
-                            PlaybackDuration -= previous.PlaybackDuration;
-                            previous = previous.PreviousBeat;
-                        }
-                    }
-
-                    break;
-            }
-
-
-            //// It can happen that the first beat of the next bar shifts into this
-            //// beat due to before-beat grace. In this case we need to
-            //// reduce the duration of this beat.
-            //// Within the same bar the start of the next beat is always directly after the current.
-
-            //if (NextBeat != null && NextBeat.Voice.Bar != Voice.Bar)
-            //{
-            //    var next = NextBeat;
-            //    while (next != null && next.GraceType == GraceType.BeforeBeat)
-            //    {
-            //        PlaybackDuration -= next.CalculateDuration();
-            //        next = next.NextBeat;
-            //    }
-            //}
-        }
-
-        internal void FinishTuplet()
-        {
-            var previousBeat = PreviousBeat;
-            var currentTupletGroup = previousBeat?.TupletGroup;
-
-            if (HasTuplet || GraceType != GraceType.None && currentTupletGroup != null)
-            {
-                if (previousBeat == null || currentTupletGroup == null || !currentTupletGroup.Check(this))
+            case GraceType.BeforeBeat:
+            case GraceType.OnBeat:
+                switch (Duration)
                 {
-                    currentTupletGroup = new TupletGroup(Voice);
-                    currentTupletGroup.Check(this);
+                    case Duration.Sixteenth:
+                        PlaybackDuration = Duration.SixtyFourth.ToTicks();
+                        break;
+                    case Duration.ThirtySecond:
+                        PlaybackDuration = Duration.OneHundredTwentyEighth.ToTicks();
+                        break;
+                    case Duration.Eighth:
+                    default:
+                        PlaybackDuration = Duration.ThirtySecond.ToTicks();
+                        break;
                 }
 
-                TupletGroup = currentTupletGroup;
-            }
-        }
+                break;
+            case GraceType.BendGrace:
+                PlaybackDuration /= 2;
+                break;
+            default:
 
-        internal void Finish()
-        {
-            // // Local variable 'needCopyBeatForBend' is only assigned but its value is never used
-            //var needCopyBeatForBend = false;
-            MinNote = null;
-            MaxNote = null;
-            MinStringNote = null;
-            MaxStringNote = null;
-
-            var visibleNotes = 0;
-            var isEffectSlurBeat = false;
-
-            for (int i = 0, j = Notes.Count; i < j; i++)
-            {
-                var note = Notes[i];
-                note.Finish();
-                if (note.IsLetRing)
+                var previous = PreviousBeat;
+                if (previous is { GraceType: GraceType.BendGrace })
                 {
-                    IsLetRing = true;
-                }
-
-                if (note.IsPalmMute)
-                {
-                    IsPalmMute = true;
-                }
-
-
-
-                if (note.IsVisible)
-                {
-                    visibleNotes++;
-                    if (MinNote == null || note.RealValue < MinNote.RealValue)
-                    {
-                        MinNote = note;
-                    }
-
-                    if (MaxNote == null || note.RealValue > MaxNote.RealValue)
-                    {
-                        MaxNote = note;
-                    }
-
-                    if (MinStringNote == null || note.String < MinStringNote.String)
-                    {
-                        MinStringNote = note;
-                    }
-
-                    if (MaxStringNote == null || note.String > MaxStringNote.String)
-                    {
-                        MaxStringNote = note;
-                    }
-
-                    if (note.HasEffectSlur)
-                    {
-                        isEffectSlurBeat = true;
-                    }
-                }
-            }
-
-            if (isEffectSlurBeat)
-            {
-                if (EffectSlurOrigin != null)
-                {
-                    EffectSlurOrigin.EffectSlurDestination = NextBeat;
-                    EffectSlurOrigin.EffectSlurDestination.EffectSlurOrigin = EffectSlurOrigin;
-                    EffectSlurOrigin = null;
+                    PlaybackDuration = previous.PlaybackDuration;
                 }
                 else
                 {
-                    IsEffectSlurOrigin = true;
-                    EffectSlurDestination = NextBeat;
-                    EffectSlurDestination.EffectSlurOrigin = this;
+                    while (previous is { GraceType: GraceType.OnBeat })
+                    {
+                        // if the previous beat is a on-beat grace it steals the duration from this beat
+                        PlaybackDuration -= previous.PlaybackDuration;
+                        previous         =  previous.PreviousBeat;
+                    }
+                }
+
+                break;
+        }
+
+
+        //// It can happen that the first beat of the next bar shifts into this
+        //// beat due to before-beat grace. In this case we need to
+        //// reduce the duration of this beat.
+        //// Within the same bar the start of the next beat is always directly after the current.
+
+        //if (NextBeat != null && NextBeat.Voice.Bar != Voice.Bar)
+        //{
+        //    var next = NextBeat;
+        //    while (next != null && next.GraceType == GraceType.BeforeBeat)
+        //    {
+        //        PlaybackDuration -= next.CalculateDuration();
+        //        next = next.NextBeat;
+        //    }
+        //}
+    }
+
+    internal void FinishTuplet()
+    {
+        var previousBeat = PreviousBeat;
+        var currentTupletGroup = previousBeat?.TupletGroup;
+
+        if (HasTuplet || GraceType != GraceType.None && currentTupletGroup != null)
+        {
+            if (previousBeat == null || currentTupletGroup == null || !currentTupletGroup.Check(this))
+            {
+                currentTupletGroup = new TupletGroup(Voice);
+                currentTupletGroup.Check(this);
+            }
+
+            TupletGroup = currentTupletGroup;
+        }
+    }
+
+    internal void Finish()
+    {
+        // // Local variable 'needCopyBeatForBend' is only assigned but its value is never used
+        //var needCopyBeatForBend = false;
+        MinNote       = null;
+        MaxNote       = null;
+        MinStringNote = null;
+        MaxStringNote = null;
+
+        var visibleNotes = 0;
+        var isEffectSlurBeat = false;
+
+        for (int i = 0, j = Notes.Count; i < j; i++)
+        {
+            var note = Notes[i];
+            note.Finish();
+            if (note.IsLetRing)
+            {
+                IsLetRing = true;
+            }
+
+            if (note.IsPalmMute)
+            {
+                IsPalmMute = true;
+            }
+
+
+
+            if (note.IsVisible)
+            {
+                visibleNotes++;
+                if (MinNote == null || note.RealValue < MinNote.RealValue)
+                {
+                    MinNote = note;
+                }
+
+                if (MaxNote == null || note.RealValue > MaxNote.RealValue)
+                {
+                    MaxNote = note;
+                }
+
+                if (MinStringNote == null || note.String < MinStringNote.String)
+                {
+                    MinStringNote = note;
+                }
+
+                if (MaxStringNote == null || note.String > MaxStringNote.String)
+                {
+                    MaxStringNote = note;
+                }
+
+                if (note.HasEffectSlur)
+                {
+                    isEffectSlurBeat = true;
                 }
             }
+        }
 
-            if (Notes.Count > 0 && visibleNotes == 0)
+        if (isEffectSlurBeat)
+        {
+            if (EffectSlurOrigin != null)
             {
-                IsEmpty = true;
+                EffectSlurOrigin.EffectSlurDestination                  = NextBeat;
+                EffectSlurOrigin.EffectSlurDestination.EffectSlurOrigin = EffectSlurOrigin;
+                EffectSlurOrigin                                        = null;
             }
-
-            // we need to clean al letring/palmmute flags for rests
-            // in case the effect is not continued on this beat
-            if (!IsRest && (!IsLetRing || !IsPalmMute))
+            else
             {
-                var currentBeat = PreviousBeat;
-                while (currentBeat is { IsRest: true })
+                IsEffectSlurOrigin                     = true;
+                EffectSlurDestination                  = NextBeat;
+                EffectSlurDestination.EffectSlurOrigin = this;
+            }
+        }
+
+        if (Notes.Count > 0 && visibleNotes == 0)
+        {
+            IsEmpty = true;
+        }
+
+        // we need to clean al letring/palmmute flags for rests
+        // in case the effect is not continued on this beat
+        if (!IsRest && (!IsLetRing || !IsPalmMute))
+        {
+            var currentBeat = PreviousBeat;
+            while (currentBeat is { IsRest: true })
+            {
+                if (!IsLetRing)
                 {
-                    if (!IsLetRing)
-                    {
-                        currentBeat.IsLetRing = false;
-                    }
-
-                    if (!IsPalmMute)
-                    {
-                        currentBeat.IsPalmMute = false;
-                    }
-
-                    currentBeat = currentBeat.PreviousBeat;
+                    currentBeat.IsLetRing = false;
                 }
-            }
 
-
-            // try to detect what kind of bend was used and cleans unneeded points if required
-            // Guitar Pro 6 and above (gpif.xml) uses exactly 4 points to define all whammys
-            if (WhammyBarPoints.Count > 0 && WhammyBarType == WhammyType.Custom)
-            {
-
-                var isContinuedWhammy = IsContinuedWhammy = PreviousBeat is { HasWhammyBar: true };
-                if (WhammyBarPoints.Count == 4)
+                if (!IsPalmMute)
                 {
-                    var origin = WhammyBarPoints[0];
-                    var middle1 = WhammyBarPoints[1];
-                    var middle2 = WhammyBarPoints[2];
-                    var destination = WhammyBarPoints[3];
+                    currentBeat.IsPalmMute = false;
+                }
 
-                    // the middle points are used for holds, anything else is a new feature we do not support yet
-                    if (middle1.Value == middle2.Value)
+                currentBeat = currentBeat.PreviousBeat;
+            }
+        }
+
+
+        // try to detect what kind of bend was used and cleans unneeded points if required
+        // Guitar Pro 6 and above (gpif.xml) uses exactly 4 points to define all whammys
+        if (WhammyBarPoints.Count > 0 && WhammyBarType == WhammyType.Custom)
+        {
+
+            var isContinuedWhammy = IsContinuedWhammy = PreviousBeat is { HasWhammyBar: true };
+            if (WhammyBarPoints.Count == 4)
+            {
+                var origin = WhammyBarPoints[0];
+                var middle1 = WhammyBarPoints[1];
+                var middle2 = WhammyBarPoints[2];
+                var destination = WhammyBarPoints[3];
+
+                // the middle points are used for holds, anything else is a new feature we do not support yet
+                if (middle1.Value == middle2.Value)
+                {
+                    // constant decrease or increase
+                    if (origin.Value < middle1.Value && middle1.Value < destination.Value ||
+                        origin.Value > middle1.Value && middle1.Value > destination.Value)
                     {
-                        // constant decrease or increase
-                        if (origin.Value < middle1.Value && middle1.Value < destination.Value ||
-                            origin.Value > middle1.Value && middle1.Value > destination.Value)
+                        if (origin.Value != 0 && !isContinuedWhammy)
                         {
-                            if (origin.Value != 0 && !isContinuedWhammy)
-                            {
-                                WhammyBarType = WhammyType.PrediveDive;
-                            }
-                            else
-                            {
-                                WhammyBarType = WhammyType.Dive;
-                            }
-
-                            WhammyBarPoints.RemoveAt(2);
-                            WhammyBarPoints.RemoveAt(1);
-                        }
-                        // down-up or up-down
-                        else if (origin.Value > middle1.Value && middle1.Value < destination.Value ||
-                                 origin.Value < middle1.Value && middle1.Value > destination.Value)
-                        {
-                            WhammyBarType = WhammyType.Dip;
-                         
-                        }
-                        else if (origin.Value == middle1.Value && middle1.Value == destination.Value)
-                        {
-                            if (origin.Value != 0 && !isContinuedWhammy)
-                            {
-                                WhammyBarType = WhammyType.Predive;
-                            }
-                            else
-                            {
-                                WhammyBarType = WhammyType.Hold;
-                            }
-
-                            WhammyBarPoints.RemoveAt(2);
-                            WhammyBarPoints.RemoveAt(1);
+                            WhammyBarType = WhammyType.PrediveDive;
                         }
                         else
                         {
-                            Logger.Warning("Model", "Unsupported whammy type detected, fallback to custom");
+                            WhammyBarType = WhammyType.Dive;
                         }
+
+                        WhammyBarPoints.RemoveAt(2);
+                        WhammyBarPoints.RemoveAt(1);
+                    }
+                    // down-up or up-down
+                    else if (origin.Value > middle1.Value && middle1.Value < destination.Value ||
+                             origin.Value < middle1.Value && middle1.Value > destination.Value)
+                    {
+                        WhammyBarType = WhammyType.Dip;
+                         
+                    }
+                    else if (origin.Value == middle1.Value && middle1.Value == destination.Value)
+                    {
+                        if (origin.Value != 0 && !isContinuedWhammy)
+                        {
+                            WhammyBarType = WhammyType.Predive;
+                        }
+                        else
+                        {
+                            WhammyBarType = WhammyType.Hold;
+                        }
+
+                        WhammyBarPoints.RemoveAt(2);
+                        WhammyBarPoints.RemoveAt(1);
                     }
                     else
                     {
                         Logger.Warning("Model", "Unsupported whammy type detected, fallback to custom");
                     }
                 }
-            }
-
-            UpdateDurations();
-
-            // Code is heuristically unreachable - Expression is always false
-            /*if (needCopyBeatForBend)
-            {
-                // if this beat is a simple bend convert it to a grace beat
-                // and generate a placeholder beat with tied notes
-
-                var cloneBeat = Clone();
-                cloneBeat.Id = _globalBeatId++;
-                for (int i = 0, j = cloneBeat.Notes.Count; i < j; i++)
+                else
                 {
-                    var cloneNote = cloneBeat.Notes[i];
-                    // remove bend on cloned note
-                    cloneNote.BendType = BendType.None;
-                    cloneNote.MaxBendPoint = null;
-                    cloneNote.BendPoints = new FastList<BendPoint>();
-                    cloneNote.BendStyle = BendStyle.Default;
-                    cloneNote.Id = Note.GlobalNoteId++;
+                    Logger.Warning("Model", "Unsupported whammy type detected, fallback to custom");
+                }
+            }
+        }
 
-                    // if the note has a bend which is continued on the next note
-                    // we need to convert this note into a hold bend
-                    var note = Notes[i];
-                    if (note.HasBend && note.IsTieOrigin)
+        UpdateDurations();
+
+        // Code is heuristically unreachable - Expression is always false
+        /*if (needCopyBeatForBend)
+        {
+            // if this beat is a simple bend convert it to a grace beat
+            // and generate a placeholder beat with tied notes
+
+            var cloneBeat = Clone();
+            cloneBeat.Id = _globalBeatId++;
+            for (int i = 0, j = cloneBeat.Notes.Count; i < j; i++)
+            {
+                var cloneNote = cloneBeat.Notes[i];
+                // remove bend on cloned note
+                cloneNote.BendType = BendType.None;
+                cloneNote.MaxBendPoint = null;
+                cloneNote.BendPoints = new FastList<BendPoint>();
+                cloneNote.BendStyle = BendStyle.Default;
+                cloneNote.Id = Note.GlobalNoteId++;
+
+                // if the note has a bend which is continued on the next note
+                // we need to convert this note into a hold bend
+                var note = Notes[i];
+                if (note.HasBend && note.IsTieOrigin)
+                {
+                    var tieDestination = Note.NextNoteOnSameLine(note);
+                    if (tieDestination is { HasBend: true })
                     {
-                        var tieDestination = Note.NextNoteOnSameLine(note);
-                        if (tieDestination is { HasBend: true })
-                        {
-                            cloneNote.BendType = BendType.Hold;
-                            var lastPoint = note.BendPoints[note.BendPoints.Count - 1];
-                            cloneNote.AddBendPoint(new BendPoint(0, lastPoint.Value));
-                            cloneNote.AddBendPoint(new BendPoint(BendPoint.MaxPosition, lastPoint.Value));
-                        }
+                        cloneNote.BendType = BendType.Hold;
+                        var lastPoint = note.BendPoints[note.BendPoints.Count - 1];
+                        cloneNote.AddBendPoint(new BendPoint(0, lastPoint.Value));
+                        cloneNote.AddBendPoint(new BendPoint(BendPoint.MaxPosition, lastPoint.Value));
                     }
-
-                    // mark as tied note
-                    cloneNote.IsTieDestination = true;
                 }
 
-                GraceType = GraceType.BendGrace;
-                UpdateDurations();
+                // mark as tied note
+                cloneNote.IsTieDestination = true;
+            }
 
-                Voice.InsertBeat(this, cloneBeat);
-            }*/
+            GraceType = GraceType.BendGrace;
+            UpdateDurations();
 
-            Fermata = Voice.Bar.MasterBar.GetFermata(this);
-        }
+            Voice.InsertBeat(this, cloneBeat);
+        }*/
 
-        /// <summary>
-        /// Checks whether the current beat is timewise before the given beat.
-        /// </summary>
-        /// <param name="beat"></param>
-        /// <returns></returns>
-        internal bool IsBefore(Beat beat)
-        {
-            return Voice.Bar.Index < beat.Voice.Bar.Index ||
-                   beat.Voice.Bar.Index == Voice.Bar.Index && Index < beat.Index;
-        }
+        Fermata = Voice.Bar.MasterBar.GetFermata(this);
+    }
 
-        /// <summary>
-        /// Checks whether the current beat is timewise after the given beat.
-        /// </summary>
-        /// <param name="beat"></param>
-        /// <returns></returns>
-        internal bool IsAfter(Beat beat)
-        {
-            return Voice.Bar.Index > beat.Voice.Bar.Index ||
-                   beat.Voice.Bar.Index == Voice.Bar.Index && Index > beat.Index;
-        }
+    /// <summary>
+    /// Checks whether the current beat is timewise before the given beat.
+    /// </summary>
+    /// <param name="beat"></param>
+    /// <returns></returns>
+    internal bool IsBefore(Beat beat)
+    {
+        return Voice.Bar.Index < beat.Voice.Bar.Index ||
+               beat.Voice.Bar.Index == Voice.Bar.Index && Index < beat.Index;
+    }
 
-        internal bool HasNoteOnString(int noteString)
-        {
-            return NoteStringLookup.ContainsKey(noteString);
-        }
+    /// <summary>
+    /// Checks whether the current beat is timewise after the given beat.
+    /// </summary>
+    /// <param name="beat"></param>
+    /// <returns></returns>
+    internal bool IsAfter(Beat beat)
+    {
+        return Voice.Bar.Index > beat.Voice.Bar.Index ||
+               beat.Voice.Bar.Index == Voice.Bar.Index && Index > beat.Index;
+    }
 
-        internal Note GetNoteWithRealValue(int noteRealValue)
-        {
-            return NoteValueLookup.ContainsKey(noteRealValue) ? NoteValueLookup[noteRealValue] : null;
-        }
+    internal bool HasNoteOnString(int noteString)
+    {
+        return NoteStringLookup.ContainsKey(noteString);
+    }
+
+    internal Note GetNoteWithRealValue(int noteRealValue)
+    {
+        return NoteValueLookup.ContainsKey(noteRealValue) ? NoteValueLookup[noteRealValue] : null;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/BendPoint.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/BendPoint.cs
@@ -3,56 +3,55 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// A single point of a bending graph. Used to 
+/// describe WhammyBar and String Bending effects.
+/// </summary>
+internal class BendPoint
 {
     /// <summary>
-    /// A single point of a bending graph. Used to 
-    /// describe WhammyBar and String Bending effects.
+    /// The maximum offset for points
     /// </summary>
-    internal class BendPoint
+    public const int MaxPosition = 60;
+
+    /// <summary>
+    /// The maximum value for points. 
+    /// </summary>
+    public const int MaxValue = 12;
+
+    /// <summary>
+    /// Gets or sets offset of the point relative to the note duration (0-60)
+    /// </summary>
+    public int Offset { get; set; }
+
+    /// <summary>
+    /// Gets or sets the 1/4 note value offsets for the bend. 
+    /// </summary>
+    public int Value { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BendPoint"/> class.
+    /// </summary>
+    /// <param name="offset">The offset.</param>
+    /// <param name="value">The value.</param>
+    public BendPoint(int offset = 0, int value = 0)
     {
-        /// <summary>
-        /// The maximum offset for points
-        /// </summary>
-        public const int MaxPosition = 60;
+        Offset = offset;
+        Value  = value;
+    }
 
-        /// <summary>
-        /// The maximum value for points. 
-        /// </summary>
-        public const int MaxValue = 12;
+    internal static void CopyTo(BendPoint src, BendPoint dst)
+    {
+        dst.Offset = src.Offset;
+        dst.Value  = src.Value;
+    }
 
-        /// <summary>
-        /// Gets or sets offset of the point relative to the note duration (0-60)
-        /// </summary>
-        public int Offset { get; set; }
-
-        /// <summary>
-        /// Gets or sets the 1/4 note value offsets for the bend. 
-        /// </summary>
-        public int Value { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BendPoint"/> class.
-        /// </summary>
-        /// <param name="offset">The offset.</param>
-        /// <param name="value">The value.</param>
-        public BendPoint(int offset = 0, int value = 0)
-        {
-            Offset = offset;
-            Value = value;
-        }
-
-        internal static void CopyTo(BendPoint src, BendPoint dst)
-        {
-            dst.Offset = src.Offset;
-            dst.Value = src.Value;
-        }
-
-        internal BendPoint Clone()
-        {
-            var point = new BendPoint();
-            CopyTo(this, point);
-            return point;
-        }
+    internal BendPoint Clone()
+    {
+        var point = new BendPoint();
+        CopyTo(this, point);
+        return point;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/BendStyle.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/BendStyle.cs
@@ -3,26 +3,25 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Lists the different bend styles
+/// </summary>
+internal enum BendStyle
 {
     /// <summary>
-    /// Lists the different bend styles
+    /// The bends are as described by the bend points 
     /// </summary>
-    internal enum BendStyle
-    {
-        /// <summary>
-        /// The bends are as described by the bend points 
-        /// </summary>
-        Default,
+    Default,
 
-        /// <summary>
-        /// The bends are gradual over the beat duration. 
-        /// </summary>
-        Gradual,
+    /// <summary>
+    /// The bends are gradual over the beat duration. 
+    /// </summary>
+    Gradual,
 
-        /// <summary>
-        /// The bends are done fast before the next note. 
-        /// </summary>
-        Fast
-    }
+    /// <summary>
+    /// The bends are done fast before the next note. 
+    /// </summary>
+    Fast
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/BendType.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/BendType.cs
@@ -3,60 +3,59 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Lists all types of bends
+/// </summary>
+internal enum BendType
 {
     /// <summary>
-    /// Lists all types of bends
+    /// No bend at all
     /// </summary>
-    internal enum BendType
-    {
-        /// <summary>
-        /// No bend at all
-        /// </summary>
-        None,
+    None,
 
-        /// <summary>
-        /// Individual points define the bends in a flexible manner.
-        /// This system was mainly used in Guitar Pro 3-5
-        /// </summary>
-        Custom,
+    /// <summary>
+    /// Individual points define the bends in a flexible manner.
+    /// This system was mainly used in Guitar Pro 3-5
+    /// </summary>
+    Custom,
 
-        /// <summary>
-        /// Simple Bend from an unbended string to a higher note.
-        /// </summary>
-        Bend,
+    /// <summary>
+    /// Simple Bend from an unbended string to a higher note.
+    /// </summary>
+    Bend,
 
-        /// <summary>
-        /// Release of a bend that was started on an earlier note.
-        /// </summary>
-        Release,
+    /// <summary>
+    /// Release of a bend that was started on an earlier note.
+    /// </summary>
+    Release,
 
-        /// <summary>
-        /// A bend that starts from an unbended string,
-        /// and also releases the bend after some time.
-        /// </summary>
-        BendRelease,
+    /// <summary>
+    /// A bend that starts from an unbended string,
+    /// and also releases the bend after some time.
+    /// </summary>
+    BendRelease,
 
-        /// <summary>
-        /// Holds a bend that was started on an earlier note
-        /// </summary>
-        Hold,
+    /// <summary>
+    /// Holds a bend that was started on an earlier note
+    /// </summary>
+    Hold,
 
-        /// <summary>
-        /// A bend that is already started before the note is played then it is held until the end.
-        /// </summary>
-        Prebend,
+    /// <summary>
+    /// A bend that is already started before the note is played then it is held until the end.
+    /// </summary>
+    Prebend,
 
-        /// <summary>
-        /// A bend that is already started before the note is played and
-        /// bends even further, then it is held until the end.
-        /// </summary>
-        PrebendBend,
+    /// <summary>
+    /// A bend that is already started before the note is played and
+    /// bends even further, then it is held until the end.
+    /// </summary>
+    PrebendBend,
 
-        /// <summary>
-        /// A bend that is already started before the note is played and
-        /// then releases the bend to a lower note where it is held until the end.
-        /// </summary>
-        PrebendRelease
-    }
+    /// <summary>
+    /// A bend that is already started before the note is played and
+    /// then releases the bend to a lower note where it is held until the end.
+    /// </summary>
+    PrebendRelease
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/BrushType.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/BrushType.cs
@@ -3,36 +3,35 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Lists all types of how to brush multiple notes on a beat. 
+/// </summary>
+internal enum BrushType
 {
     /// <summary>
-    /// Lists all types of how to brush multiple notes on a beat. 
+    /// No brush. 
     /// </summary>
-    internal enum BrushType
-    {
-        /// <summary>
-        /// No brush. 
-        /// </summary>
-        None,
+    None,
 
-        /// <summary>
-        /// Normal brush up. 
-        /// </summary>
-        BrushUp,
+    /// <summary>
+    /// Normal brush up. 
+    /// </summary>
+    BrushUp,
 
-        /// <summary>
-        /// Normal brush down. 
-        /// </summary>
-        BrushDown,
+    /// <summary>
+    /// Normal brush down. 
+    /// </summary>
+    BrushDown,
 
-        /// <summary>
-        /// Arpeggio up. 
-        /// </summary>
-        ArpeggioUp,
+    /// <summary>
+    /// Arpeggio up. 
+    /// </summary>
+    ArpeggioUp,
 
-        /// <summary>
-        /// Arpeggio down. 
-        /// </summary>
-        ArpeggioDown
-    }
+    /// <summary>
+    /// Arpeggio down. 
+    /// </summary>
+    ArpeggioDown
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Chord.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Chord.cs
@@ -5,77 +5,76 @@
 
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// A chord definition.
+/// </summary>
+internal class Chord
 {
     /// <summary>
-    /// A chord definition.
+    /// Gets or sets the name of the chord
     /// </summary>
-    internal class Chord
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Indicates the first fret of the chord diagram.
+    /// </summary>
+    public int FirstFret { get; set; }
+
+    /// <summary>
+    /// Gets or sets the frets played on the individual strings for this chord. 
+    /// - The order in this list goes from the highest string to the lowest string.  
+    /// - -1 indicates that the string is not played. 
+    /// </summary>
+    public FastList<int> Strings { get; set; }
+
+    /// <summary>
+    /// Gets or sets a list of frets where the finger should hold a barre 
+    /// </summary>
+    public FastList<int> BarreFrets { get; set; }
+
+    /// <summary>
+    /// Gets or sets the staff the chord belongs to. 
+    /// </summary>
+    public Staff Staff { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the chord name is shown above the chord diagram. 
+    /// </summary>
+    public bool ShowName { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the chord diagram is shown.
+    /// </summary>
+    public bool ShowDiagram { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the fingering is shown below the chord diagram. 
+    /// </summary>
+    public bool ShowFingering { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Chord"/> class.
+    /// </summary>
+    public Chord()
     {
-        /// <summary>
-        /// Gets or sets the name of the chord
-        /// </summary>
-        public string Name { get; set; }
+        Strings       = new FastList<int>();
+        BarreFrets    = new FastList<int>();
+        ShowDiagram   = true;
+        ShowName      = true;
+        ShowFingering = true;
+        FirstFret     = 1;
+    }
 
-        /// <summary>
-        /// Indicates the first fret of the chord diagram.
-        /// </summary>
-        public int FirstFret { get; set; }
-
-        /// <summary>
-        /// Gets or sets the frets played on the individual strings for this chord. 
-        /// - The order in this list goes from the highest string to the lowest string.  
-        /// - -1 indicates that the string is not played. 
-        /// </summary>
-        public FastList<int> Strings { get; set; }
-
-        /// <summary>
-        /// Gets or sets a list of frets where the finger should hold a barre 
-        /// </summary>
-        public FastList<int> BarreFrets { get; set; }
-
-        /// <summary>
-        /// Gets or sets the staff the chord belongs to. 
-        /// </summary>
-        public Staff Staff { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether the chord name is shown above the chord diagram. 
-        /// </summary>
-        public bool ShowName { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether the chord diagram is shown.
-        /// </summary>
-        public bool ShowDiagram { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether the fingering is shown below the chord diagram. 
-        /// </summary>
-        public bool ShowFingering { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Chord"/> class.
-        /// </summary>
-        public Chord()
-        {
-            Strings = new FastList<int>();
-            BarreFrets = new FastList<int>();
-            ShowDiagram = true;
-            ShowName = true;
-            ShowFingering = true;
-            FirstFret = 1;
-        }
-
-        internal static void CopyTo(Chord src, Chord dst)
-        {
-            dst.FirstFret = src.FirstFret;
-            dst.Name = src.Name;
-            dst.Strings = src.Strings.Clone();
-            dst.BarreFrets = src.BarreFrets.Clone();
-            dst.ShowName = src.ShowName;
-            dst.ShowDiagram = src.ShowDiagram;
-            dst.ShowFingering = src.ShowFingering;
-        }
+    internal static void CopyTo(Chord src, Chord dst)
+    {
+        dst.FirstFret     = src.FirstFret;
+        dst.Name          = src.Name;
+        dst.Strings       = src.Strings.Clone();
+        dst.BarreFrets    = src.BarreFrets.Clone();
+        dst.ShowName      = src.ShowName;
+        dst.ShowDiagram   = src.ShowDiagram;
+        dst.ShowFingering = src.ShowFingering;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Clef.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Clef.cs
@@ -3,36 +3,35 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// This public enumeration lists all supported Clefs.
+/// </summary>
+internal enum Clef
 {
     /// <summary>
-    /// This public enumeration lists all supported Clefs.
+    /// Neutral clef.
     /// </summary>
-    internal enum Clef
-    {
-        /// <summary>
-        /// Neutral clef.
-        /// </summary>
-        Neutral,
+    Neutral,
 
-        /// <summary>
-        /// C3 clef
-        /// </summary>
-        C3,
+    /// <summary>
+    /// C3 clef
+    /// </summary>
+    C3,
 
-        /// <summary>
-        /// C4 clef
-        /// </summary>
-        C4,
+    /// <summary>
+    /// C4 clef
+    /// </summary>
+    C4,
 
-        /// <summary>
-        /// F4 clef
-        /// </summary>
-        F4,
+    /// <summary>
+    /// F4 clef
+    /// </summary>
+    F4,
 
-        /// <summary>
-        /// G2 clef
-        /// </summary>
-        G2
-    }
+    /// <summary>
+    /// G2 clef
+    /// </summary>
+    G2
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/CrescendoType.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/CrescendoType.cs
@@ -3,26 +3,25 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Lists all Crescendo and Decrescendo types. 
+/// </summary>
+internal enum CrescendoType
 {
     /// <summary>
-    /// Lists all Crescendo and Decrescendo types. 
+    /// No crescendo applied. 
     /// </summary>
-    internal enum CrescendoType
-    {
-        /// <summary>
-        /// No crescendo applied. 
-        /// </summary>
-        None,
+    None,
 
-        /// <summary>
-        /// Normal crescendo applied. 
-        /// </summary>
-        Crescendo,
+    /// <summary>
+    /// Normal crescendo applied. 
+    /// </summary>
+    Crescendo,
 
-        /// <summary>
-        /// Normal decrescendo applied. 
-        /// </summary>
-        Decrescendo
-    }
+    /// <summary>
+    /// Normal decrescendo applied. 
+    /// </summary>
+    Decrescendo
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Duration.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Duration.cs
@@ -3,66 +3,65 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Lists all durations of a beat.
+/// </summary>
+internal enum Duration
 {
     /// <summary>
-    /// Lists all durations of a beat.
+    /// A quadruple whole note duration 
     /// </summary>
-    internal enum Duration
-    {
-        /// <summary>
-        /// A quadruple whole note duration 
-        /// </summary>
-        QuadrupleWhole = -4,
+    QuadrupleWhole = -4,
 
-        /// <summary>
-        /// A double whole note duration 
-        /// </summary>
-        DoubleWhole = -2,
+    /// <summary>
+    /// A double whole note duration 
+    /// </summary>
+    DoubleWhole = -2,
 
-        /// <summary>
-        /// A whole note duration 
-        /// </summary>
-        Whole = 1,
+    /// <summary>
+    /// A whole note duration 
+    /// </summary>
+    Whole = 1,
 
-        /// <summary>
-        /// A 1/2 note duration 
-        /// </summary>
-        Half = 2,
+    /// <summary>
+    /// A 1/2 note duration 
+    /// </summary>
+    Half = 2,
 
-        /// <summary>
-        /// A 1/4 note duration 
-        /// </summary>
-        Quarter = 4,
+    /// <summary>
+    /// A 1/4 note duration 
+    /// </summary>
+    Quarter = 4,
 
-        /// <summary>
-        /// A 1/8 note duration 
-        /// </summary>
-        Eighth = 8,
+    /// <summary>
+    /// A 1/8 note duration 
+    /// </summary>
+    Eighth = 8,
 
-        /// <summary>
-        /// A 1/16 note duration 
-        /// </summary>
-        Sixteenth = 16,
+    /// <summary>
+    /// A 1/16 note duration 
+    /// </summary>
+    Sixteenth = 16,
 
-        /// <summary>
-        /// A 1/32 note duration 
-        /// </summary>
-        ThirtySecond = 32,
+    /// <summary>
+    /// A 1/32 note duration 
+    /// </summary>
+    ThirtySecond = 32,
 
-        /// <summary>
-        /// A 1/64 note duration 
-        /// </summary>
-        SixtyFourth = 64,
+    /// <summary>
+    /// A 1/64 note duration 
+    /// </summary>
+    SixtyFourth = 64,
 
-        /// <summary>
-        /// A 1/128 note duration 
-        /// </summary>
-        OneHundredTwentyEighth = 128,
+    /// <summary>
+    /// A 1/128 note duration 
+    /// </summary>
+    OneHundredTwentyEighth = 128,
 
-        /// <summary>
-        /// A 1/256 note duration 
-        /// </summary>
-        TwoHundredFiftySixth = 256
-    }
+    /// <summary>
+    /// A 1/256 note duration 
+    /// </summary>
+    TwoHundredFiftySixth = 256
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/DynamicValue.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/DynamicValue.cs
@@ -3,53 +3,52 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+// ReSharper disable InconsistentNaming
+/// <summary>
+/// Lists all dynamics.
+/// </summary>
+internal enum DynamicValue
 {
-    // ReSharper disable InconsistentNaming
     /// <summary>
-    /// Lists all dynamics.
+    /// pianississimo (very very soft)
     /// </summary>
-    internal enum DynamicValue
-    {
-        /// <summary>
-        /// pianississimo (very very soft)
-        /// </summary>
-        PPP,
+    PPP,
 
-        /// <summary>
-        /// pianissimo (very soft)
-        /// </summary>
-        PP,
+    /// <summary>
+    /// pianissimo (very soft)
+    /// </summary>
+    PP,
 
-        /// <summary>
-        /// piano (soft)
-        /// </summary>
-        P,
+    /// <summary>
+    /// piano (soft)
+    /// </summary>
+    P,
 
-        /// <summary>
-        /// mezzo-piano (half soft)
-        /// </summary>
-        MP,
+    /// <summary>
+    /// mezzo-piano (half soft)
+    /// </summary>
+    MP,
 
-        /// <summary>
-        /// mezzo-forte (half loud)
-        /// </summary>
-        MF,
+    /// <summary>
+    /// mezzo-forte (half loud)
+    /// </summary>
+    MF,
 
-        /// <summary>
-        /// forte (loud)
-        /// </summary>
-        F,
+    /// <summary>
+    /// forte (loud)
+    /// </summary>
+    F,
 
-        /// <summary>
-        /// fortissimo (very loud)
-        /// </summary>
-        FF,
+    /// <summary>
+    /// fortissimo (very loud)
+    /// </summary>
+    FF,
 
-        /// <summary>
-        /// fortississimo (very very loud)
-        /// </summary>
-        FFF
-    }
-    // ReSharper restore InconsistentNaming
+    /// <summary>
+    /// fortississimo (very very loud)
+    /// </summary>
+    FFF
 }
+// ReSharper restore InconsistentNaming

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Fermata.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Fermata.cs
@@ -3,27 +3,26 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Represents a fermata. 
+/// </summary>
+internal class Fermata
 {
     /// <summary>
-    /// Represents a fermata. 
+    /// Gets or sets the type of fermata. 
     /// </summary>
-    internal class Fermata
+    public FermataType Type { get; set; }
+
+    /// <summary>
+    /// Gets or sets the actual lenght of the fermata. 
+    /// </summary>
+    public float Length { get; set; }
+
+    internal static void CopyTo(Fermata src, Fermata dst)
     {
-        /// <summary>
-        /// Gets or sets the type of fermata. 
-        /// </summary>
-        public FermataType Type { get; set; }
-
-        /// <summary>
-        /// Gets or sets the actual lenght of the fermata. 
-        /// </summary>
-        public float Length { get; set; }
-
-        internal static void CopyTo(Fermata src, Fermata dst)
-        {
-            dst.Type = src.Type;
-            dst.Length = src.Length;
-        }
+        dst.Type   = src.Type;
+        dst.Length = src.Length;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/FermataType.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/FermataType.cs
@@ -3,26 +3,25 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Lists all types of fermatas
+/// </summary>
+internal enum FermataType
 {
     /// <summary>
-    /// Lists all types of fermatas
+    /// A short fermata (triangle symbol)
     /// </summary>
-    internal enum FermataType
-    {
-        /// <summary>
-        /// A short fermata (triangle symbol)
-        /// </summary>
-        Short,
+    Short,
 
-        /// <summary>
-        /// A medium fermata (round symbol)
-        /// </summary>
-        Medium,
+    /// <summary>
+    /// A medium fermata (round symbol)
+    /// </summary>
+    Medium,
 
-        /// <summary>
-        /// A long fermata (rectangular symbol)
-        /// </summary>
-        Long
-    }
+    /// <summary>
+    /// A long fermata (rectangular symbol)
+    /// </summary>
+    Long
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Fingers.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Fingers.cs
@@ -3,46 +3,45 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Lists all fingers.
+/// </summary>
+internal enum Fingers
 {
     /// <summary>
-    /// Lists all fingers.
+    /// Unknown type (not documented)
     /// </summary>
-    internal enum Fingers
-    {
-        /// <summary>
-        /// Unknown type (not documented)
-        /// </summary>
-        Unknown = -2,
+    Unknown = -2,
 
-        /// <summary>
-        /// No finger, dead note
-        /// </summary>
-        NoOrDead = -1,
+    /// <summary>
+    /// No finger, dead note
+    /// </summary>
+    NoOrDead = -1,
 
-        /// <summary>
-        /// The thumb
-        /// </summary>
-        Thumb = 0,
+    /// <summary>
+    /// The thumb
+    /// </summary>
+    Thumb = 0,
 
-        /// <summary>
-        /// The index finger
-        /// </summary>
-        IndexFinger = 1,
+    /// <summary>
+    /// The index finger
+    /// </summary>
+    IndexFinger = 1,
 
-        /// <summary>
-        /// The middle finger
-        /// </summary>
-        MiddleFinger = 2,
+    /// <summary>
+    /// The middle finger
+    /// </summary>
+    MiddleFinger = 2,
 
-        /// <summary>
-        /// The annular finger
-        /// </summary>
-        AnnularFinger = 3,
+    /// <summary>
+    /// The annular finger
+    /// </summary>
+    AnnularFinger = 3,
 
-        /// <summary>
-        /// The little finger
-        /// </summary>
-        LittleFinger = 4
-    }
+    /// <summary>
+    /// The little finger
+    /// </summary>
+    LittleFinger = 4
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/GraceType.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/GraceType.cs
@@ -3,31 +3,30 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Lists all types of grace notes
+/// </summary>
+internal enum GraceType
 {
     /// <summary>
-    /// Lists all types of grace notes
+    /// No grace, normal beat. 
     /// </summary>
-    internal enum GraceType
-    {
-        /// <summary>
-        /// No grace, normal beat. 
-        /// </summary>
-        None,
+    None,
 
-        /// <summary>
-        /// The beat contains on-beat grace notes. 
-        /// </summary>
-        OnBeat,
+    /// <summary>
+    /// The beat contains on-beat grace notes. 
+    /// </summary>
+    OnBeat,
 
-        /// <summary>
-        /// The beat contains before-beat grace notes. 
-        /// </summary>
-        BeforeBeat,
+    /// <summary>
+    /// The beat contains before-beat grace notes. 
+    /// </summary>
+    BeforeBeat,
 
-        /// <summary>
-        /// The beat contains very special bend-grace notes used in SongBook style displays.
-        /// </summary>
-        BendGrace
-    }
+    /// <summary>
+    /// The beat contains very special bend-grace notes used in SongBook style displays.
+    /// </summary>
+    BendGrace
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/HarmonicType.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/HarmonicType.cs
@@ -3,46 +3,45 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Lists all harmonic types.
+/// </summary>
+internal enum HarmonicType
 {
     /// <summary>
-    /// Lists all harmonic types.
+    /// No harmonics. 
     /// </summary>
-    internal enum HarmonicType
-    {
-        /// <summary>
-        /// No harmonics. 
-        /// </summary>
-        None,
+    None,
 
-        /// <summary>
-        /// Natural harmonic
-        /// </summary>
-        Natural,
+    /// <summary>
+    /// Natural harmonic
+    /// </summary>
+    Natural,
 
-        /// <summary>
-        /// Artificial harmonic
-        /// </summary>
-        Artificial,
+    /// <summary>
+    /// Artificial harmonic
+    /// </summary>
+    Artificial,
 
-        /// <summary>
-        /// Pinch harmonics
-        /// </summary>
-        Pinch,
+    /// <summary>
+    /// Pinch harmonics
+    /// </summary>
+    Pinch,
 
-        /// <summary>
-        /// Tap harmonics
-        /// </summary>
-        Tap,
+    /// <summary>
+    /// Tap harmonics
+    /// </summary>
+    Tap,
 
-        /// <summary>
-        /// Semi harmonics
-        /// </summary>
-        Semi,
+    /// <summary>
+    /// Semi harmonics
+    /// </summary>
+    Semi,
 
-        /// <summary>
-        /// Feedback harmonics
-        /// </summary>
-        Feedback
-    }
+    /// <summary>
+    /// Feedback harmonics
+    /// </summary>
+    Feedback
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/KeySignatureType.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/KeySignatureType.cs
@@ -3,102 +3,101 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// This public enumeration lists all available key signatures
+/// </summary>
+internal enum KeySignature
 {
     /// <summary>
-    /// This public enumeration lists all available key signatures
+    /// Cb (7 flats)
     /// </summary>
-    internal enum KeySignature
-    {
-        /// <summary>
-        /// Cb (7 flats)
-        /// </summary>
-        Cb = -7,
-
-        /// <summary>
-        /// Gb (6 flats)
-        /// </summary>
-        Gb = -6,
-
-        /// <summary>
-        /// Db (5 flats)
-        /// </summary>
-        Db = -5,
-
-        /// <summary>
-        /// Ab (4 flats)
-        /// </summary>
-        Ab = -4,
-
-        /// <summary>
-        /// Eb (3 flats)
-        /// </summary>
-        Eb = -3,
-
-        /// <summary>
-        /// Bb (2 flats)
-        /// </summary>
-        Bb = -2,
-
-        /// <summary>
-        /// F (1 flat)
-        /// </summary>
-        F = -1,
-
-        /// <summary>
-        /// C (no signs)
-        /// </summary>
-        C = 0,
-
-        /// <summary>
-        /// G (1 sharp)
-        /// </summary>
-        G = 1,
-
-        /// <summary>
-        /// D (2 sharp)
-        /// </summary>
-        D = 2,
-
-        /// <summary>
-        /// A (3 sharp)
-        /// </summary>
-        A = 3,
-
-        /// <summary>
-        /// E (4 sharp)
-        /// </summary>
-        E = 4,
-
-        /// <summary>
-        /// B (5 sharp)
-        /// </summary>
-        B = 5,
-
-        /// <summary>
-        /// F# (6 sharp)
-        /// </summary>
-        FSharp = 6,
-
-        /// <summary>
-        /// C# (8 sharp)
-        /// </summary>
-        CSharp = 7
-    }
+    Cb = -7,
 
     /// <summary>
-    /// This public enumeration lists all available types of KeySignatures
+    /// Gb (6 flats)
     /// </summary>
-    public enum KeySignatureType
-    {
-        /// <summary>
-        /// Major
-        /// </summary>
-        Major,
+    Gb = -6,
 
-        /// <summary>
-        /// Minor
-        /// </summary>
-        Minor
-    }
+    /// <summary>
+    /// Db (5 flats)
+    /// </summary>
+    Db = -5,
+
+    /// <summary>
+    /// Ab (4 flats)
+    /// </summary>
+    Ab = -4,
+
+    /// <summary>
+    /// Eb (3 flats)
+    /// </summary>
+    Eb = -3,
+
+    /// <summary>
+    /// Bb (2 flats)
+    /// </summary>
+    Bb = -2,
+
+    /// <summary>
+    /// F (1 flat)
+    /// </summary>
+    F = -1,
+
+    /// <summary>
+    /// C (no signs)
+    /// </summary>
+    C = 0,
+
+    /// <summary>
+    /// G (1 sharp)
+    /// </summary>
+    G = 1,
+
+    /// <summary>
+    /// D (2 sharp)
+    /// </summary>
+    D = 2,
+
+    /// <summary>
+    /// A (3 sharp)
+    /// </summary>
+    A = 3,
+
+    /// <summary>
+    /// E (4 sharp)
+    /// </summary>
+    E = 4,
+
+    /// <summary>
+    /// B (5 sharp)
+    /// </summary>
+    B = 5,
+
+    /// <summary>
+    /// F# (6 sharp)
+    /// </summary>
+    FSharp = 6,
+
+    /// <summary>
+    /// C# (8 sharp)
+    /// </summary>
+    CSharp = 7
+}
+
+/// <summary>
+/// This public enumeration lists all available types of KeySignatures
+/// </summary>
+public enum KeySignatureType
+{
+    /// <summary>
+    /// Major
+    /// </summary>
+    Major,
+
+    /// <summary>
+    /// Minor
+    /// </summary>
+    Minor
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Lyrics.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Lyrics.cs
@@ -5,166 +5,165 @@
 
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Represents the lyrics of a song. 
+/// </summary>
+internal class Lyrics
 {
+    private const int CharCodeLF = '\n';
+    private const int CharCodeTab = '\t';
+    private const int CharCodeCR = '\r';
+    private const int CharCodeSpace = ' ';
+    private const int CharCodeBrackedClose = ']';
+    private const int CharCodeBrackedOpen = '[';
+    private const int CharCodeDash = '-';
+
     /// <summary>
-    /// Represents the lyrics of a song. 
+    /// Gets or sets he start bar on which the lyrics should begin. 
     /// </summary>
-    internal class Lyrics
+    public int StartBar { get; set; }
+
+    /// <summary>
+    /// Gets or sets the raw lyrics text in Guitar Pro format.
+    /// (spaces split word syllables, plus merge syllables, [..] are comments) 
+    /// </summary>
+    public string Text { get; set; }
+
+    /// <summary>
+    /// Gets or sets the prepared chunks of the lyrics to apply to beats. 
+    /// </summary>
+    public string[] Chunks { get; set; }
+
+    internal void Finish()
     {
-        private const int CharCodeLF = '\n';
-        private const int CharCodeTab = '\t';
-        private const int CharCodeCR = '\r';
-        private const int CharCodeSpace = ' ';
-        private const int CharCodeBrackedClose = ']';
-        private const int CharCodeBrackedOpen = '[';
-        private const int CharCodeDash = '-';
+        var chunks = new FastList<string>();
+        Parse(Text, 0, chunks);
+        Chunks = chunks.ToArray();
+    }
 
-        /// <summary>
-        /// Gets or sets he start bar on which the lyrics should begin. 
-        /// </summary>
-        public int StartBar { get; set; }
-
-        /// <summary>
-        /// Gets or sets the raw lyrics text in Guitar Pro format.
-        /// (spaces split word syllables, plus merge syllables, [..] are comments) 
-        /// </summary>
-        public string Text { get; set; }
-
-        /// <summary>
-        /// Gets or sets the prepared chunks of the lyrics to apply to beats. 
-        /// </summary>
-        public string[] Chunks { get; set; }
-
-        internal void Finish()
+    private static void Parse(string str, int p, FastList<string> chunks)
+    {
+        if (string.IsNullOrEmpty(str))
         {
-            var chunks = new FastList<string>();
-            Parse(Text, 0, chunks);
-            Chunks = chunks.ToArray();
+            return;
         }
 
-        private static void Parse(string str, int p, FastList<string> chunks)
+        var state = LyricsState.Begin;
+        var next = LyricsState.Begin;
+        var skipSpace = false;
+        var start = 0;
+
+        while (p < str.Length)
         {
-            if (string.IsNullOrEmpty(str))
+            int c = str[p];
+            switch (state)
             {
-                return;
-            }
-
-            var state = LyricsState.Begin;
-            var next = LyricsState.Begin;
-            var skipSpace = false;
-            var start = 0;
-
-            while (p < str.Length)
-            {
-                int c = str[p];
-                switch (state)
-                {
-                    case LyricsState.IgnoreSpaces:
-                        switch (c)
-                        {
-                            case CharCodeLF:
-                            case CharCodeCR:
-                            case CharCodeTab:
-                                break;
-                            case CharCodeSpace:
-                                if (!skipSpace)
-                                {
-                                    state = next;
-                                    continue;
-                                }
-
-                                break;
-                            default:
-                                skipSpace = false;
+                case LyricsState.IgnoreSpaces:
+                    switch (c)
+                    {
+                        case CharCodeLF:
+                        case CharCodeCR:
+                        case CharCodeTab:
+                            break;
+                        case CharCodeSpace:
+                            if (!skipSpace)
+                            {
                                 state = next;
                                 continue;
-                        }
+                            }
 
-                        break;
-                    case LyricsState.Begin:
-                        switch (c)
-                        {
-                            case CharCodeBrackedOpen:
-                                state = LyricsState.Comment;
-                                break;
-                            default:
-                                start = p;
-                                state = LyricsState.Text;
-                                continue;
-                        }
+                            break;
+                        default:
+                            skipSpace = false;
+                            state     = next;
+                            continue;
+                    }
 
-                        break;
-                    case LyricsState.Comment:
-                        state = c switch
-                        {
-                            CharCodeBrackedClose => LyricsState.Begin,
-                            _                    => state
-                        };
+                    break;
+                case LyricsState.Begin:
+                    switch (c)
+                    {
+                        case CharCodeBrackedOpen:
+                            state = LyricsState.Comment;
+                            break;
+                        default:
+                            start = p;
+                            state = LyricsState.Text;
+                            continue;
+                    }
 
-                        break;
+                    break;
+                case LyricsState.Comment:
+                    state = c switch
+                    {
+                        CharCodeBrackedClose => LyricsState.Begin,
+                        _                    => state
+                    };
 
-                    case LyricsState.Text:
-                        switch (c)
-                        {
-                            case CharCodeDash:
-                                state = LyricsState.Dash;
-                                break;
-                            case CharCodeCR:
-                            case CharCodeLF:
-                            case CharCodeSpace:
-                                var txt = str.Substring(start, p - start);
-                                chunks.Add(PrepareChunk(txt));
+                    break;
 
-                                state = LyricsState.IgnoreSpaces;
-                                next = LyricsState.Begin;
-                                break;
-                        }
+                case LyricsState.Text:
+                    switch (c)
+                    {
+                        case CharCodeDash:
+                            state = LyricsState.Dash;
+                            break;
+                        case CharCodeCR:
+                        case CharCodeLF:
+                        case CharCodeSpace:
+                            var txt = str.Substring(start, p - start);
+                            chunks.Add(PrepareChunk(txt));
 
-                        break;
+                            state = LyricsState.IgnoreSpaces;
+                            next  = LyricsState.Begin;
+                            break;
+                    }
 
-                    case LyricsState.Dash:
-                        switch (c)
-                        {
-                            case CharCodeDash:
-                                break;
-                            default:
-                                var txt = str.Substring(start, p - start);
-                                chunks.Add(PrepareChunk(txt));
+                    break;
 
-                                skipSpace = true;
-                                state = LyricsState.IgnoreSpaces;
-                                next = LyricsState.Begin;
-                                continue;
-                        }
+                case LyricsState.Dash:
+                    switch (c)
+                    {
+                        case CharCodeDash:
+                            break;
+                        default:
+                            var txt = str.Substring(start, p - start);
+                            chunks.Add(PrepareChunk(txt));
 
-                        break;
-                }
+                            skipSpace = true;
+                            state     = LyricsState.IgnoreSpaces;
+                            next      = LyricsState.Begin;
+                            continue;
+                    }
 
-                p++;
+                    break;
             }
 
-            if (state == LyricsState.Text)
+            p++;
+        }
+
+        if (state == LyricsState.Text)
+        {
+            if (p != start)
             {
-                if (p != start)
-                {
-                    chunks.Add(str.Substring(start, p - start));
-                }
+                chunks.Add(str.Substring(start, p - start));
             }
         }
+    }
 
-        private static string PrepareChunk(string txt)
-        {
-            return txt.Replace("+", " ");
-        }
+    private static string PrepareChunk(string txt)
+    {
+        return txt.Replace("+", " ");
+    }
 
-        private enum LyricsState
-        {
-            IgnoreSpaces,
-            Begin,
-            Text,
-            Comment,
-            Dash
-        }
+    private enum LyricsState
+    {
+        IgnoreSpaces,
+        Begin,
+        Text,
+        Comment,
+        Dash
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Lyrics.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Lyrics.cs
@@ -43,7 +43,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
             Chunks = chunks.ToArray();
         }
 
-        private void Parse(string str, int p, FastList<string> chunks)
+        private static void Parse(string str, int p, FastList<string> chunks)
         {
             if (string.IsNullOrEmpty(str))
             {
@@ -96,12 +96,11 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
 
                         break;
                     case LyricsState.Comment:
-                        switch (c)
+                        state = c switch
                         {
-                            case CharCodeBrackedClose:
-                                state = LyricsState.Begin;
-                                break;
-                        }
+                            CharCodeBrackedClose => LyricsState.Begin,
+                            _                    => state
+                        };
 
                         break;
 
@@ -154,7 +153,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
             }
         }
 
-        private string PrepareChunk(string txt)
+        private static string PrepareChunk(string txt)
         {
             return txt.Replace("+", " ");
         }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/MasterBar.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/MasterBar.cs
@@ -7,189 +7,188 @@ using System.Linq;
 using BardMusicPlayer.Siren.AlphaTab.Audio;
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// The MasterBar stores information about a bar which affects
+/// all tracks.
+/// </summary>
+internal class MasterBar
 {
     /// <summary>
-    /// The MasterBar stores information about a bar which affects
-    /// all tracks.
+    /// The maximum alternate endings.  (1 byte with 8 bitflags)
     /// </summary>
-    internal class MasterBar
-    {
-        /// <summary>
-        /// The maximum alternate endings.  (1 byte with 8 bitflags)
-        /// </summary>
-        public const int MaxAlternateEndings = 8;
+    public const int MaxAlternateEndings = 8;
 
-        /// <summary>
-        /// Gets or sets the bitflag for the alternate endings. Each bit defines for which repeat counts
-        /// the bar is played.
-        /// </summary>
-        public byte AlternateEndings { get; set; }
+    /// <summary>
+    /// Gets or sets the bitflag for the alternate endings. Each bit defines for which repeat counts
+    /// the bar is played.
+    /// </summary>
+    public byte AlternateEndings { get; set; }
 
-        /// <summary>
-        /// Gets or sets the next masterbar in the song. 
-        /// </summary>
-        public MasterBar NextMasterBar { get; set; }
+    /// <summary>
+    /// Gets or sets the next masterbar in the song. 
+    /// </summary>
+    public MasterBar NextMasterBar { get; set; }
 
-        /// <summary>
-        /// Gets or sets the next masterbar in the song. 
-        /// </summary>
-        public MasterBar PreviousMasterBar { get; set; }
+    /// <summary>
+    /// Gets or sets the next masterbar in the song. 
+    /// </summary>
+    public MasterBar PreviousMasterBar { get; set; }
 
-        /// <summary>
-        /// Gets the zero based index of the masterbar. 
-        /// </summary>
-        public int Index { get; set; }
+    /// <summary>
+    /// Gets the zero based index of the masterbar. 
+    /// </summary>
+    public int Index { get; set; }
 
-        /// <summary>
-        /// Gets or sets the key signature used on all bars.
-        /// </summary>
-        public KeySignature KeySignature { get; set; }
+    /// <summary>
+    /// Gets or sets the key signature used on all bars.
+    /// </summary>
+    public KeySignature KeySignature { get; set; }
 
-        /// <summary>
-        /// Gets or sets the type of key signature (major/minor)
-        /// </summary>
-        public KeySignatureType KeySignatureType { get; set; }
+    /// <summary>
+    /// Gets or sets the type of key signature (major/minor)
+    /// </summary>
+    public KeySignatureType KeySignatureType { get; set; }
 
-        /// <summary>
-        /// Gets or sets whether a double bar is shown for this masterbar. 
-        /// </summary>
-        public bool IsDoubleBar { get; set; }
+    /// <summary>
+    /// Gets or sets whether a double bar is shown for this masterbar. 
+    /// </summary>
+    public bool IsDoubleBar { get; set; }
 
-        /// <summary>
-        /// Gets or sets whether a repeat section starts on this masterbar. 
-        /// </summary>
-        public bool IsRepeatStart { get; set; }
+    /// <summary>
+    /// Gets or sets whether a repeat section starts on this masterbar. 
+    /// </summary>
+    public bool IsRepeatStart { get; set; }
 
-        /// <summary>
-        /// Gets or sets whether a repeat section ends on this masterbar. 
-        /// </summary>
-        public bool IsRepeatEnd => RepeatCount > 0;
+    /// <summary>
+    /// Gets or sets whether a repeat section ends on this masterbar. 
+    /// </summary>
+    public bool IsRepeatEnd => RepeatCount > 0;
 
-        /// <summary>
-        /// Gets or sets the number of repeats for the current repeat section. 
-        /// </summary>
-        public int RepeatCount { get; set; }
+    /// <summary>
+    /// Gets or sets the number of repeats for the current repeat section. 
+    /// </summary>
+    public int RepeatCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the repeat group this bar belongs to. 
-        /// </summary>
-        public RepeatGroup RepeatGroup { get; set; }
+    /// <summary>
+    /// Gets or sets the repeat group this bar belongs to. 
+    /// </summary>
+    public RepeatGroup RepeatGroup { get; set; }
 
-        /// <summary>
-        /// Gets or sets the time signature numerator.
-        /// </summary>
-        public int TimeSignatureNumerator { get; set; }
+    /// <summary>
+    /// Gets or sets the time signature numerator.
+    /// </summary>
+    public int TimeSignatureNumerator { get; set; }
 
-        /// <summary>
-        /// Gets or sets the time signature denominiator. 
-        /// </summary>
-        public int TimeSignatureDenominator { get; set; }
+    /// <summary>
+    /// Gets or sets the time signature denominiator. 
+    /// </summary>
+    public int TimeSignatureDenominator { get; set; }
 
-        /// <summary>
-        /// Gets or sets whether this is bar has a common time signature. 
-        /// </summary>
-        public bool TimeSignatureCommon { get; set; }
+    /// <summary>
+    /// Gets or sets whether this is bar has a common time signature. 
+    /// </summary>
+    public bool TimeSignatureCommon { get; set; }
 
-        /// <summary>
-        /// Gets or sets the triplet feel that is valid for this bar. 
-        /// </summary>
-        public TripletFeel TripletFeel { get; set; }
+    /// <summary>
+    /// Gets or sets the triplet feel that is valid for this bar. 
+    /// </summary>
+    public TripletFeel TripletFeel { get; set; }
 
-        /// <summary>
-        /// Gets or sets the new section information for this bar. 
-        /// </summary>
-        public Section Section { get; set; }
+    /// <summary>
+    /// Gets or sets the new section information for this bar. 
+    /// </summary>
+    public Section Section { get; set; }
 
-        /// <summary>
-        /// Gets a value indicating whether a new section starts on this bar. 
-        /// </summary>
-        public bool IsSectionStart => Section != null;
+    /// <summary>
+    /// Gets a value indicating whether a new section starts on this bar. 
+    /// </summary>
+    public bool IsSectionStart => Section != null;
 
  
 
-        /// <summary>
-        /// Gets or sets the reference to the score this song belongs to. 
-        /// </summary>
-        public Score Score { get; set; }
+    /// <summary>
+    /// Gets or sets the reference to the score this song belongs to. 
+    /// </summary>
+    public Score Score { get; set; }
 
-        /// <summary>
-        /// Gets or sets the fermatas for this bar. The key is the offset of the fermata in midi ticks. 
-        /// </summary>
-        public FastDictionary<int, Fermata> Fermata { get; set; }
+    /// <summary>
+    /// Gets or sets the fermatas for this bar. The key is the offset of the fermata in midi ticks. 
+    /// </summary>
+    public FastDictionary<int, Fermata> Fermata { get; set; }
 
-        /// <summary>
-        /// The timeline position of the voice within the whole score. (unit: midi ticks)
-        /// </summary>
-        public int Start { get; set; }
+    /// <summary>
+    /// The timeline position of the voice within the whole score. (unit: midi ticks)
+    /// </summary>
+    public int Start { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether the master bar is an anacrusis (aka. pickup bar)
-        /// </summary>
-        public bool IsAnacrusis { get; set; }
+    /// <summary>
+    /// Gets or sets a value indicating whether the master bar is an anacrusis (aka. pickup bar)
+    /// </summary>
+    public bool IsAnacrusis { get; set; }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MasterBar"/> class.
-        /// </summary>
-        public MasterBar()
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MasterBar"/> class.
+    /// </summary>
+    public MasterBar()
+    {
+        TimeSignatureDenominator = 4;
+        TimeSignatureNumerator   = 4;
+        TripletFeel              = TripletFeel.NoTripletFeel;
+        KeySignatureType         = KeySignatureType.Major;
+        TimeSignatureCommon      = false;
+        Fermata                  = new FastDictionary<int, Fermata>();
+    }
+
+    internal static void CopyTo(MasterBar src, MasterBar dst)
+    {
+        dst.IsAnacrusis              = src.IsAnacrusis;
+        dst.AlternateEndings         = src.AlternateEndings;
+        dst.Index                    = src.Index;
+        dst.KeySignature             = src.KeySignature;
+        dst.KeySignatureType         = src.KeySignatureType;
+        dst.IsDoubleBar              = src.IsDoubleBar;
+        dst.IsRepeatStart            = src.IsRepeatStart;
+        dst.RepeatCount              = src.RepeatCount;
+        dst.TimeSignatureNumerator   = src.TimeSignatureNumerator;
+        dst.TimeSignatureDenominator = src.TimeSignatureDenominator;
+        dst.TimeSignatureCommon      = src.TimeSignatureCommon;
+        dst.TripletFeel              = src.TripletFeel;
+        dst.Start                    = src.Start;
+    }
+
+    /// <summary>
+    /// Calculates the time spent in this bar. (unit: midi ticks)
+    /// </summary>
+    /// <returns></returns>
+    public int CalculateDuration()
+    {
+        if (IsAnacrusis)
         {
-            TimeSignatureDenominator = 4;
-            TimeSignatureNumerator = 4;
-            TripletFeel = TripletFeel.NoTripletFeel;
-            KeySignatureType = KeySignatureType.Major;
-            TimeSignatureCommon = false;
-            Fermata = new FastDictionary<int, Fermata>();
+            return Score.Tracks.Aggregate(0, (current, track) => track.Staves.Select(staff => staff.Bars[0].CalculateDuration()).Prepend(current).Max());
         }
 
-        internal static void CopyTo(MasterBar src, MasterBar dst)
-        {
-            dst.IsAnacrusis = src.IsAnacrusis;
-            dst.AlternateEndings = src.AlternateEndings;
-            dst.Index = src.Index;
-            dst.KeySignature = src.KeySignature;
-            dst.KeySignatureType = src.KeySignatureType;
-            dst.IsDoubleBar = src.IsDoubleBar;
-            dst.IsRepeatStart = src.IsRepeatStart;
-            dst.RepeatCount = src.RepeatCount;
-            dst.TimeSignatureNumerator = src.TimeSignatureNumerator;
-            dst.TimeSignatureDenominator = src.TimeSignatureDenominator;
-            dst.TimeSignatureCommon = src.TimeSignatureCommon;
-            dst.TripletFeel = src.TripletFeel;
-            dst.Start = src.Start;
-        }
+        return TimeSignatureNumerator * MidiUtils.ValueToTicks(TimeSignatureDenominator);
+    }
 
-        /// <summary>
-        /// Calculates the time spent in this bar. (unit: midi ticks)
-        /// </summary>
-        /// <returns></returns>
-        public int CalculateDuration()
-        {
-            if (IsAnacrusis)
-            {
-                return Score.Tracks.Aggregate(0, (current, track) => track.Staves.Select(staff => staff.Bars[0].CalculateDuration()).Prepend(current).Max());
-            }
+    /// <summary>
+    /// Adds a fermata to the masterbar. 
+    /// </summary>
+    /// <param name="offset">The offset of the fermata within the bar in midi ticks. </param>
+    /// <param name="fermata">The fermata.</param>
+    internal void AddFermata(int offset, Fermata fermata)
+    {
+        Fermata[offset] = fermata;
+    }
 
-            return TimeSignatureNumerator * MidiUtils.ValueToTicks(TimeSignatureDenominator);
-        }
-
-        /// <summary>
-        /// Adds a fermata to the masterbar. 
-        /// </summary>
-        /// <param name="offset">The offset of the fermata within the bar in midi ticks. </param>
-        /// <param name="fermata">The fermata.</param>
-        internal void AddFermata(int offset, Fermata fermata)
-        {
-            Fermata[offset] = fermata;
-        }
-
-        /// <summary>
-        /// Gets the fermata for a given beat. 
-        /// </summary>
-        /// <param name="beat">The beat to get the fermata for.</param>
-        /// <returns></returns>
-        internal Fermata GetFermata(Beat beat)
-        {
-            return Fermata.ContainsKey(beat.PlaybackStart) ? Fermata[beat.PlaybackStart] : null;
-        }
+    /// <summary>
+    /// Gets the fermata for a given beat. 
+    /// </summary>
+    /// <param name="beat">The beat to get the fermata for.</param>
+    /// <returns></returns>
+    internal Fermata GetFermata(Beat beat)
+    {
+        return Fermata.ContainsKey(beat.PlaybackStart) ? Fermata[beat.PlaybackStart] : null;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/MasterBar.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/MasterBar.cs
@@ -3,6 +3,7 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
+using System.Linq;
 using BardMusicPlayer.Siren.AlphaTab.Audio;
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 
@@ -165,20 +166,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
         {
             if (IsAnacrusis)
             {
-                var duration = 0;
-                foreach (var track in Score.Tracks)
-                {
-                    foreach (var staff in track.Staves)
-                    {
-                        var barDuration = staff.Bars[0].CalculateDuration();
-                        if (barDuration > duration)
-                        {
-                            duration = barDuration;
-                        }
-                    }
-                }
-
-                return duration;
+                return Score.Tracks.Aggregate(0, (current, track) => track.Staves.Select(staff => staff.Bars[0].CalculateDuration()).Prepend(current).Max());
             }
 
             return TimeSignatureNumerator * MidiUtils.ValueToTicks(TimeSignatureDenominator);
@@ -201,12 +189,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
         /// <returns></returns>
         internal Fermata GetFermata(Beat beat)
         {
-            if (Fermata.ContainsKey(beat.PlaybackStart))
-            {
-                return Fermata[beat.PlaybackStart];
-            }
-
-            return null;
+            return Fermata.ContainsKey(beat.PlaybackStart) ? Fermata[beat.PlaybackStart] : null;
         }
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Note.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Note.cs
@@ -6,967 +6,966 @@
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 using BardMusicPlayer.Siren.AlphaTab.Util;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// A note is a single played sound on a fretted instrument.
+/// It consists of a fret offset and a string on which the note is played on.
+/// It also can be modified by a lot of different effects.
+/// </summary>
+internal class Note
 {
     /// <summary>
-    /// A note is a single played sound on a fretted instrument.
-    /// It consists of a fret offset and a string on which the note is played on.
-    /// It also can be modified by a lot of different effects.
+    /// This is a global counter for all notes. We use it
+    /// at several locations for lookup tables.
     /// </summary>
-    internal class Note
+    internal static int GlobalNoteId;
+
+    /// <summary>
+    /// Gets or sets the unique id of this note.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the zero-based index of this note within the beat.
+    /// </summary>
+    public int Index { get; set; }
+
+
+    /// <summary>
+    /// Gets or sets the bend type for this note.
+    /// </summary>
+    public BendType BendType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the bend style for this note.
+    /// </summary>
+    public BendStyle BendStyle { get; set; }
+
+    /// <summary>
+    /// Gets or sets the note from which this note continues the bend.
+    /// </summary>
+    public Note BendOrigin { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this note continues a bend from a previous note.
+    /// </summary>
+    public bool IsContinuedBend { get; set; }
+
+    /// <summary>
+    /// Gets or sets a list of the points defining the bend behavior.
+    /// </summary>
+    public FastList<BendPoint> BendPoints { get; set; }
+
+    /// <summary>
+    /// Gets or sets the bend point with the highest bend value.
+    /// </summary>
+    public BendPoint MaxBendPoint { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this note is bended.
+    /// </summary>
+    public bool HasBend => BendType != BendType.None;
+
+    #region Stringed Instruments
+
+    /// <summary>
+    /// Gets a value indicating whether this note is defined via a string on the instrument. .
+    /// </summary>
+    public bool IsStringed => String >= 0;
+
+    /// <summary>
+    /// Gets or sets the fret on which this note is played on the instrument.
+    /// </summary>
+    public int Fret { get; set; }
+
+    /// <summary>
+    /// Gets or sets the string number where the note is placed.
+    /// 1 is the lowest string on the guitar and the bottom line on the tablature.
+    /// It then increases the the number of strings on available on the track.
+    /// </summary>
+    public int String { get; set; }
+
+    #endregion
+
+    #region Piano Instruments
+
+    /// <summary>
+    /// Gets a value indicating whether the value of this note is defined via octave and tone.
+    /// </summary>
+    public bool IsPiano => !IsStringed && Octave >= 0 && Tone >= 0;
+
+    /// <summary>
+    /// Gets or sets the octave on which this note is played.
+    /// </summary>
+    public int Octave { get; set; }
+
+    /// <summary>
+    /// Gets or sets the tone of this note within the octave.
+    /// </summary>
+    public int Tone { get; set; }
+
+    #endregion
+
+    #region Percussion
+
+    /// <summary>
+    /// Gets a value indicating whether this note is a percussion note.
+    /// </summary>
+    public bool IsPercussion => !IsStringed && Element >= 0 && Variation >= 0;
+
+    /// <summary>
+    /// Gets or sets the percusson element.
+    /// </summary>
+    public int Element { get; set; }
+
+    /// <summary>
+    /// Gets or sets the variation of this note.
+    /// </summary>
+    public int Variation { get; set; }
+
+    #endregion
+
+    /// <summary>
+    /// Gets or sets whether this note is visible on the music sheet.
+    /// </summary>
+    public bool IsVisible { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this note starts a hammeron or pulloff.
+    /// </summary>
+    public bool IsHammerPullOrigin { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this note ends a hammeron or pulloff.
+    /// </summary>
+    public bool IsHammerPullDestination => HammerPullOrigin != null;
+
+    /// <summary>
+    /// Gets the origin of the hammeron/pulloff of this note.
+    /// </summary>
+    public Note HammerPullOrigin { get; set; }
+
+    /// <summary>
+    /// Gets the destination for the hammeron/pullof started by this note.
+    /// </summary>
+    public Note HammerPullDestination { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this note starts a slur.
+    /// </summary>
+    public bool IsSlurOrigin => SlurDestination != null;
+
+    /// <summary>
+    /// Gets or sets whether this note finishes a slur.
+    /// </summary>
+    public bool IsSlurDestination { get; set; }
+
+    /// <summary>
+    /// Gets or sets the note where the slur of this note starts.
+    /// </summary>
+    public Note SlurOrigin { get; set; }
+
+    /// <summary>
+    /// Gets or sets the note where the slur of this note ends.
+    /// </summary>
+    public Note SlurDestination { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this note has an harmonic effect.
+    /// </summary>
+    public bool IsHarmonic => HarmonicType != HarmonicType.None;
+
+    /// <summary>
+    /// Gets or sets the harmonic type applied to this note.
+    /// </summary>
+    public HarmonicType HarmonicType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value defining the harmonic pitch.
+    /// </summary>
+    public float HarmonicValue { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the note is a ghost note and shown in parenthesis. Also this will make the note a bit more silent.
+    /// </summary>
+    public bool IsGhost { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this note has a let-ring effect.
+    /// </summary>
+    public bool IsLetRing { get; set; }
+
+    /// <summary>
+    /// Gets or sets the destination note for the let-ring effect.
+    /// </summary>
+    public Note LetRingDestination { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this note has a palm-mute effect.
+    /// </summary>
+    public bool IsPalmMute { get; set; }
+
+    /// <summary>
+    /// Gets or sets the destination note for the palm-mute effect.
+    /// </summary>
+    public Note PalmMuteDestination { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the note is shown and played as dead note.
+    /// </summary>
+    public bool IsDead { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the note is played as staccato.
+    /// </summary>
+    public bool IsStaccato { get; set; }
+
+    /// <summary>
+    /// Gets or sets the slide-in type this note is played with.
+    /// </summary>
+    public SlideInType SlideInType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the slide-out type this note is played with.
+    /// </summary>
+    public SlideOutType SlideOutType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the target note for several slide types.
+    /// </summary>
+    public Note SlideTarget { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether a vibrato is played on the note.
+    /// </summary>
+    public VibratoType Vibrato { get; set; }
+
+    /// <summary>
+    /// Gets or sets the origin of the tied if this note is tied.
+    /// </summary>
+    public Note TieOrigin { get; set; }
+
+    /// <summary>
+    /// Gets or sets the desination of the tie.
+    /// </summary>
+    public Note TieDestination { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this note is ends a tied note.
+    /// </summary>
+    public bool IsTieDestination { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this note starts or continues a tied note.
+    /// </summary>
+    public bool IsTieOrigin => TieDestination != null;
+
+    /// <summary>
+    /// Gets or sets the fingers used for this note on the left hand.
+    /// </summary>
+    public Fingers LeftHandFinger { get; set; }
+
+    /// <summary>
+    /// Gets or sets the fingers used for this note on the right hand.
+    /// </summary>
+    public Fingers RightHandFinger { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether this note has fingering defined.
+    /// </summary>
+    public bool IsFingering { get; set; }
+
+    /// <summary>
+    /// Gets or sets the target note value for the trill effect.
+    /// </summary>
+    public int TrillValue { get; set; }
+
+    /// <summary>
+    /// Gets the fret for the trill.
+    /// </summary>
+    public int TrillFret => TrillValue - StringTuning;
+
+    /// <summary>
+    /// Gets a value indicating whether this note has a trill effect.
+    /// </summary>
+    public bool IsTrill => TrillValue >= 0;
+
+    /// <summary>
+    /// Gets or sets the speed of the trill effect.
+    /// </summary>
+    public Duration TrillSpeed { get; set; }
+
+    /// <summary>
+    /// Gets or sets the percentual duration of the note relative to the overall beat duration .
+    /// </summary>
+    public double DurationPercent { get; set; }
+
+    /// <summary>
+    /// Gets or sets how accidentals for this note should be handled.
+    /// </summary>
+    public NoteAccidentalMode AccidentalMode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the reference to the parent beat to which this note belongs to.
+    /// </summary>
+    public Beat Beat { get; set; }
+
+    /// <summary>
+    /// Gets or sets the dynamics for this note.
+    /// </summary>
+    public DynamicValue Dynamics { get; set; }
+
+    internal bool IsEffectSlurOrigin { get; set; }
+    internal bool HasEffectSlur { get; set; }
+    internal bool IsEffectSlurDestination => EffectSlurOrigin != null;
+    internal Note EffectSlurOrigin { get; set; }
+    internal Note EffectSlurDestination { get; set; }
+
+
+    /// <summary>
+    /// Gets the base note value for the string of this note.
+    /// </summary>
+    public int StringTuning => Beat.Voice.Bar.Staff.Capo + GetStringTuning(Beat.Voice.Bar.Staff, String);
+
+    internal static int GetStringTuning(Staff staff, int noteString)
     {
-        /// <summary>
-        /// This is a global counter for all notes. We use it
-        /// at several locations for lookup tables.
-        /// </summary>
-        internal static int GlobalNoteId;
-
-        /// <summary>
-        /// Gets or sets the unique id of this note.
-        /// </summary>
-        public int Id { get; set; }
-
-        /// <summary>
-        /// Gets or sets the zero-based index of this note within the beat.
-        /// </summary>
-        public int Index { get; set; }
-
-
-        /// <summary>
-        /// Gets or sets the bend type for this note.
-        /// </summary>
-        public BendType BendType { get; set; }
-
-        /// <summary>
-        /// Gets or sets the bend style for this note.
-        /// </summary>
-        public BendStyle BendStyle { get; set; }
-
-        /// <summary>
-        /// Gets or sets the note from which this note continues the bend.
-        /// </summary>
-        public Note BendOrigin { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether this note continues a bend from a previous note.
-        /// </summary>
-        public bool IsContinuedBend { get; set; }
-
-        /// <summary>
-        /// Gets or sets a list of the points defining the bend behavior.
-        /// </summary>
-        public FastList<BendPoint> BendPoints { get; set; }
-
-        /// <summary>
-        /// Gets or sets the bend point with the highest bend value.
-        /// </summary>
-        public BendPoint MaxBendPoint { get; set; }
-
-        /// <summary>
-        /// Gets a value indicating whether this note is bended.
-        /// </summary>
-        public bool HasBend => BendType != BendType.None;
-
-        #region Stringed Instruments
-
-        /// <summary>
-        /// Gets a value indicating whether this note is defined via a string on the instrument. .
-        /// </summary>
-        public bool IsStringed => String >= 0;
-
-        /// <summary>
-        /// Gets or sets the fret on which this note is played on the instrument.
-        /// </summary>
-        public int Fret { get; set; }
-
-        /// <summary>
-        /// Gets or sets the string number where the note is placed.
-        /// 1 is the lowest string on the guitar and the bottom line on the tablature.
-        /// It then increases the the number of strings on available on the track.
-        /// </summary>
-        public int String { get; set; }
-
-        #endregion
-
-        #region Piano Instruments
-
-        /// <summary>
-        /// Gets a value indicating whether the value of this note is defined via octave and tone.
-        /// </summary>
-        public bool IsPiano => !IsStringed && Octave >= 0 && Tone >= 0;
-
-        /// <summary>
-        /// Gets or sets the octave on which this note is played.
-        /// </summary>
-        public int Octave { get; set; }
-
-        /// <summary>
-        /// Gets or sets the tone of this note within the octave.
-        /// </summary>
-        public int Tone { get; set; }
-
-        #endregion
-
-        #region Percussion
-
-        /// <summary>
-        /// Gets a value indicating whether this note is a percussion note.
-        /// </summary>
-        public bool IsPercussion => !IsStringed && Element >= 0 && Variation >= 0;
-
-        /// <summary>
-        /// Gets or sets the percusson element.
-        /// </summary>
-        public int Element { get; set; }
-
-        /// <summary>
-        /// Gets or sets the variation of this note.
-        /// </summary>
-        public int Variation { get; set; }
-
-        #endregion
-
-        /// <summary>
-        /// Gets or sets whether this note is visible on the music sheet.
-        /// </summary>
-        public bool IsVisible { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether this note starts a hammeron or pulloff.
-        /// </summary>
-        public bool IsHammerPullOrigin { get; set; }
-
-        /// <summary>
-        /// Gets a value indicating whether this note ends a hammeron or pulloff.
-        /// </summary>
-        public bool IsHammerPullDestination => HammerPullOrigin != null;
-
-        /// <summary>
-        /// Gets the origin of the hammeron/pulloff of this note.
-        /// </summary>
-        public Note HammerPullOrigin { get; set; }
-
-        /// <summary>
-        /// Gets the destination for the hammeron/pullof started by this note.
-        /// </summary>
-        public Note HammerPullDestination { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether this note starts a slur.
-        /// </summary>
-        public bool IsSlurOrigin => SlurDestination != null;
-
-        /// <summary>
-        /// Gets or sets whether this note finishes a slur.
-        /// </summary>
-        public bool IsSlurDestination { get; set; }
-
-        /// <summary>
-        /// Gets or sets the note where the slur of this note starts.
-        /// </summary>
-        public Note SlurOrigin { get; set; }
-
-        /// <summary>
-        /// Gets or sets the note where the slur of this note ends.
-        /// </summary>
-        public Note SlurDestination { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether this note has an harmonic effect.
-        /// </summary>
-        public bool IsHarmonic => HarmonicType != HarmonicType.None;
-
-        /// <summary>
-        /// Gets or sets the harmonic type applied to this note.
-        /// </summary>
-        public HarmonicType HarmonicType { get; set; }
-
-        /// <summary>
-        /// Gets or sets the value defining the harmonic pitch.
-        /// </summary>
-        public float HarmonicValue { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether the note is a ghost note and shown in parenthesis. Also this will make the note a bit more silent.
-        /// </summary>
-        public bool IsGhost { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether this note has a let-ring effect.
-        /// </summary>
-        public bool IsLetRing { get; set; }
-
-        /// <summary>
-        /// Gets or sets the destination note for the let-ring effect.
-        /// </summary>
-        public Note LetRingDestination { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether this note has a palm-mute effect.
-        /// </summary>
-        public bool IsPalmMute { get; set; }
-
-        /// <summary>
-        /// Gets or sets the destination note for the palm-mute effect.
-        /// </summary>
-        public Note PalmMuteDestination { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether the note is shown and played as dead note.
-        /// </summary>
-        public bool IsDead { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether the note is played as staccato.
-        /// </summary>
-        public bool IsStaccato { get; set; }
-
-        /// <summary>
-        /// Gets or sets the slide-in type this note is played with.
-        /// </summary>
-        public SlideInType SlideInType { get; set; }
-
-        /// <summary>
-        /// Gets or sets the slide-out type this note is played with.
-        /// </summary>
-        public SlideOutType SlideOutType { get; set; }
-
-        /// <summary>
-        /// Gets or sets the target note for several slide types.
-        /// </summary>
-        public Note SlideTarget { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether a vibrato is played on the note.
-        /// </summary>
-        public VibratoType Vibrato { get; set; }
-
-        /// <summary>
-        /// Gets or sets the origin of the tied if this note is tied.
-        /// </summary>
-        public Note TieOrigin { get; set; }
-
-        /// <summary>
-        /// Gets or sets the desination of the tie.
-        /// </summary>
-        public Note TieDestination { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether this note is ends a tied note.
-        /// </summary>
-        public bool IsTieDestination { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether this note starts or continues a tied note.
-        /// </summary>
-        public bool IsTieOrigin => TieDestination != null;
-
-        /// <summary>
-        /// Gets or sets the fingers used for this note on the left hand.
-        /// </summary>
-        public Fingers LeftHandFinger { get; set; }
-
-        /// <summary>
-        /// Gets or sets the fingers used for this note on the right hand.
-        /// </summary>
-        public Fingers RightHandFinger { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether this note has fingering defined.
-        /// </summary>
-        public bool IsFingering { get; set; }
-
-        /// <summary>
-        /// Gets or sets the target note value for the trill effect.
-        /// </summary>
-        public int TrillValue { get; set; }
-
-        /// <summary>
-        /// Gets the fret for the trill.
-        /// </summary>
-        public int TrillFret => TrillValue - StringTuning;
-
-        /// <summary>
-        /// Gets a value indicating whether this note has a trill effect.
-        /// </summary>
-        public bool IsTrill => TrillValue >= 0;
-
-        /// <summary>
-        /// Gets or sets the speed of the trill effect.
-        /// </summary>
-        public Duration TrillSpeed { get; set; }
-
-        /// <summary>
-        /// Gets or sets the percentual duration of the note relative to the overall beat duration .
-        /// </summary>
-        public double DurationPercent { get; set; }
-
-        /// <summary>
-        /// Gets or sets how accidentals for this note should be handled.
-        /// </summary>
-        public NoteAccidentalMode AccidentalMode { get; set; }
-
-        /// <summary>
-        /// Gets or sets the reference to the parent beat to which this note belongs to.
-        /// </summary>
-        public Beat Beat { get; set; }
-
-        /// <summary>
-        /// Gets or sets the dynamics for this note.
-        /// </summary>
-        public DynamicValue Dynamics { get; set; }
-
-        internal bool IsEffectSlurOrigin { get; set; }
-        internal bool HasEffectSlur { get; set; }
-        internal bool IsEffectSlurDestination => EffectSlurOrigin != null;
-        internal Note EffectSlurOrigin { get; set; }
-        internal Note EffectSlurDestination { get; set; }
-
-
-        /// <summary>
-        /// Gets the base note value for the string of this note.
-        /// </summary>
-        public int StringTuning => Beat.Voice.Bar.Staff.Capo + GetStringTuning(Beat.Voice.Bar.Staff, String);
-
-        internal static int GetStringTuning(Staff staff, int noteString)
+        return staff.Tuning.Length > 0 ? staff.Tuning[staff.Tuning.Length - (noteString - 1) - 1] : 0;
+    }
+
+    /// <summary>
+    /// Gets the absolute value of this note for playback.
+    /// </summary>
+    public int RealValue
+    {
+        get
         {
-            return staff.Tuning.Length > 0 ? staff.Tuning[staff.Tuning.Length - (noteString - 1) - 1] : 0;
-        }
 
-        /// <summary>
-        /// Gets the absolute value of this note for playback.
-        /// </summary>
-        public int RealValue
-        {
-            get
+            if (IsStringed)
             {
-
-                if (IsStringed)
+                if (HarmonicType == HarmonicType.Natural)
                 {
-                    if (HarmonicType == HarmonicType.Natural)
-                    {
-                        return HarmonicPitch + StringTuning - Beat.Voice.Bar.Staff.TranspositionPitch;
-                    }
-
-                    return Fret + StringTuning - Beat.Voice.Bar.Staff.TranspositionPitch + HarmonicPitch;
+                    return HarmonicPitch + StringTuning - Beat.Voice.Bar.Staff.TranspositionPitch;
                 }
 
-                if (IsPiano)
-                {
-                    return Octave * 12 + Tone - Beat.Voice.Bar.Staff.TranspositionPitch;
-                }
+                return Fret + StringTuning - Beat.Voice.Bar.Staff.TranspositionPitch + HarmonicPitch;
+            }
 
+            if (IsPiano)
+            {
+                return Octave * 12 + Tone - Beat.Voice.Bar.Staff.TranspositionPitch;
+            }
+
+            return 0;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the harmonic pitch value for this note.
+    /// </summary>
+    public int HarmonicPitch
+    {
+        get
+        {
+            if (HarmonicType == HarmonicType.None || !IsStringed)
+            {
                 return 0;
             }
-        }
 
-        /// <summary>
-        /// Gets or sets the harmonic pitch value for this note.
-        /// </summary>
-        public int HarmonicPitch
-        {
-            get
+            var value = HarmonicValue;
+
+            // add semitones to reach corresponding harmonic frets
+            if (value.IsAlmostEqualTo(2.4f))
             {
-                if (HarmonicType == HarmonicType.None || !IsStringed)
-                {
-                    return 0;
-                }
+                return 36;
+            }
 
-                var value = HarmonicValue;
+            if (value.IsAlmostEqualTo(2.7f))
+            {
+                // Fret 3 2nd octave + minor seventh
+                return 34;
+            }
 
-                // add semitones to reach corresponding harmonic frets
-                if (value.IsAlmostEqualTo(2.4f))
-                {
-                    return 36;
-                }
+            if (value < 3)
+            {
+                // no natural harmonics below fret 3
+                return 0;
+            }
 
-                if (value.IsAlmostEqualTo(2.7f))
-                {
-                    // Fret 3 2nd octave + minor seventh
+            if (value <= 3.5 /*3.2*/)
+            {
+                // Fret 3 2nd octave + fifth
+                return 31;
+            }
+
+            switch (value)
+            {
+                case <= 4:
+                    return 28;
+                case <= 5:
+                    return 24;
+                /* 5.8 */
+                case <= 6:
                     return 34;
-                }
-
-                if (value < 3)
-                {
-                    // no natural harmonics below fret 3
-                    return 0;
-                }
-
-                if (value <= 3.5 /*3.2*/)
-                {
-                    // Fret 3 2nd octave + fifth
-                    return 31;
-                }
-
-                switch (value)
-                {
-                    case <= 4:
-                        return 28;
-                    case <= 5:
-                        return 24;
-                    /* 5.8 */
-                    case <= 6:
-                        return 34;
-                    case <= 7:
-                        return 19;
-                }
-
-                if (value <= 8.5 /*8.2*/)
-                {
-                    return 36;
-                }
-
-                return value switch
-                {
-                    <= 9 => 28,
-                    /*9.6*/
-                    <= 10 => 34,
-                    <= 11 => 0,
-                    <= 12 => 12,
-                    < 14  => 0,
-                    /*14.7*/
-                    <= 15 => 34,
-                    <= 16 => 28,
-                    <= 17 => 36,
-                    <= 18 => 0,
-                    <= 19 => 19,
-                    <= 21 => 0,
-                    /* 21.7 */
-                    <= 22 => 36,
-                    <= 24 => 24,
-                    _     => 0
-                };
+                case <= 7:
+                    return 19;
             }
+
+            if (value <= 8.5 /*8.2*/)
+            {
+                return 36;
+            }
+
+            return value switch
+            {
+                <= 9 => 28,
+                /*9.6*/
+                <= 10 => 34,
+                <= 11 => 0,
+                <= 12 => 12,
+                < 14  => 0,
+                /*14.7*/
+                <= 15 => 34,
+                <= 16 => 28,
+                <= 17 => 36,
+                <= 18 => 0,
+                <= 19 => 19,
+                <= 21 => 0,
+                /* 21.7 */
+                <= 22 => 36,
+                <= 24 => 24,
+                _     => 0
+            };
         }
+    }
 
-        /// <summary>
-        /// Gets the absolute value of this note considering
-        /// offsets by bends and ottavia
-        /// </summary>
-        public int DisplayValue
+    /// <summary>
+    /// Gets the absolute value of this note considering
+    /// offsets by bends and ottavia
+    /// </summary>
+    public int DisplayValue
+    {
+        get
         {
-            get
+            var noteValue = DisplayValueWithoutBend;
+
+            if (HasBend)
             {
-                var noteValue = DisplayValueWithoutBend;
-
-                if (HasBend)
-                {
-                    noteValue += BendPoints[0].Value / 2;
-                }
-                else if (BendOrigin != null)
-                {
-                    noteValue += BendOrigin.BendPoints[BendOrigin.BendPoints.Count - 1].Value / 2;
-                }
-                else if (IsTieDestination && TieOrigin.BendOrigin != null)
-                {
-                    noteValue += TieOrigin.BendOrigin.BendPoints[TieOrigin.BendOrigin.BendPoints.Count - 1].Value / 2;
-                }
-                else if (Beat.HasWhammyBar)
-                {
-                    noteValue += Beat.WhammyBarPoints[0].Value / 2;
-                }
-                else if (Beat.IsContinuedWhammy)
-                {
-                    noteValue += Beat.PreviousBeat.WhammyBarPoints[Beat.PreviousBeat.WhammyBarPoints.Count - 1].Value /
-                                 2;
-                }
-
-
-                return noteValue;
+                noteValue += BendPoints[0].Value / 2;
             }
+            else if (BendOrigin != null)
+            {
+                noteValue += BendOrigin.BendPoints[BendOrigin.BendPoints.Count - 1].Value / 2;
+            }
+            else if (IsTieDestination && TieOrigin.BendOrigin != null)
+            {
+                noteValue += TieOrigin.BendOrigin.BendPoints[TieOrigin.BendOrigin.BendPoints.Count - 1].Value / 2;
+            }
+            else if (Beat.HasWhammyBar)
+            {
+                noteValue += Beat.WhammyBarPoints[0].Value / 2;
+            }
+            else if (Beat.IsContinuedWhammy)
+            {
+                noteValue += Beat.PreviousBeat.WhammyBarPoints[Beat.PreviousBeat.WhammyBarPoints.Count - 1].Value /
+                             2;
+            }
+
+
+            return noteValue;
         }
+    }
 
-        /// <summary>
-        /// Gets the absolute value of this note considering all effects beside bends.
-        /// </summary>
-        public int DisplayValueWithoutBend
+    /// <summary>
+    /// Gets the absolute value of this note considering all effects beside bends.
+    /// </summary>
+    public int DisplayValueWithoutBend
+    {
+        get
         {
-            get
+            var noteValue = RealValue;
+
+            if (HarmonicType != HarmonicType.Natural && HarmonicType != HarmonicType.None)
             {
-                var noteValue = RealValue;
-
-                if (HarmonicType != HarmonicType.Natural && HarmonicType != HarmonicType.None)
-                {
-                    noteValue -= HarmonicPitch;
-                }
-
-                switch (Beat.Ottava)
-                {
-                    case Ottavia._15ma:
-                        noteValue -= 24;
-                        break;
-                    case Ottavia._8va:
-                        noteValue -= 12;
-                        break;
-                    case Ottavia.Regular:
-                        break;
-                    case Ottavia._8vb:
-                        noteValue += 12;
-                        break;
-                    case Ottavia._15mb:
-                        noteValue += 24;
-                        break;
-                }
-
-                switch (Beat.Voice.Bar.ClefOttava)
-                {
-                    case Ottavia._15ma:
-                        noteValue -= 24;
-                        break;
-                    case Ottavia._8va:
-                        noteValue -= 12;
-                        break;
-                    case Ottavia.Regular:
-                        break;
-                    case Ottavia._8vb:
-                        noteValue += 12;
-                        break;
-                    case Ottavia._15mb:
-                        noteValue += 24;
-                        break;
-                }
-
-                return noteValue - Beat.Voice.Bar.Staff.DisplayTranspositionPitch;
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets whether the note has a offset of a quartertone caused by bends.
-        /// </summary>
-        public bool HasQuarterToneOffset
-        {
-            get
-            {
-                if (HasBend)
-                {
-                    return BendPoints[0].Value % 2 != 0;
-                }
-
-                if (BendOrigin != null)
-                {
-                    return BendOrigin.BendPoints[BendOrigin.BendPoints.Count - 1].Value % 2 != 0;
-                }
-
-                if (Beat.HasWhammyBar)
-                {
-                    return Beat.WhammyBarPoints[0].Value % 2 != 0;
-                }
-
-                if (Beat.IsContinuedWhammy)
-                {
-                    return Beat.PreviousBeat.WhammyBarPoints[Beat.PreviousBeat.WhammyBarPoints.Count - 1].Value % 2 !=
-                           0;
-                }
-
-                return false;
-            }
-        }
-
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Note"/> class.
-        /// </summary>
-        public Note()
-        {
-            Id = GlobalNoteId++;
-            BendType = BendType.None;
-            BendStyle = BendStyle.Default;
-            BendPoints = new FastList<BendPoint>();
-            Dynamics = DynamicValue.F;
-            
-            Fret = int.MinValue;
-            HarmonicType = HarmonicType.None;
-            SlideInType = SlideInType.None;
-            SlideOutType = SlideOutType.None;
-            Vibrato = VibratoType.None;
-
-            LeftHandFinger = Fingers.Unknown;
-            RightHandFinger = Fingers.Unknown;
-
-            TrillValue = -1;
-            TrillSpeed = Duration.ThirtySecond;
-            DurationPercent = 1;
-
-            Octave = -1;
-            Tone = -1;
-
-            Fret = -1;
-            String = -1;
-
-            Element = -1;
-            Variation = -1;
-            IsVisible = true;
-        }
-
-        internal static void CopyTo(Note src, Note dst)
-        {
-            dst.Id = src.Id;
-            dst.Fret = src.Fret;
-            dst.String = src.String;
-            dst.HarmonicValue = src.HarmonicValue;
-            dst.HarmonicType = src.HarmonicType;
-            dst.IsGhost = src.IsGhost;
-            dst.IsLetRing = src.IsLetRing;
-            dst.IsPalmMute = src.IsPalmMute;
-            dst.IsDead = src.IsDead;
-            dst.IsStaccato = src.IsStaccato;
-            dst.SlideInType = src.SlideInType;
-            dst.SlideOutType = src.SlideOutType;
-            dst.Vibrato = src.Vibrato;
-            dst.IsTieDestination = src.IsTieDestination;
-            dst.IsSlurDestination = src.IsSlurDestination;
-            dst.IsHammerPullOrigin = src.IsHammerPullOrigin;
-            dst.LeftHandFinger = src.LeftHandFinger;
-            dst.RightHandFinger = src.RightHandFinger;
-            dst.IsFingering = src.IsFingering;
-            dst.TrillValue = src.TrillValue;
-            dst.TrillSpeed = src.TrillSpeed;
-            dst.DurationPercent = src.DurationPercent;
-            dst.AccidentalMode = src.AccidentalMode;
-            dst.Dynamics = src.Dynamics;
-            dst.Octave = src.Octave;
-            dst.Tone = src.Tone;
-            dst.Element = src.Element;
-            dst.Variation = src.Variation;
-            dst.BendType = src.BendType;
-            dst.BendStyle = src.BendStyle;
-            dst.IsContinuedBend = src.IsContinuedBend;
-            dst.IsVisible = src.IsVisible;
-        }
-
-        internal Note Clone()
-        {
-            var n = new Note();
-            var id = n.Id;
-            CopyTo(this, n);
-            for (int i = 0, j = BendPoints.Count; i < j; i++)
-            {
-                n.AddBendPoint(BendPoints[i].Clone());
+                noteValue -= HarmonicPitch;
             }
 
-            n.Id = id;
-            return n;
-        }
-
-        internal void AddBendPoint(BendPoint point)
-        {
-            BendPoints.Add(point);
-            if (MaxBendPoint == null || point.Value > MaxBendPoint.Value)
+            switch (Beat.Ottava)
             {
-                MaxBendPoint = point;
-            }
-
-            if (BendType == BendType.None)
-            {
-                BendType = BendType.Custom;
-            }
-        }
-
-        internal void Finish()
-        {
-            var nextNoteOnLine = new Lazy<Note>(() => NextNoteOnSameLine(this));
-
-            // // Compiler Warnings: Local variable 'isSongBook' is only assigned but its value is never used
-            // var isSongBook = false;
-
-            // connect ties
-            if (IsTieDestination)
-            {
-                if (TieOrigin != null)
-                {
-                    TieOrigin.TieDestination = this;
-                }
-                else
-                {
-                    var tieOrigin = FindTieOrigin(this);
-                    if (tieOrigin == null)
-                    {
-                        IsTieDestination = false;
-                    }
-                    else
-                    {
-                        TieOrigin = tieOrigin;
-                        TieOrigin.TieDestination = this;
-                        Fret = TieOrigin.Fret;
-                        Octave = TieOrigin.Octave;
-                        Tone = TieOrigin.Tone;
-
-                        if (TieOrigin.HasBend)
-                        {
-                            BendOrigin = TieOrigin;
-                        }
-                    }
-                }
-
-                // // // Code is heuristically unreachable
-                // // implicit let ring
-                // if (isSongBook && TieOrigin.IsLetRing)
-                // {
-                //     IsLetRing = true;
-                // }
-            }
-
-            // connect letring
-            if (IsLetRing)
-            {
-                LetRingDestination = nextNoteOnLine.Value is not { IsLetRing: true } ? this : nextNoteOnLine.Value;
-
-                // // // Code is heuristically unreachable
-                // if (isSongBook && IsTieDestination && !TieOrigin.HasBend)
-                // {
-                //     IsVisible = false;
-                // }
-            }
-
-
-            // connect palmmute
-            if (IsPalmMute)
-            {
-                PalmMuteDestination = nextNoteOnLine.Value is not { IsPalmMute: true } ? this : nextNoteOnLine.Value;
-            }
-
-            // set hammeron/pulloffs
-            if (IsHammerPullOrigin)
-            {
-                if (nextNoteOnLine.Value == null)
-                {
-                    IsHammerPullOrigin = false;
-                }
-                else
-                {
-                    HammerPullDestination = nextNoteOnLine.Value;
-                    HammerPullDestination.HammerPullOrigin = this;
-                }
-            }
-
-            // set slides
-            switch (SlideOutType)
-            {
-                case SlideOutType.Shift:
-                case SlideOutType.Legato:
-                    SlideTarget = nextNoteOnLine.Value;
-                    if (SlideTarget == null)
-                    {
-                        SlideOutType = SlideOutType.None;
-                    }
-
+                case Ottavia._15ma:
+                    noteValue -= 24;
+                    break;
+                case Ottavia._8va:
+                    noteValue -= 12;
+                    break;
+                case Ottavia.Regular:
+                    break;
+                case Ottavia._8vb:
+                    noteValue += 12;
+                    break;
+                case Ottavia._15mb:
+                    noteValue += 24;
                     break;
             }
 
-            Note effectSlurDestination = null;
-            if (IsHammerPullOrigin)
+            switch (Beat.Voice.Bar.ClefOttava)
             {
-                effectSlurDestination = HammerPullDestination;
-            }
-            else if (SlideOutType == SlideOutType.Legato && SlideTarget != null)
-            {
-                effectSlurDestination = SlideTarget;
+                case Ottavia._15ma:
+                    noteValue -= 24;
+                    break;
+                case Ottavia._8va:
+                    noteValue -= 12;
+                    break;
+                case Ottavia.Regular:
+                    break;
+                case Ottavia._8vb:
+                    noteValue += 12;
+                    break;
+                case Ottavia._15mb:
+                    noteValue += 24;
+                    break;
             }
 
-            if (effectSlurDestination != null)
+            return noteValue - Beat.Voice.Bar.Staff.DisplayTranspositionPitch;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets whether the note has a offset of a quartertone caused by bends.
+    /// </summary>
+    public bool HasQuarterToneOffset
+    {
+        get
+        {
+            if (HasBend)
             {
-                HasEffectSlur = true;
-                if (EffectSlurOrigin != null)
+                return BendPoints[0].Value % 2 != 0;
+            }
+
+            if (BendOrigin != null)
+            {
+                return BendOrigin.BendPoints[BendOrigin.BendPoints.Count - 1].Value % 2 != 0;
+            }
+
+            if (Beat.HasWhammyBar)
+            {
+                return Beat.WhammyBarPoints[0].Value % 2 != 0;
+            }
+
+            if (Beat.IsContinuedWhammy)
+            {
+                return Beat.PreviousBeat.WhammyBarPoints[Beat.PreviousBeat.WhammyBarPoints.Count - 1].Value % 2 !=
+                       0;
+            }
+
+            return false;
+        }
+    }
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Note"/> class.
+    /// </summary>
+    public Note()
+    {
+        Id         = GlobalNoteId++;
+        BendType   = BendType.None;
+        BendStyle  = BendStyle.Default;
+        BendPoints = new FastList<BendPoint>();
+        Dynamics   = DynamicValue.F;
+            
+        Fret         = int.MinValue;
+        HarmonicType = HarmonicType.None;
+        SlideInType  = SlideInType.None;
+        SlideOutType = SlideOutType.None;
+        Vibrato      = VibratoType.None;
+
+        LeftHandFinger  = Fingers.Unknown;
+        RightHandFinger = Fingers.Unknown;
+
+        TrillValue      = -1;
+        TrillSpeed      = Duration.ThirtySecond;
+        DurationPercent = 1;
+
+        Octave = -1;
+        Tone   = -1;
+
+        Fret   = -1;
+        String = -1;
+
+        Element   = -1;
+        Variation = -1;
+        IsVisible = true;
+    }
+
+    internal static void CopyTo(Note src, Note dst)
+    {
+        dst.Id                 = src.Id;
+        dst.Fret               = src.Fret;
+        dst.String             = src.String;
+        dst.HarmonicValue      = src.HarmonicValue;
+        dst.HarmonicType       = src.HarmonicType;
+        dst.IsGhost            = src.IsGhost;
+        dst.IsLetRing          = src.IsLetRing;
+        dst.IsPalmMute         = src.IsPalmMute;
+        dst.IsDead             = src.IsDead;
+        dst.IsStaccato         = src.IsStaccato;
+        dst.SlideInType        = src.SlideInType;
+        dst.SlideOutType       = src.SlideOutType;
+        dst.Vibrato            = src.Vibrato;
+        dst.IsTieDestination   = src.IsTieDestination;
+        dst.IsSlurDestination  = src.IsSlurDestination;
+        dst.IsHammerPullOrigin = src.IsHammerPullOrigin;
+        dst.LeftHandFinger     = src.LeftHandFinger;
+        dst.RightHandFinger    = src.RightHandFinger;
+        dst.IsFingering        = src.IsFingering;
+        dst.TrillValue         = src.TrillValue;
+        dst.TrillSpeed         = src.TrillSpeed;
+        dst.DurationPercent    = src.DurationPercent;
+        dst.AccidentalMode     = src.AccidentalMode;
+        dst.Dynamics           = src.Dynamics;
+        dst.Octave             = src.Octave;
+        dst.Tone               = src.Tone;
+        dst.Element            = src.Element;
+        dst.Variation          = src.Variation;
+        dst.BendType           = src.BendType;
+        dst.BendStyle          = src.BendStyle;
+        dst.IsContinuedBend    = src.IsContinuedBend;
+        dst.IsVisible          = src.IsVisible;
+    }
+
+    internal Note Clone()
+    {
+        var n = new Note();
+        var id = n.Id;
+        CopyTo(this, n);
+        for (int i = 0, j = BendPoints.Count; i < j; i++)
+        {
+            n.AddBendPoint(BendPoints[i].Clone());
+        }
+
+        n.Id = id;
+        return n;
+    }
+
+    internal void AddBendPoint(BendPoint point)
+    {
+        BendPoints.Add(point);
+        if (MaxBendPoint == null || point.Value > MaxBendPoint.Value)
+        {
+            MaxBendPoint = point;
+        }
+
+        if (BendType == BendType.None)
+        {
+            BendType = BendType.Custom;
+        }
+    }
+
+    internal void Finish()
+    {
+        var nextNoteOnLine = new Lazy<Note>(() => NextNoteOnSameLine(this));
+
+        // // Compiler Warnings: Local variable 'isSongBook' is only assigned but its value is never used
+        // var isSongBook = false;
+
+        // connect ties
+        if (IsTieDestination)
+        {
+            if (TieOrigin != null)
+            {
+                TieOrigin.TieDestination = this;
+            }
+            else
+            {
+                var tieOrigin = FindTieOrigin(this);
+                if (tieOrigin == null)
                 {
-                    EffectSlurOrigin.EffectSlurDestination = effectSlurDestination;
-                    EffectSlurOrigin.EffectSlurDestination.EffectSlurOrigin = EffectSlurOrigin;
-                    EffectSlurOrigin = null;
+                    IsTieDestination = false;
                 }
                 else
                 {
-                    IsEffectSlurOrigin = true;
-                    EffectSlurDestination = effectSlurDestination;
-                    EffectSlurDestination.EffectSlurOrigin = this;
+                    TieOrigin                = tieOrigin;
+                    TieOrigin.TieDestination = this;
+                    Fret                     = TieOrigin.Fret;
+                    Octave                   = TieOrigin.Octave;
+                    Tone                     = TieOrigin.Tone;
+
+                    if (TieOrigin.HasBend)
+                    {
+                        BendOrigin = TieOrigin;
+                    }
                 }
             }
 
-            switch (BendPoints.Count)
+            // // // Code is heuristically unreachable
+            // // implicit let ring
+            // if (isSongBook && TieOrigin.IsLetRing)
+            // {
+            //     IsLetRing = true;
+            // }
+        }
+
+        // connect letring
+        if (IsLetRing)
+        {
+            LetRingDestination = nextNoteOnLine.Value is not { IsLetRing: true } ? this : nextNoteOnLine.Value;
+
+            // // // Code is heuristically unreachable
+            // if (isSongBook && IsTieDestination && !TieOrigin.HasBend)
+            // {
+            //     IsVisible = false;
+            // }
+        }
+
+
+        // connect palmmute
+        if (IsPalmMute)
+        {
+            PalmMuteDestination = nextNoteOnLine.Value is not { IsPalmMute: true } ? this : nextNoteOnLine.Value;
+        }
+
+        // set hammeron/pulloffs
+        if (IsHammerPullOrigin)
+        {
+            if (nextNoteOnLine.Value == null)
             {
-                // try to detect what kind of bend was used and cleans unneeded points if required
-                // Guitar Pro 6 and above (gpif.xml) uses exactly 4 points to define all bends
-                case > 0 when BendType == BendType.Custom:
+                IsHammerPullOrigin = false;
+            }
+            else
+            {
+                HammerPullDestination                  = nextNoteOnLine.Value;
+                HammerPullDestination.HammerPullOrigin = this;
+            }
+        }
+
+        // set slides
+        switch (SlideOutType)
+        {
+            case SlideOutType.Shift:
+            case SlideOutType.Legato:
+                SlideTarget = nextNoteOnLine.Value;
+                if (SlideTarget == null)
                 {
-                    var isContinuedBend = IsContinuedBend = TieOrigin is { HasBend: true };
-                    switch (BendPoints.Count)
+                    SlideOutType = SlideOutType.None;
+                }
+
+                break;
+        }
+
+        Note effectSlurDestination = null;
+        if (IsHammerPullOrigin)
+        {
+            effectSlurDestination = HammerPullDestination;
+        }
+        else if (SlideOutType == SlideOutType.Legato && SlideTarget != null)
+        {
+            effectSlurDestination = SlideTarget;
+        }
+
+        if (effectSlurDestination != null)
+        {
+            HasEffectSlur = true;
+            if (EffectSlurOrigin != null)
+            {
+                EffectSlurOrigin.EffectSlurDestination                  = effectSlurDestination;
+                EffectSlurOrigin.EffectSlurDestination.EffectSlurOrigin = EffectSlurOrigin;
+                EffectSlurOrigin                                        = null;
+            }
+            else
+            {
+                IsEffectSlurOrigin                     = true;
+                EffectSlurDestination                  = effectSlurDestination;
+                EffectSlurDestination.EffectSlurOrigin = this;
+            }
+        }
+
+        switch (BendPoints.Count)
+        {
+            // try to detect what kind of bend was used and cleans unneeded points if required
+            // Guitar Pro 6 and above (gpif.xml) uses exactly 4 points to define all bends
+            case > 0 when BendType == BendType.Custom:
+            {
+                var isContinuedBend = IsContinuedBend = TieOrigin is { HasBend: true };
+                switch (BendPoints.Count)
+                {
+                    case 4:
                     {
-                        case 4:
+                        var origin = BendPoints[0];
+                        var middle1 = BendPoints[1];
+                        var middle2 = BendPoints[2];
+                        var destination = BendPoints[3];
+
+                        // the middle points are used for holds, anything else is a new feature we do not support yet
+                        if (middle1.Value == middle2.Value)
                         {
-                            var origin = BendPoints[0];
-                            var middle1 = BendPoints[1];
-                            var middle2 = BendPoints[2];
-                            var destination = BendPoints[3];
-
-                            // the middle points are used for holds, anything else is a new feature we do not support yet
-                            if (middle1.Value == middle2.Value)
-                            {
-                                // bend higher?
-                                if (destination.Value > origin.Value)
-                                {
-                                    if (middle1.Value > destination.Value)
-                                    {
-                                        BendType = BendType.BendRelease;
-                                    }
-                                    else if (!isContinuedBend && origin.Value > 0)
-                                    {
-                                        BendType = BendType.PrebendBend;
-                                        BendPoints.RemoveAt(2);
-                                        BendPoints.RemoveAt(1);
-                                    }
-                                    else
-                                    {
-                                        BendType = BendType.Bend;
-                                        BendPoints.RemoveAt(2);
-                                        BendPoints.RemoveAt(1);
-                                    }
-                                }
-                                // release?
-                                else if (destination.Value < origin.Value)
-                                {
-                                    // origin must be > 0 otherwise it's no release, we cannot bend negative
-                                    if (isContinuedBend)
-                                    {
-                                        BendType = BendType.Release;
-                                        BendPoints.RemoveAt(2);
-                                        BendPoints.RemoveAt(1);
-                                    }
-                                    else
-                                    {
-                                        BendType = BendType.PrebendRelease;
-                                        BendPoints.RemoveAt(2);
-                                        BendPoints.RemoveAt(1);
-                                    }
-                                }
-                                // hold?
-                                else
-                                {
-                                    if (middle1.Value > origin.Value)
-                                    {
-                                        BendType = BendType.BendRelease;
-                                    }
-                                    else if (origin.Value > 0 && !isContinuedBend)
-                                    {
-                                        BendType = BendType.Prebend;
-                                        BendPoints.RemoveAt(2);
-                                        BendPoints.RemoveAt(1);
-                                    }
-                                    else
-                                    {
-                                        BendType = BendType.Hold;
-                                        BendPoints.RemoveAt(2);
-                                        BendPoints.RemoveAt(1);
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                Logger.Warning("Model", "Unsupported bend type detected, fallback to custom");
-                            }
-
-                            break;
-                        }
-                        case 2:
-                        {
-                            var origin = BendPoints[0];
-                            var destination = BendPoints[1];
-
                             // bend higher?
                             if (destination.Value > origin.Value)
                             {
-                                if (!isContinuedBend && origin.Value > 0)
+                                if (middle1.Value > destination.Value)
+                                {
+                                    BendType = BendType.BendRelease;
+                                }
+                                else if (!isContinuedBend && origin.Value > 0)
                                 {
                                     BendType = BendType.PrebendBend;
+                                    BendPoints.RemoveAt(2);
+                                    BendPoints.RemoveAt(1);
                                 }
                                 else
                                 {
                                     BendType = BendType.Bend;
+                                    BendPoints.RemoveAt(2);
+                                    BendPoints.RemoveAt(1);
                                 }
                             }
                             // release?
                             else if (destination.Value < origin.Value)
                             {
                                 // origin must be > 0 otherwise it's no release, we cannot bend negative
-                                BendType = isContinuedBend ? BendType.Release : BendType.PrebendRelease;
+                                if (isContinuedBend)
+                                {
+                                    BendType = BendType.Release;
+                                    BendPoints.RemoveAt(2);
+                                    BendPoints.RemoveAt(1);
+                                }
+                                else
+                                {
+                                    BendType = BendType.PrebendRelease;
+                                    BendPoints.RemoveAt(2);
+                                    BendPoints.RemoveAt(1);
+                                }
                             }
                             // hold?
                             else
                             {
-                                BendType = BendType.Hold;
+                                if (middle1.Value > origin.Value)
+                                {
+                                    BendType = BendType.BendRelease;
+                                }
+                                else if (origin.Value > 0 && !isContinuedBend)
+                                {
+                                    BendType = BendType.Prebend;
+                                    BendPoints.RemoveAt(2);
+                                    BendPoints.RemoveAt(1);
+                                }
+                                else
+                                {
+                                    BendType = BendType.Hold;
+                                    BendPoints.RemoveAt(2);
+                                    BendPoints.RemoveAt(1);
+                                }
                             }
-
-                            break;
                         }
-                    }
+                        else
+                        {
+                            Logger.Warning("Model", "Unsupported bend type detected, fallback to custom");
+                        }
 
-                    break;
+                        break;
+                    }
+                    case 2:
+                    {
+                        var origin = BendPoints[0];
+                        var destination = BendPoints[1];
+
+                        // bend higher?
+                        if (destination.Value > origin.Value)
+                        {
+                            if (!isContinuedBend && origin.Value > 0)
+                            {
+                                BendType = BendType.PrebendBend;
+                            }
+                            else
+                            {
+                                BendType = BendType.Bend;
+                            }
+                        }
+                        // release?
+                        else if (destination.Value < origin.Value)
+                        {
+                            // origin must be > 0 otherwise it's no release, we cannot bend negative
+                            BendType = isContinuedBend ? BendType.Release : BendType.PrebendRelease;
+                        }
+                        // hold?
+                        else
+                        {
+                            BendType = BendType.Hold;
+                        }
+
+                        break;
+                    }
                 }
-                case 0:
-                    BendType = BendType.None;
-                    break;
+
+                break;
             }
+            case 0:
+                BendType = BendType.None;
+                break;
+        }
+    }
+
+    private const int MaxOffsetForSameLineSearch = 3;
+
+    internal static Note NextNoteOnSameLine(Note note)
+    {
+        var nextBeat = note.Beat.NextBeat;
+        // keep searching in same bar
+        while (nextBeat != null &&
+               nextBeat.Voice.Bar.Index <= note.Beat.Voice.Bar.Index + MaxOffsetForSameLineSearch)
+        {
+            var noteOnString = nextBeat.GetNoteOnString(note.String);
+            if (noteOnString != null)
+            {
+                return noteOnString;
+            }
+
+            nextBeat = nextBeat.NextBeat;
         }
 
-        private const int MaxOffsetForSameLineSearch = 3;
+        return null;
+    }
 
-        internal static Note NextNoteOnSameLine(Note note)
+    internal static Note FindTieOrigin(Note note)
+    {
+        var previousBeat = note.Beat.PreviousBeat;
+
+        // keep searching in same bar
+        while (previousBeat != null &&
+               previousBeat.Voice.Bar.Index >= note.Beat.Voice.Bar.Index - MaxOffsetForSameLineSearch)
         {
-            var nextBeat = note.Beat.NextBeat;
-            // keep searching in same bar
-            while (nextBeat != null &&
-                   nextBeat.Voice.Bar.Index <= note.Beat.Voice.Bar.Index + MaxOffsetForSameLineSearch)
+            if (note.IsStringed)
             {
-                var noteOnString = nextBeat.GetNoteOnString(note.String);
+                var noteOnString = previousBeat.GetNoteOnString(note.String);
                 if (noteOnString != null)
                 {
                     return noteOnString;
                 }
-
-                nextBeat = nextBeat.NextBeat;
             }
-
-            return null;
-        }
-
-        internal static Note FindTieOrigin(Note note)
-        {
-            var previousBeat = note.Beat.PreviousBeat;
-
-            // keep searching in same bar
-            while (previousBeat != null &&
-                   previousBeat.Voice.Bar.Index >= note.Beat.Voice.Bar.Index - MaxOffsetForSameLineSearch)
+            else
             {
-                if (note.IsStringed)
+                if (note.Octave == -1 && note.Tone == -1)
                 {
-                    var noteOnString = previousBeat.GetNoteOnString(note.String);
-                    if (noteOnString != null)
+                    // if the note has no value (e.g. alphaTex dash tie), we try to find a matching
+                    // note on the previous beat by index.
+                    if (note.Index < previousBeat.Notes.Count)
                     {
-                        return noteOnString;
+                        return previousBeat.Notes[note.Index];
                     }
                 }
                 else
                 {
-                    if (note.Octave == -1 && note.Tone == -1)
+                    var noteWithValue = previousBeat.GetNoteWithRealValue(note.RealValue);
+                    if (noteWithValue != null)
                     {
-                        // if the note has no value (e.g. alphaTex dash tie), we try to find a matching
-                        // note on the previous beat by index.
-                        if (note.Index < previousBeat.Notes.Count)
-                        {
-                            return previousBeat.Notes[note.Index];
-                        }
-                    }
-                    else
-                    {
-                        var noteWithValue = previousBeat.GetNoteWithRealValue(note.RealValue);
-                        if (noteWithValue != null)
-                        {
-                            return noteWithValue;
-                        }
+                        return noteWithValue;
                     }
                 }
-
-                previousBeat = previousBeat.PreviousBeat;
             }
 
-            return null;
+            previousBeat = previousBeat.PreviousBeat;
         }
+
+        return null;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/NoteAccidentalMode.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/NoteAccidentalMode.cs
@@ -3,36 +3,35 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Lists the modes how accidentals are handled for notes
+/// </summary>
+internal enum NoteAccidentalMode
 {
     /// <summary>
-    /// Lists the modes how accidentals are handled for notes
+    /// Accidentals are calculated automatically.
     /// </summary>
-    internal enum NoteAccidentalMode
-    {
-        /// <summary>
-        /// Accidentals are calculated automatically.
-        /// </summary>
-        Default,
+    Default,
 
-        /// <summary>
-        /// If the default behavior calculates a Sharp, use flat instead (and vice versa).
-        /// </summary>
-        SwapAccidentals,
+    /// <summary>
+    /// If the default behavior calculates a Sharp, use flat instead (and vice versa).
+    /// </summary>
+    SwapAccidentals,
 
-        /// <summary>
-        /// This will move the note one line down and applies a Naturalize.
-        /// </summary>
-        ForceNatural,
+    /// <summary>
+    /// This will move the note one line down and applies a Naturalize.
+    /// </summary>
+    ForceNatural,
 
-        /// <summary>
-        /// This will move the note one line down and applies a Sharp.
-        /// </summary>
-        ForceSharp,
+    /// <summary>
+    /// This will move the note one line down and applies a Sharp.
+    /// </summary>
+    ForceSharp,
 
-        /// <summary>
-        /// This will move the note one line up and applies a Flat.
-        /// </summary>
-        ForceFlat
-    }
+    /// <summary>
+    /// This will move the note one line up and applies a Flat.
+    /// </summary>
+    ForceFlat
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Ottavia.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Ottavia.cs
@@ -5,36 +5,35 @@
 
 // ReSharper disable InconsistentNaming
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Lists all ottavia.  
+/// </summary>
+internal enum Ottavia
 {
     /// <summary>
-    /// Lists all ottavia.  
+    /// 2 octaves higher 
     /// </summary>
-    internal enum Ottavia
-    {
-        /// <summary>
-        /// 2 octaves higher 
-        /// </summary>
-        _15ma,
+    _15ma,
 
-        /// <summary>
-        /// 1 octave higher
-        /// </summary>
-        _8va,
+    /// <summary>
+    /// 1 octave higher
+    /// </summary>
+    _8va,
 
-        /// <summary>
-        /// Normal
-        /// </summary>
-        Regular,
+    /// <summary>
+    /// Normal
+    /// </summary>
+    Regular,
 
-        /// <summary>
-        /// 1 octave lower
-        /// </summary>
-        _8vb,
+    /// <summary>
+    /// 1 octave lower
+    /// </summary>
+    _8vb,
 
-        /// <summary>
-        /// 2 octaves lower. 
-        /// </summary>
-        _15mb
-    }
+    /// <summary>
+    /// 2 octaves lower. 
+    /// </summary>
+    _15mb
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/PickStroke.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/PickStroke.cs
@@ -3,26 +3,25 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Lists all types of pick strokes.
+/// </summary>
+internal enum PickStroke
 {
     /// <summary>
-    /// Lists all types of pick strokes.
+    /// No pickstroke used. 
     /// </summary>
-    internal enum PickStroke
-    {
-        /// <summary>
-        /// No pickstroke used. 
-        /// </summary>
-        None,
+    None,
 
-        /// <summary>
-        /// Pickstroke up. 
-        /// </summary>
-        Up,
+    /// <summary>
+    /// Pickstroke up. 
+    /// </summary>
+    Up,
 
-        /// <summary>
-        /// Pickstroke down
-        /// </summary>
-        Down
-    }
+    /// <summary>
+    /// Pickstroke down
+    /// </summary>
+    Down
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/PlaybackInformation.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/PlaybackInformation.cs
@@ -3,74 +3,73 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// This public class stores the midi specific information of a track needed
+/// for playback.
+/// </summary>
+internal class PlaybackInformation
 {
     /// <summary>
-    /// This public class stores the midi specific information of a track needed
-    /// for playback.
+    /// Gets or sets the volume (0-16)
     /// </summary>
-    internal class PlaybackInformation
+    public int Volume { get; set; }
+
+    /// <summary>
+    /// Gets or sets the balance (0-16; 8=center)
+    /// </summary>
+    public int Balance { get; set; }
+
+    /// <summary>
+    /// Gets or sets the midi port to use.
+    /// </summary>
+    public int Port { get; set; }
+
+    /// <summary>
+    /// Gets or sets the midi program to use. 
+    /// </summary>
+    public int Program { get; set; }
+
+    /// <summary>
+    /// Gets or sets the primary channel for all normal midi events. 
+    /// </summary>
+    public int PrimaryChannel { get; set; }
+
+    /// <summary>
+    /// Gets or sets the secondary channel for special midi events. 
+    /// </summary>
+    public int SecondaryChannel { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the track is muted.
+    /// </summary>
+    public bool IsMute { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the track is playing alone. 
+    /// </summary>
+    public bool IsSolo { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlaybackInformation"/> class.
+    /// </summary>
+    public PlaybackInformation()
     {
-        /// <summary>
-        /// Gets or sets the volume (0-16)
-        /// </summary>
-        public int Volume { get; set; }
+        Volume  = 15;
+        Balance = 8;
+        Port    = 1;
+    }
 
-        /// <summary>
-        /// Gets or sets the balance (0-16; 8=center)
-        /// </summary>
-        public int Balance { get; set; }
-
-        /// <summary>
-        /// Gets or sets the midi port to use.
-        /// </summary>
-        public int Port { get; set; }
-
-        /// <summary>
-        /// Gets or sets the midi program to use. 
-        /// </summary>
-        public int Program { get; set; }
-
-        /// <summary>
-        /// Gets or sets the primary channel for all normal midi events. 
-        /// </summary>
-        public int PrimaryChannel { get; set; }
-
-        /// <summary>
-        /// Gets or sets the secondary channel for special midi events. 
-        /// </summary>
-        public int SecondaryChannel { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether the track is muted.
-        /// </summary>
-        public bool IsMute { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether the track is playing alone. 
-        /// </summary>
-        public bool IsSolo { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PlaybackInformation"/> class.
-        /// </summary>
-        public PlaybackInformation()
-        {
-            Volume = 15;
-            Balance = 8;
-            Port = 1;
-        }
-
-        internal static void CopyTo(PlaybackInformation src, PlaybackInformation dst)
-        {
-            dst.Volume = src.Volume;
-            dst.Balance = src.Balance;
-            dst.Port = src.Port;
-            dst.Program = src.Program;
-            dst.PrimaryChannel = src.PrimaryChannel;
-            dst.SecondaryChannel = src.SecondaryChannel;
-            dst.IsMute = src.IsMute;
-            dst.IsSolo = src.IsSolo;
-        }
+    internal static void CopyTo(PlaybackInformation src, PlaybackInformation dst)
+    {
+        dst.Volume           = src.Volume;
+        dst.Balance          = src.Balance;
+        dst.Port             = src.Port;
+        dst.Program          = src.Program;
+        dst.PrimaryChannel   = src.PrimaryChannel;
+        dst.SecondaryChannel = src.SecondaryChannel;
+        dst.IsMute           = src.IsMute;
+        dst.IsSolo           = src.IsSolo;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/RenderStylesheet.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/RenderStylesheet.cs
@@ -3,30 +3,29 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// This class represents the rendering stylesheet.
+/// It contains settings which control the display of the score when rendered. 
+/// </summary>
+internal class RenderStylesheet
 {
     /// <summary>
-    /// This class represents the rendering stylesheet.
-    /// It contains settings which control the display of the score when rendered. 
+    /// Gets or sets whether dynamics are hidden.
     /// </summary>
-    internal class RenderStylesheet
+    public bool HideDynamics { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RenderStylesheet"/> class.
+    /// </summary>
+    public RenderStylesheet()
     {
-        /// <summary>
-        /// Gets or sets whether dynamics are hidden.
-        /// </summary>
-        public bool HideDynamics { get; set; }
+        HideDynamics = false;
+    }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RenderStylesheet"/> class.
-        /// </summary>
-        public RenderStylesheet()
-        {
-            HideDynamics = false;
-        }
-
-        internal static void CopyTo(RenderStylesheet src, RenderStylesheet dst)
-        {
-            dst.HideDynamics = src.HideDynamics;
-        }
+    internal static void CopyTo(RenderStylesheet src, RenderStylesheet dst)
+    {
+        dst.HideDynamics = src.HideDynamics;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/RepeatGroup.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/RepeatGroup.cs
@@ -5,75 +5,74 @@
 
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// This public class can store the information about a group of measures which are repeated
+/// </summary>
+internal class RepeatGroup
 {
     /// <summary>
-    /// This public class can store the information about a group of measures which are repeated
+    /// All masterbars repeated within this group
     /// </summary>
-    internal class RepeatGroup
+    public FastList<MasterBar> MasterBars { get; set; }
+
+    /// <summary>
+    /// a list of masterbars which open the group. 
+    /// </summary>
+    public FastList<MasterBar> Openings { get; set; }
+
+    /// <summary>
+    /// a list of masterbars which close the group. 
+    /// </summary>
+    public FastList<MasterBar> Closings { get; set; }
+
+    /// <summary>
+    ///  true if the repeat group was opened well
+    /// </summary>
+    public bool IsOpened { get; set; }
+
+    /// <summary>
+    ///  true if the repeat group was closed well
+    /// </summary>
+    public bool IsClosed { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RepeatGroup"/> class.
+    /// </summary>
+    public RepeatGroup()
     {
-        /// <summary>
-        /// All masterbars repeated within this group
-        /// </summary>
-        public FastList<MasterBar> MasterBars { get; set; }
+        MasterBars = new FastList<MasterBar>();
+        Openings   = new FastList<MasterBar>();
+        Closings   = new FastList<MasterBar>();
+        IsClosed   = false;
+    }
 
-        /// <summary>
-        /// a list of masterbars which open the group. 
-        /// </summary>
-        public FastList<MasterBar> Openings { get; set; }
-
-        /// <summary>
-        /// a list of masterbars which close the group. 
-        /// </summary>
-        public FastList<MasterBar> Closings { get; set; }
-
-        /// <summary>
-        ///  true if the repeat group was opened well
-        /// </summary>
-        public bool IsOpened { get; set; }
-
-        /// <summary>
-        ///  true if the repeat group was closed well
-        /// </summary>
-        public bool IsClosed { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RepeatGroup"/> class.
-        /// </summary>
-        public RepeatGroup()
+    internal void AddMasterBar(MasterBar masterBar)
+    {
+        if (Openings.Count == 0)
         {
-            MasterBars = new FastList<MasterBar>();
-            Openings = new FastList<MasterBar>();
-            Closings = new FastList<MasterBar>();
-            IsClosed = false;
+            Openings.Add(masterBar);
         }
 
-        internal void AddMasterBar(MasterBar masterBar)
+        MasterBars.Add(masterBar);
+        masterBar.RepeatGroup = this;
+
+        if (masterBar.IsRepeatEnd)
         {
-            if (Openings.Count == 0)
+            Closings.Add(masterBar);
+            IsClosed = true;
+            if (!IsOpened)
             {
-                Openings.Add(masterBar);
+                MasterBars[0].IsRepeatStart = true;
+                IsOpened                    = true;
             }
-
-            MasterBars.Add(masterBar);
-            masterBar.RepeatGroup = this;
-
-            if (masterBar.IsRepeatEnd)
-            {
-                Closings.Add(masterBar);
-                IsClosed = true;
-                if (!IsOpened)
-                {
-                    MasterBars[0].IsRepeatStart = true;
-                    IsOpened = true;
-                }
-            }
-            // a new item after the header was closed? -> repeat alternative reopens the group
-            else if (IsClosed)
-            {
-                IsClosed = false;
-                Openings.Add(masterBar);
-            }
+        }
+        // a new item after the header was closed? -> repeat alternative reopens the group
+        else if (IsClosed)
+        {
+            IsClosed = false;
+            Openings.Add(masterBar);
         }
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Score.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Score.cs
@@ -5,175 +5,174 @@
 
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// The score is the root node of the complete 
+/// model. It stores the basic information of 
+/// a song and stores the sub components. 
+/// </summary>
+internal class Score
 {
+    private RepeatGroup _currentRepeatGroup;
+
     /// <summary>
-    /// The score is the root node of the complete 
-    /// model. It stores the basic information of 
-    /// a song and stores the sub components. 
+    /// The album of this song. 
     /// </summary>
-    internal class Score
+    public string Album { get; set; }
+
+    /// <summary>
+    /// The artist who performs this song.
+    /// </summary>
+    public string Artist { get; set; }
+
+    /// <summary>
+    /// The owner of the copyright of this song. 
+    /// </summary>
+    public string Copyright { get; set; }
+
+    /// <summary>
+    /// Additional instructions
+    /// </summary>
+    public string Instructions { get; set; }
+
+    /// <summary>
+    /// The author of the music. 
+    /// </summary>
+    public string Music { get; set; }
+
+    /// <summary>
+    /// Some additional notes about the song. 
+    /// </summary>
+    public string Notices { get; set; }
+
+    /// <summary>
+    /// The subtitle of the song. 
+    /// </summary>
+    public string SubTitle { get; set; }
+
+    /// <summary>
+    /// The title of the song. 
+    /// </summary>
+    public string Title { get; set; }
+
+    /// <summary>
+    /// The author of the song lyrics
+    /// </summary>
+    public string Words { get; set; }
+
+    /// <summary>
+    /// The author of this tablature.
+    /// </summary>
+    public string Tab { get; set; }
+
+    /// <summary>
+    /// Gets or sets the global tempo of the song in BPM. The tempo might change via <see cref="MasterBar.TempoAutomation"/>.
+    /// </summary>
+    public int Tempo { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name/label of the tempo. 
+    /// </summary>
+    public string TempoLabel { get; set; }
+
+    /// <summary>
+    /// Gets or sets a list of all masterbars contained in this song. 
+    /// </summary>
+    public FastList<MasterBar> MasterBars { get; set; }
+
+    /// <summary>
+    /// Gets or sets a list of all tracks contained in this song. 
+    /// </summary>
+    public FastList<Track> Tracks { get; set; }
+
+    /// <summary>
+    /// Gets or sets the rendering stylesheet for this song.
+    /// </summary>
+    public RenderStylesheet Stylesheet { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Score"/> class.
+    /// </summary>
+    public Score()
     {
-        private RepeatGroup _currentRepeatGroup;
+        MasterBars          = new FastList<MasterBar>();
+        Tracks              = new FastList<Track>();
+        _currentRepeatGroup = new RepeatGroup();
+        Album = Artist = Copyright =
+            Instructions = Music = Notices = SubTitle = Title = Words = Tab = TempoLabel = "";
+        Tempo      = 120;
+        Stylesheet = new RenderStylesheet();
+    }
 
-        /// <summary>
-        /// The album of this song. 
-        /// </summary>
-        public string Album { get; set; }
+    internal static void CopyTo(Score src, Score dst)
+    {
+        dst.Album        = src.Album;
+        dst.Artist       = src.Artist;
+        dst.Copyright    = src.Copyright;
+        dst.Instructions = src.Instructions;
+        dst.Music        = src.Music;
+        dst.Notices      = src.Notices;
+        dst.SubTitle     = src.SubTitle;
+        dst.Title        = src.Title;
+        dst.Words        = src.Words;
+        dst.Tab          = src.Tab;
+        dst.Tempo        = src.Tempo;
+        dst.TempoLabel   = src.TempoLabel;
+    }
 
-        /// <summary>
-        /// The artist who performs this song.
-        /// </summary>
-        public string Artist { get; set; }
-
-        /// <summary>
-        /// The owner of the copyright of this song. 
-        /// </summary>
-        public string Copyright { get; set; }
-
-        /// <summary>
-        /// Additional instructions
-        /// </summary>
-        public string Instructions { get; set; }
-
-        /// <summary>
-        /// The author of the music. 
-        /// </summary>
-        public string Music { get; set; }
-
-        /// <summary>
-        /// Some additional notes about the song. 
-        /// </summary>
-        public string Notices { get; set; }
-
-        /// <summary>
-        /// The subtitle of the song. 
-        /// </summary>
-        public string SubTitle { get; set; }
-
-        /// <summary>
-        /// The title of the song. 
-        /// </summary>
-        public string Title { get; set; }
-
-        /// <summary>
-        /// The author of the song lyrics
-        /// </summary>
-        public string Words { get; set; }
-
-        /// <summary>
-        /// The author of this tablature.
-        /// </summary>
-        public string Tab { get; set; }
-
-        /// <summary>
-        /// Gets or sets the global tempo of the song in BPM. The tempo might change via <see cref="MasterBar.TempoAutomation"/>.
-        /// </summary>
-        public int Tempo { get; set; }
-
-        /// <summary>
-        /// Gets or sets the name/label of the tempo. 
-        /// </summary>
-        public string TempoLabel { get; set; }
-
-        /// <summary>
-        /// Gets or sets a list of all masterbars contained in this song. 
-        /// </summary>
-        public FastList<MasterBar> MasterBars { get; set; }
-
-        /// <summary>
-        /// Gets or sets a list of all tracks contained in this song. 
-        /// </summary>
-        public FastList<Track> Tracks { get; set; }
-
-        /// <summary>
-        /// Gets or sets the rendering stylesheet for this song.
-        /// </summary>
-        public RenderStylesheet Stylesheet { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Score"/> class.
-        /// </summary>
-        public Score()
+    internal void RebuildRepeatGroups()
+    {
+        var currentGroup = new RepeatGroup();
+        foreach (var bar in MasterBars)
         {
-            MasterBars = new FastList<MasterBar>();
-            Tracks = new FastList<Track>();
-            _currentRepeatGroup = new RepeatGroup();
-            Album = Artist = Copyright =
-                Instructions = Music = Notices = SubTitle = Title = Words = Tab = TempoLabel = "";
-            Tempo = 120;
-            Stylesheet = new RenderStylesheet();
-        }
-
-        internal static void CopyTo(Score src, Score dst)
-        {
-            dst.Album = src.Album;
-            dst.Artist = src.Artist;
-            dst.Copyright = src.Copyright;
-            dst.Instructions = src.Instructions;
-            dst.Music = src.Music;
-            dst.Notices = src.Notices;
-            dst.SubTitle = src.SubTitle;
-            dst.Title = src.Title;
-            dst.Words = src.Words;
-            dst.Tab = src.Tab;
-            dst.Tempo = src.Tempo;
-            dst.TempoLabel = src.TempoLabel;
-        }
-
-        internal void RebuildRepeatGroups()
-        {
-            var currentGroup = new RepeatGroup();
-            foreach (var bar in MasterBars)
-            {
-                // if the group is closed only the next upcoming header can
-                // reopen the group in case of a repeat alternative, so we 
-                // remove the current group 
-                if (bar.IsRepeatStart || _currentRepeatGroup.IsClosed && bar.AlternateEndings <= 0)
-                {
-                    currentGroup = new RepeatGroup();
-                }
-
-                currentGroup.AddMasterBar(bar);
-            }
-        }
-
-        internal void AddMasterBar(MasterBar bar)
-        {
-            bar.Score = this;
-            bar.Index = MasterBars.Count;
-            if (MasterBars.Count != 0)
-            {
-                bar.PreviousMasterBar = MasterBars[MasterBars.Count - 1];
-                bar.PreviousMasterBar.NextMasterBar = bar;
-                bar.Start = bar.PreviousMasterBar.Start + bar.PreviousMasterBar.CalculateDuration();
-            }
-
             // if the group is closed only the next upcoming header can
             // reopen the group in case of a repeat alternative, so we 
             // remove the current group 
             if (bar.IsRepeatStart || _currentRepeatGroup.IsClosed && bar.AlternateEndings <= 0)
             {
-                _currentRepeatGroup = new RepeatGroup();
+                currentGroup = new RepeatGroup();
             }
 
-            _currentRepeatGroup.AddMasterBar(bar);
-            MasterBars.Add(bar);
+            currentGroup.AddMasterBar(bar);
+        }
+    }
+
+    internal void AddMasterBar(MasterBar bar)
+    {
+        bar.Score = this;
+        bar.Index = MasterBars.Count;
+        if (MasterBars.Count != 0)
+        {
+            bar.PreviousMasterBar = MasterBars[MasterBars.Count - 1];
+            bar.PreviousMasterBar.NextMasterBar = bar;
+            bar.Start = bar.PreviousMasterBar.Start + bar.PreviousMasterBar.CalculateDuration();
         }
 
-        internal void AddTrack(Track track)
+        // if the group is closed only the next upcoming header can
+        // reopen the group in case of a repeat alternative, so we 
+        // remove the current group 
+        if (bar.IsRepeatStart || _currentRepeatGroup.IsClosed && bar.AlternateEndings <= 0)
         {
-            track.Score = this;
-            track.Index = Tracks.Count;
-            Tracks.Add(track);
+            _currentRepeatGroup = new RepeatGroup();
         }
 
-        internal void Finish()
+        _currentRepeatGroup.AddMasterBar(bar);
+        MasterBars.Add(bar);
+    }
+
+    internal void AddTrack(Track track)
+    {
+        track.Score = this;
+        track.Index = Tracks.Count;
+        Tracks.Add(track);
+    }
+
+    internal void Finish()
+    {
+        for (int i = 0, j = Tracks.Count; i < j; i++)
         {
-            for (int i = 0, j = Tracks.Count; i < j; i++)
-            {
-                Tracks[i].Finish();
-            }
+            Tracks[i].Finish();
         }
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Section.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Section.cs
@@ -3,36 +3,35 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// This public class is used to describe the beginning of a 
+/// section within a song. It acts like a marker. 
+/// </summary>
+internal class Section
 {
     /// <summary>
-    /// This public class is used to describe the beginning of a 
-    /// section within a song. It acts like a marker. 
+    /// Gets or sets the marker ID for this section. 
     /// </summary>
-    internal class Section
+    public string Marker { get; set; }
+
+    /// <summary>
+    /// Gets or sets the descriptional text of this section.
+    /// </summary>
+    public string Text { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Section"/> class.
+    /// </summary>
+    public Section()
     {
-        /// <summary>
-        /// Gets or sets the marker ID for this section. 
-        /// </summary>
-        public string Marker { get; set; }
+        Text = Marker = "";
+    }
 
-        /// <summary>
-        /// Gets or sets the descriptional text of this section.
-        /// </summary>
-        public string Text { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Section"/> class.
-        /// </summary>
-        public Section()
-        {
-            Text = Marker = "";
-        }
-
-        internal static void CopyTo(Section src, Section dst)
-        {
-            dst.Marker = src.Marker;
-            dst.Text = src.Text;
-        }
+    internal static void CopyTo(Section src, Section dst)
+    {
+        dst.Marker = src.Marker;
+        dst.Text   = src.Text;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/SimileMark.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/SimileMark.cs
@@ -3,33 +3,32 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Lists all simile mark types as they are assigned to bars. 
+/// </summary>
+internal enum SimileMark
 {
     /// <summary>
-    /// Lists all simile mark types as they are assigned to bars. 
+    /// No simile mark is applied
     /// </summary>
-    internal enum SimileMark
-    {
-        /// <summary>
-        /// No simile mark is applied
-        /// </summary>
-        None,
+    None,
 
-        /// <summary>
-        /// A simple simile mark. The previous bar is repeated. 
-        /// </summary>
-        Simple,
+    /// <summary>
+    /// A simple simile mark. The previous bar is repeated. 
+    /// </summary>
+    Simple,
 
-        /// <summary>
-        /// A double simile mark. This value is assigned to the first
-        /// bar of the 2 repeat bars. 
-        /// </summary>
-        FirstOfDouble,
+    /// <summary>
+    /// A double simile mark. This value is assigned to the first
+    /// bar of the 2 repeat bars. 
+    /// </summary>
+    FirstOfDouble,
 
-        /// <summary>
-        /// A double simile mark. This value is assigned to the second
-        /// bar of the 2 repeat bars. 
-        /// </summary>
-        SecondOfDouble
-    }
+    /// <summary>
+    /// A double simile mark. This value is assigned to the second
+    /// bar of the 2 repeat bars. 
+    /// </summary>
+    SecondOfDouble
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/SlideType.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/SlideType.cs
@@ -3,67 +3,66 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// This public enum lists all different types of finger slide-ins on a string.
+/// </summary>
+internal enum SlideInType
 {
     /// <summary>
-    /// This public enum lists all different types of finger slide-ins on a string.
+    /// No slide.
     /// </summary>
-    internal enum SlideInType
-    {
-        /// <summary>
-        /// No slide.
-        /// </summary>
-        None,
-
-        /// <summary>
-        /// Slide into the note from below on the same string.
-        /// </summary>
-        IntoFromBelow,
-
-        /// <summary>
-        /// Slide into the note from above on the same string.
-        /// </summary>
-        IntoFromAbove
-    }
+    None,
 
     /// <summary>
-    /// This public enum lists all different types of finger slide-outs on a string.
+    /// Slide into the note from below on the same string.
     /// </summary>
-    internal enum SlideOutType
-    {
-        /// <summary>
-        /// No slide.
-        /// </summary>
-        None,
+    IntoFromBelow,
 
-        /// <summary>
-        /// Shift slide to next note on same string
-        /// </summary>
-        Shift,
+    /// <summary>
+    /// Slide into the note from above on the same string.
+    /// </summary>
+    IntoFromAbove
+}
 
-        /// <summary>
-        /// Legato slide to next note on same string.
-        /// </summary>
-        Legato,
+/// <summary>
+/// This public enum lists all different types of finger slide-outs on a string.
+/// </summary>
+internal enum SlideOutType
+{
+    /// <summary>
+    /// No slide.
+    /// </summary>
+    None,
 
-        /// <summary>
-        /// Slide out from the note from upwards on the same string.
-        /// </summary>
-        OutUp,
+    /// <summary>
+    /// Shift slide to next note on same string
+    /// </summary>
+    Shift,
 
-        /// <summary>
-        /// Slide out from the note from downwards on the same string.
-        /// </summary>
-        OutDown,
+    /// <summary>
+    /// Legato slide to next note on same string.
+    /// </summary>
+    Legato,
 
-        /// <summary>
-        /// Pickslide down on this note
-        /// </summary>
-        PickSlideDown,
+    /// <summary>
+    /// Slide out from the note from upwards on the same string.
+    /// </summary>
+    OutUp,
 
-        /// <summary>
-        /// Pickslide up on this note
-        /// </summary>
-        PickSlideUp
-    }
+    /// <summary>
+    /// Slide out from the note from downwards on the same string.
+    /// </summary>
+    OutDown,
+
+    /// <summary>
+    /// Pickslide down on this note
+    /// </summary>
+    PickSlideDown,
+
+    /// <summary>
+    /// Pickslide up on this note
+    /// </summary>
+    PickSlideUp
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Staff.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Staff.cs
@@ -6,133 +6,132 @@
 using System;
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// This class describes a single staff within a track. There are instruments like pianos
+/// where a single track can contain multiple staffs. 
+/// </summary>
+internal class Staff
 {
     /// <summary>
-    /// This class describes a single staff within a track. There are instruments like pianos
-    /// where a single track can contain multiple staffs. 
+    /// Gets or sets the zero-based index of this staff within the track.
     /// </summary>
-    internal class Staff
+    public int Index { get; set; }
+
+    /// <summary>
+    /// Gets or sets the reference to the track this staff belongs to. 
+    /// </summary>
+    public Track Track { get; set; }
+
+    /// <summary>
+    /// Gets or sets a list of all bars contained in this staff. 
+    /// </summary>
+    public FastList<Bar> Bars { get; set; }
+
+    /// <summary>
+    /// Gets or sets a list of all chords defined for this staff. <see cref="Beat.ChordId"/> refers to entries in this lookup.
+    /// </summary>
+    public FastDictionary<string, Chord> Chords { get; set; }
+
+    /// <summary>
+    /// Gets or sets the fret on which a capo is set. s
+    /// </summary>
+    public int Capo { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of semitones this track should be
+    /// transposed. This applies to rendering and playback.
+    /// </summary>
+    public int TranspositionPitch { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of semitones this track should be 
+    /// transposed. This applies only to rendering. 
+    /// </summary>
+    public int DisplayTranspositionPitch { get; set; }
+
+    /// <summary>
+    /// Get or set the guitar tuning of the guitar. This tuning also indicates the number of strings shown in the
+    /// guitar tablature. Unlike the <see cref="Note.String"/> property this array directly represents
+    /// the order of the tracks shown in the tablature. The first item is the most top tablature line. 
+    /// </summary>
+    public int[] Tuning { get; set; }
+
+    /// <summary>
+    /// Gets or sets the name of the tuning.
+    /// </summary>
+    public string TuningName { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether this staff contains string based notes.
+    /// </summary>
+    public bool IsStringed => Tuning.Length > 0;
+
+    /// <summary>
+    /// Gets or sets whether the tabs are shown. 
+    /// </summary>
+    public bool ShowTablature { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the standard notation is shown. 
+    /// </summary>
+    public bool ShowStandardNotation { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the staff contains percussion notation
+    /// </summary>
+    public bool IsPercussion { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Staff"/> class.
+    /// </summary>
+    public Staff()
     {
-        /// <summary>
-        /// Gets or sets the zero-based index of this staff within the track.
-        /// </summary>
-        public int Index { get; set; }
+        Bars                 = new FastList<Bar>();
+        Tuning               = Array.Empty<int>();
+        Chords               = new FastDictionary<string, Chord>();
+        ShowStandardNotation = true;
+        ShowTablature        = true;
+    }
 
-        /// <summary>
-        /// Gets or sets the reference to the track this staff belongs to. 
-        /// </summary>
-        public Track Track { get; set; }
+    internal static void CopyTo(Staff src, Staff dst)
+    {
+        dst.Capo                      = src.Capo;
+        dst.Index                     = src.Index;
+        dst.Tuning                    = Platform.CloneArray(src.Tuning);
+        dst.TranspositionPitch        = src.TranspositionPitch;
+        dst.DisplayTranspositionPitch = src.DisplayTranspositionPitch;
+        dst.ShowStandardNotation      = src.ShowStandardNotation;
+        dst.ShowTablature             = src.ShowTablature;
+        dst.IsPercussion              = src.IsPercussion;
+    }
 
-        /// <summary>
-        /// Gets or sets a list of all bars contained in this staff. 
-        /// </summary>
-        public FastList<Bar> Bars { get; set; }
-
-        /// <summary>
-        /// Gets or sets a list of all chords defined for this staff. <see cref="Beat.ChordId"/> refers to entries in this lookup.
-        /// </summary>
-        public FastDictionary<string, Chord> Chords { get; set; }
-
-        /// <summary>
-        /// Gets or sets the fret on which a capo is set. s
-        /// </summary>
-        public int Capo { get; set; }
-
-        /// <summary>
-        /// Gets or sets the number of semitones this track should be
-        /// transposed. This applies to rendering and playback.
-        /// </summary>
-        public int TranspositionPitch { get; set; }
-
-        /// <summary>
-        /// Gets or sets the number of semitones this track should be 
-        /// transposed. This applies only to rendering. 
-        /// </summary>
-        public int DisplayTranspositionPitch { get; set; }
-
-        /// <summary>
-        /// Get or set the guitar tuning of the guitar. This tuning also indicates the number of strings shown in the
-        /// guitar tablature. Unlike the <see cref="Note.String"/> property this array directly represents
-        /// the order of the tracks shown in the tablature. The first item is the most top tablature line. 
-        /// </summary>
-        public int[] Tuning { get; set; }
-
-        /// <summary>
-        /// Gets or sets the name of the tuning.
-        /// </summary>
-        public string TuningName { get; set; }
-
-        /// <summary>
-        /// Gets a value indicating whether this staff contains string based notes.
-        /// </summary>
-        public bool IsStringed => Tuning.Length > 0;
-
-        /// <summary>
-        /// Gets or sets whether the tabs are shown. 
-        /// </summary>
-        public bool ShowTablature { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether the standard notation is shown. 
-        /// </summary>
-        public bool ShowStandardNotation { get; set; }
-
-        /// <summary>
-        /// Gets or sets whether the staff contains percussion notation
-        /// </summary>
-        public bool IsPercussion { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Staff"/> class.
-        /// </summary>
-        public Staff()
+    internal void Finish()
+    {
+        for (int i = 0, j = Bars.Count; i < j; i++)
         {
-            Bars                 = new FastList<Bar>();
-            Tuning               = Array.Empty<int>();
-            Chords               = new FastDictionary<string, Chord>();
-            ShowStandardNotation = true;
-            ShowTablature        = true;
+            Bars[i].Finish();
+        }
+    }
+
+    internal void AddChord(string chordId, Chord chord)
+    {
+        chord.Staff     = this;
+        Chords[chordId] = chord;
+    }
+
+    internal void AddBar(Bar bar)
+    {
+        var bars = Bars;
+        bar.Staff = this;
+        bar.Index = bars.Count;
+        if (bars.Count > 0)
+        {
+            bar.PreviousBar         = bars[bars.Count - 1];
+            bar.PreviousBar.NextBar = bar;
         }
 
-        internal static void CopyTo(Staff src, Staff dst)
-        {
-            dst.Capo = src.Capo;
-            dst.Index = src.Index;
-            dst.Tuning = Platform.CloneArray(src.Tuning);
-            dst.TranspositionPitch = src.TranspositionPitch;
-            dst.DisplayTranspositionPitch = src.DisplayTranspositionPitch;
-            dst.ShowStandardNotation = src.ShowStandardNotation;
-            dst.ShowTablature = src.ShowTablature;
-            dst.IsPercussion = src.IsPercussion;
-        }
-
-        internal void Finish()
-        {
-            for (int i = 0, j = Bars.Count; i < j; i++)
-            {
-                Bars[i].Finish();
-            }
-        }
-
-        internal void AddChord(string chordId, Chord chord)
-        {
-            chord.Staff = this;
-            Chords[chordId] = chord;
-        }
-
-        internal void AddBar(Bar bar)
-        {
-            var bars = Bars;
-            bar.Staff = this;
-            bar.Index = bars.Count;
-            if (bars.Count > 0)
-            {
-                bar.PreviousBar = bars[bars.Count - 1];
-                bar.PreviousBar.NextBar = bar;
-            }
-
-            bars.Add(bar);
-        }
+        bars.Add(bar);
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Staff.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Staff.cs
@@ -3,6 +3,7 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
+using System;
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 
 namespace BardMusicPlayer.Siren.AlphaTab.Model
@@ -87,11 +88,11 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
         /// </summary>
         public Staff()
         {
-            Bars = new FastList<Bar>();
-            Tuning = new int[0];
-            Chords = new FastDictionary<string, Chord>();
+            Bars                 = new FastList<Bar>();
+            Tuning               = Array.Empty<int>();
+            Chords               = new FastDictionary<string, Chord>();
             ShowStandardNotation = true;
-            ShowTablature = true;
+            ShowTablature        = true;
         }
 
         internal static void CopyTo(Staff src, Staff dst)

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Track.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Track.cs
@@ -5,131 +5,130 @@
 
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// This public class describes a single track or instrument of score.
+/// It is basically a list of staffs containing individual music notation kinds.
+/// </summary>
+internal class Track
 {
+    private const int ShortNameMaxLength = 10;
+
     /// <summary>
-    /// This public class describes a single track or instrument of score.
-    /// It is basically a list of staffs containing individual music notation kinds.
+    /// Gets or sets the zero-based index of this track. 
     /// </summary>
-    internal class Track
+    public int Index { get; set; }
+
+    /// <summary>
+    /// Gets or sets the reference this track belongs to. 
+    /// </summary>
+    public Score Score { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of staffs that are defined for this track. 
+    /// </summary>
+    public FastList<Staff> Staves { get; set; }
+
+    /// <summary>
+    /// Gets or sets the playback information for this track. 
+    /// </summary>
+    public PlaybackInformation PlaybackInfo { get; set; }
+
+    /// <summary>
+    /// Gets or sets the long name of this track. 
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the short name of this track. 
+    /// </summary>
+    public string ShortName { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Track"/> class.
+    /// </summary>
+    /// <param name="staveCount">The stave count.</param>
+    public Track(int staveCount)
     {
-        private const int ShortNameMaxLength = 10;
+        Staves = new FastList<Staff>();
+        EnsureStaveCount(staveCount);
+        PlaybackInfo = new PlaybackInformation();
+        Name         = "";
+        ShortName    = "";
+    }
 
-        /// <summary>
-        /// Gets or sets the zero-based index of this track. 
-        /// </summary>
-        public int Index { get; set; }
-
-        /// <summary>
-        /// Gets or sets the reference this track belongs to. 
-        /// </summary>
-        public Score Score { get; set; }
-
-        /// <summary>
-        /// Gets or sets the list of staffs that are defined for this track. 
-        /// </summary>
-        public FastList<Staff> Staves { get; set; }
-
-        /// <summary>
-        /// Gets or sets the playback information for this track. 
-        /// </summary>
-        public PlaybackInformation PlaybackInfo { get; set; }
-
-        /// <summary>
-        /// Gets or sets the long name of this track. 
-        /// </summary>
-        public string Name { get; set; }
-
-        /// <summary>
-        /// Gets or sets the short name of this track. 
-        /// </summary>
-        public string ShortName { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Track"/> class.
-        /// </summary>
-        /// <param name="staveCount">The stave count.</param>
-        public Track(int staveCount)
+    internal void EnsureStaveCount(int staveCount)
+    {
+        while (Staves.Count < staveCount)
         {
-            Staves = new FastList<Staff>();
-            EnsureStaveCount(staveCount);
-            PlaybackInfo = new PlaybackInformation();
-            Name = "";
-            ShortName = "";
+            AddStaff(new Staff());
         }
+    }
 
-        internal void EnsureStaveCount(int staveCount)
+    internal void AddStaff(Staff staff)
+    {
+        staff.Index = Staves.Count;
+        staff.Track = this;
+        Staves.Add(staff);
+    }
+
+    internal static void CopyTo(Track src, Track dst)
+    {
+        dst.Name      = src.Name;
+        dst.ShortName = src.ShortName;
+        dst.Index     = src.Index;
+    }
+
+    internal void Finish()
+    {
+        if (string.IsNullOrEmpty(ShortName))
         {
-            while (Staves.Count < staveCount)
+            ShortName = Name;
+            if (ShortName.Length > ShortNameMaxLength)
             {
-                AddStaff(new Staff());
+                ShortName = ShortName.Substring(0, ShortNameMaxLength);
             }
         }
 
-        internal void AddStaff(Staff staff)
+        for (int i = 0, j = Staves.Count; i < j; i++)
         {
-            staff.Index = Staves.Count;
-            staff.Track = this;
-            Staves.Add(staff);
+            Staves[i].Finish();
+        }
+    }
+
+    internal void ApplyLyrics(FastList<Lyrics> lyrics)
+    {
+        foreach (var lyric in lyrics)
+        {
+            lyric.Finish();
         }
 
-        internal static void CopyTo(Track src, Track dst)
-        {
-            dst.Name = src.Name;
-            dst.ShortName = src.ShortName;
-            dst.Index = src.Index;
-        }
+        var staff = Staves[0];
 
-        internal void Finish()
+        for (var li = 0; li < lyrics.Count; li++)
         {
-            if (string.IsNullOrEmpty(ShortName))
+            var lyric = lyrics[li];
+            if (lyric.StartBar >= 0)
             {
-                ShortName = Name;
-                if (ShortName.Length > ShortNameMaxLength)
+                var beat = staff.Bars[lyric.StartBar].Voices[0].Beats[0];
+                for (var ci = 0; ci < lyric.Chunks.Length && beat != null; ci++)
                 {
-                    ShortName = ShortName.Substring(0, ShortNameMaxLength);
-                }
-            }
-
-            for (int i = 0, j = Staves.Count; i < j; i++)
-            {
-                Staves[i].Finish();
-            }
-        }
-
-        internal void ApplyLyrics(FastList<Lyrics> lyrics)
-        {
-            foreach (var lyric in lyrics)
-            {
-                lyric.Finish();
-            }
-
-            var staff = Staves[0];
-
-            for (var li = 0; li < lyrics.Count; li++)
-            {
-                var lyric = lyrics[li];
-                if (lyric.StartBar >= 0)
-                {
-                    var beat = staff.Bars[lyric.StartBar].Voices[0].Beats[0];
-                    for (var ci = 0; ci < lyric.Chunks.Length && beat != null; ci++)
+                    // skip rests and empty beats
+                    while (beat != null && (beat.IsEmpty || beat.IsRest))
                     {
-                        // skip rests and empty beats
-                        while (beat != null && (beat.IsEmpty || beat.IsRest))
-                        {
-                            beat = beat.NextBeat;
-                        }
+                        beat = beat.NextBeat;
+                    }
 
-                        // mismatch between chunks and beats might lead to missing beats
-                        if (beat != null)
-                        {
-                            // initialize lyrics list for beat if required
-                            beat.Lyrics ??= new string[lyrics.Count];
+                    // mismatch between chunks and beats might lead to missing beats
+                    if (beat != null)
+                    {
+                        // initialize lyrics list for beat if required
+                        beat.Lyrics ??= new string[lyrics.Count];
 
-                            // assign chunk
-                            beat.Lyrics[li] = lyric.Chunks[ci];
-                            beat = beat.NextBeat;
-                        }
+                        // assign chunk
+                        beat.Lyrics[li] = lyric.Chunks[ci];
+                        beat            = beat.NextBeat;
                     }
                 }
             }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Track.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Track.cs
@@ -9,7 +9,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
 {
     /// <summary>
     /// This public class describes a single track or instrument of score.
-    /// It is bascially a list of staffs containing individual music notation kinds.
+    /// It is basically a list of staffs containing individual music notation kinds.
     /// </summary>
     internal class Track
     {
@@ -124,10 +124,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
                         if (beat != null)
                         {
                             // initialize lyrics list for beat if required
-                            if (beat.Lyrics == null)
-                            {
-                                beat.Lyrics = new string[lyrics.Count];
-                            }
+                            beat.Lyrics ??= new string[lyrics.Count];
 
                             // assign chunk
                             beat.Lyrics[li] = lyric.Chunks[ci];

--- a/BardMusicPlayer.Siren/AlphaTab/Model/TripletFeel.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/TripletFeel.cs
@@ -3,48 +3,47 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+// ReSharper disable InconsistentNaming
+/// <summary>
+/// This public enumeration lists all feels of triplets.
+/// </summary>
+internal enum TripletFeel
 {
-    // ReSharper disable InconsistentNaming
     /// <summary>
-    /// This public enumeration lists all feels of triplets.
+    /// No triplet feel
     /// </summary>
-    internal enum TripletFeel
-    {
-        /// <summary>
-        /// No triplet feel
-        /// </summary>
-        NoTripletFeel,
+    NoTripletFeel,
 
-        /// <summary>
-        /// Triplet 16th
-        /// </summary>
-        Triplet16th,
+    /// <summary>
+    /// Triplet 16th
+    /// </summary>
+    Triplet16th,
 
-        /// <summary>
-        /// Triplet 8th
-        /// </summary>
-        Triplet8th,
+    /// <summary>
+    /// Triplet 8th
+    /// </summary>
+    Triplet8th,
 
-        /// <summary>
-        /// Dotted 16th
-        /// </summary>
-        Dotted16th,
+    /// <summary>
+    /// Dotted 16th
+    /// </summary>
+    Dotted16th,
 
-        /// <summary>
-        /// Dotted 8th
-        /// </summary>
-        Dotted8th,
+    /// <summary>
+    /// Dotted 8th
+    /// </summary>
+    Dotted8th,
 
-        /// <summary>
-        /// Scottish 16th
-        /// </summary>
-        Scottish16th,
+    /// <summary>
+    /// Scottish 16th
+    /// </summary>
+    Scottish16th,
 
-        /// <summary>
-        /// Scottish 8th
-        /// </summary>
-        Scottish8th
-    }
-    // ReSharper restore InconsistentNaming
+    /// <summary>
+    /// Scottish 8th
+    /// </summary>
+    Scottish8th
 }
+// ReSharper restore InconsistentNaming

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Tuning.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Tuning.cs
@@ -5,439 +5,438 @@
 
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// This public class represents a predefined string tuning.
+/// </summary>
+internal class Tuning
 {
-    /// <summary>
-    /// This public class represents a predefined string tuning.
-    /// </summary>
-    internal class Tuning
+    private static FastList<Tuning> _sevenStrings;
+    private static FastList<Tuning> _sixStrings;
+    private static FastList<Tuning> _fiveStrings;
+    private static FastList<Tuning> _fourStrings;
+    private static FastDictionary<int, Tuning> _defaultTunings;
+
+    internal static string GetTextForTuning(int tuning, bool includeOctave)
     {
-        private static FastList<Tuning> _sevenStrings;
-        private static FastList<Tuning> _sixStrings;
-        private static FastList<Tuning> _fiveStrings;
-        private static FastList<Tuning> _fourStrings;
-        private static FastDictionary<int, Tuning> _defaultTunings;
-
-        internal static string GetTextForTuning(int tuning, bool includeOctave)
+        var octave = tuning / 12;
+        var note = tuning % 12;
+        var notes = new[]
         {
-            var octave = tuning / 12;
-            var note = tuning % 12;
-            var notes = new[]
-            {
-                "C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"
-            };
-            var result = notes[note];
-            if (includeOctave)
-            {
-                result += octave - 1;
-            }
-
-            return result;
+            "C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"
+        };
+        var result = notes[note];
+        if (includeOctave)
+        {
+            result += octave - 1;
         }
 
-        /// <summary>
-        /// Gets the default tuning for the given string count. 
-        /// </summary>
-        /// <param name="stringCount">The string count. </param>
-        /// <returns>The tuning for the given string count or null if the string count is not defined. </returns>
-        public static Tuning GetDefaultTuningFor(int stringCount)
-        {
-            return _defaultTunings.ContainsKey(stringCount) ? _defaultTunings[stringCount] : null;
-        }
+        return result;
+    }
 
-        /// <summary>
-        /// Gets a list of all tuning presets for a given string count. 
-        /// </summary>
-        /// <param name="stringCount">The string count. </param>
-        /// <returns>The list of known tunings for the given string count or an empty list if the string count is not defined. </returns>
-        public static FastList<Tuning> GetPresetsFor(int stringCount)
+    /// <summary>
+    /// Gets the default tuning for the given string count. 
+    /// </summary>
+    /// <param name="stringCount">The string count. </param>
+    /// <returns>The tuning for the given string count or null if the string count is not defined. </returns>
+    public static Tuning GetDefaultTuningFor(int stringCount)
+    {
+        return _defaultTunings.ContainsKey(stringCount) ? _defaultTunings[stringCount] : null;
+    }
+
+    /// <summary>
+    /// Gets a list of all tuning presets for a given string count. 
+    /// </summary>
+    /// <param name="stringCount">The string count. </param>
+    /// <returns>The list of known tunings for the given string count or an empty list if the string count is not defined. </returns>
+    public static FastList<Tuning> GetPresetsFor(int stringCount)
+    {
+        return stringCount switch
         {
-            return stringCount switch
+            7 => _sevenStrings,
+            6 => _sixStrings,
+            5 => _fiveStrings,
+            4 => _fourStrings,
+            _ => new FastList<Tuning>()
+        };
+    }
+
+    static Tuning()
+    {
+        Initialize();
+    }
+
+    private static void Initialize()
+    {
+        _sevenStrings = new FastList<Tuning>();
+        _sixStrings   = new FastList<Tuning>();
+        _fiveStrings  = new FastList<Tuning>();
+        _fourStrings  = new FastList<Tuning>();
+        _defaultTunings = new FastDictionary<int, Tuning>
+        {
+            [7] = new("Guitar 7 strings",
+                new[]
+                {
+                    64, 59, 55, 50, 45, 40, 35
+                },
+                true)
+        };
+
+        _sevenStrings.Add(_defaultTunings[7]);
+
+        _defaultTunings[6] = new Tuning("Guitar Standard Tuning",
+            new[]
             {
-                7 => _sevenStrings,
-                6 => _sixStrings,
-                5 => _fiveStrings,
-                4 => _fourStrings,
-                _ => new FastList<Tuning>()
-            };
-        }
+                64, 59, 55, 50, 45, 40
+            },
+            true);
+        _sixStrings.Add(_defaultTunings[6]);
 
-        static Tuning()
-        {
-            Initialize();
-        }
-
-        private static void Initialize()
-        {
-            _sevenStrings   = new FastList<Tuning>();
-            _sixStrings     = new FastList<Tuning>();
-            _fiveStrings    = new FastList<Tuning>();
-            _fourStrings    = new FastList<Tuning>();
-            _defaultTunings = new FastDictionary<int, Tuning>
+        _sixStrings.Add(new Tuning("Guitar Tune down ½ step",
+            new[]
             {
-                [7] = new("Guitar 7 strings",
-                    new[]
-                    {
-                        64, 59, 55, 50, 45, 40, 35
-                    },
-                    true)
-            };
-
-            _sevenStrings.Add(_defaultTunings[7]);
-
-            _defaultTunings[6] = new Tuning("Guitar Standard Tuning",
-                new[]
-                {
-                    64, 59, 55, 50, 45, 40
-                },
-                true);
-            _sixStrings.Add(_defaultTunings[6]);
-
-            _sixStrings.Add(new Tuning("Guitar Tune down ½ step",
-                new[]
-                {
-                    63, 58, 54, 49, 44, 39
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Tune down 1 step",
-                new[]
-                {
-                    62, 57, 53, 48, 43, 38
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Tune down 2 step",
-                new[]
-                {
-                    60, 55, 51, 46, 41, 36
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Dropped D Tuning",
-                new[]
-                {
-                    64, 59, 55, 50, 45, 38
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Dropped D Tuning variant",
-                new[]
-                {
-                    64, 57, 55, 50, 45, 38
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Double Dropped D Tuning",
-                new[]
-                {
-                    62, 59, 55, 50, 45, 38
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Dropped E Tuning",
-                new[]
-                {
-                    66, 61, 57, 52, 47, 40
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Dropped C Tuning",
-                new[]
-                {
-                    62, 57, 53, 48, 43, 36
-                },
-                false));
-
-            _sixStrings.Add(new Tuning("Guitar Open C Tuning",
-                new[]
-                {
-                    64, 60, 55, 48, 43, 36
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open Cm Tuning",
-                new[]
-                {
-                    63, 60, 55, 48, 43, 36
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open C6 Tuning",
-                new[]
-                {
-                    64, 57, 55, 48, 43, 36
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open Cmaj7 Tuning",
-                new[]
-                {
-                    64, 59, 55, 52, 43, 36
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open D Tuning",
-                new[]
-                {
-                    62, 57, 54, 50, 45, 38
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open Dm Tuning",
-                new[]
-                {
-                    62, 57, 53, 50, 45, 38
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open D5 Tuning",
-                new[]
-                {
-                    62, 57, 50, 50, 45, 38
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open D6 Tuning",
-                new[]
-                {
-                    62, 59, 54, 50, 45, 38
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open Dsus4 Tuning",
-                new[]
-                {
-                    62, 57, 55, 50, 45, 38
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open E Tuning",
-                new[]
-                {
-                    64, 59, 56, 52, 47, 40
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open Em Tuning",
-                new[]
-                {
-                    64, 59, 55, 52, 47, 40
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open Esus11 Tuning",
-                new[]
-                {
-                    64, 59, 55, 52, 45, 40
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open F Tuning",
-                new[]
-                {
-                    65, 60, 53, 48, 45, 41
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open G Tuning",
-                new[]
-                {
-                    62, 59, 55, 50, 43, 38
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open Gm Tuning",
-                new[]
-                {
-                    62, 58, 55, 50, 43, 38
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open G6 Tuning",
-                new[]
-                {
-                    64, 59, 55, 50, 43, 38
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open Gsus4 Tuning",
-                new[]
-                {
-                    62, 60, 55, 50, 43, 38
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open A Tuning",
-                new[]
-                {
-                    64, 61, 57, 52, 45, 40
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Open Am Tuning",
-                new[]
-                {
-                    64, 60, 57, 52, 45, 40
-                },
-                false));
-            _sixStrings.Add(new Tuning("Guitar Nashville Tuning",
-                new[]
-                {
-                    64, 59, 67, 62, 57, 52
-                },
-                false));
-            _sixStrings.Add(new Tuning("Bass 6 Strings Tuning",
-                new[]
-                {
-                    48, 43, 38, 33, 28, 23
-                },
-                false));
-            _sixStrings.Add(new Tuning("Lute or Vihuela Tuning",
-                new[]
-                {
-                    64, 59, 54, 50, 45, 40
-                },
-                false));
-
-            _defaultTunings[5] = new Tuning("Bass 5 Strings Tuning",
-                new[]
-                {
-                    43, 38, 33, 28, 23
-                },
-                true);
-            _fiveStrings.Add(_defaultTunings[5]);
-            _fiveStrings.Add(new Tuning("Banjo Dropped C Tuning",
-                new[]
-                {
-                    62, 59, 55, 48, 67
-                },
-                false));
-            _fiveStrings.Add(new Tuning("Banjo Open D Tuning",
-                new[]
-                {
-                    62, 57, 54, 50, 69
-                },
-                false));
-            _fiveStrings.Add(new Tuning("Banjo Open G Tuning",
-                new[]
-                {
-                    62, 59, 55, 50, 67
-                },
-                false));
-            _fiveStrings.Add(new Tuning("Banjo G Minor Tuning",
-                new[]
-                {
-                    62, 58, 55, 50, 67
-                },
-                false));
-            _fiveStrings.Add(new Tuning("Banjo G Modal Tuning",
-                new[]
-                {
-                    62, 57, 55, 50, 67
-                },
-                false));
-
-            _defaultTunings[4] = new Tuning("Bass Standard Tuning",
-                new[]
-                {
-                    43, 38, 33, 28
-                },
-                true);
-            _fourStrings.Add(_defaultTunings[4]);
-            _fourStrings.Add(new Tuning("Bass Tune down ½ step",
-                new[]
-                {
-                    42, 37, 32, 27
-                },
-                false));
-            _fourStrings.Add(new Tuning("Bass Tune down 1 step",
-                new[]
-                {
-                    41, 36, 31, 26
-                },
-                false));
-            _fourStrings.Add(new Tuning("Bass Tune down 2 step",
-                new[]
-                {
-                    39, 34, 29, 24
-                },
-                false));
-            _fourStrings.Add(new Tuning("Bass Dropped D Tuning",
-                new[]
-                {
-                    43, 38, 33, 26
-                },
-                false));
-            _fourStrings.Add(new Tuning("Ukulele C Tuning",
-                new[]
-                {
-                    45, 40, 36, 43
-                },
-                false));
-            _fourStrings.Add(new Tuning("Ukulele G Tuning",
-                new[]
-                {
-                    52, 47, 43, 38
-                },
-                false));
-            _fourStrings.Add(new Tuning("Mandolin Standard Tuning",
-                new[]
-                {
-                    64, 57, 50, 43
-                },
-                false));
-            _fourStrings.Add(new Tuning("Mandolin or Violin Tuning",
-                new[]
-                {
-                    76, 69, 62, 55
-                },
-                false));
-            _fourStrings.Add(new Tuning("Viola Tuning",
-                new[]
-                {
-                    69, 62, 55, 48
-                },
-                false));
-            _fourStrings.Add(new Tuning("Cello Tuning",
-                new[]
-                {
-                    57, 50, 43, 36
-                },
-                false));
-        }
-
-        /// <summary>
-        /// Tries to find a known tuning by a given list of tuning values. 
-        /// </summary>
-        /// <param name="strings">The values defining the tuning. </param>
-        /// <returns>The known tuning. </returns>
-        public static Tuning FindTuning(int[] strings)
-        {
-            var tunings = GetPresetsFor(strings.Length);
-            for (int t = 0, tc = tunings.Count; t < tc; t++)
+                63, 58, 54, 49, 44, 39
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Tune down 1 step",
+            new[]
             {
-                var tuning = tunings[t];
-                var equals = true;
-                for (int i = 0, j = strings.Length; i < j; i++)
-                {
-                    if (strings[i] != tuning.Tunings[i])
-                    {
-                        equals = false;
-                        break;
-                    }
-                }
+                62, 57, 53, 48, 43, 38
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Tune down 2 step",
+            new[]
+            {
+                60, 55, 51, 46, 41, 36
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Dropped D Tuning",
+            new[]
+            {
+                64, 59, 55, 50, 45, 38
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Dropped D Tuning variant",
+            new[]
+            {
+                64, 57, 55, 50, 45, 38
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Double Dropped D Tuning",
+            new[]
+            {
+                62, 59, 55, 50, 45, 38
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Dropped E Tuning",
+            new[]
+            {
+                66, 61, 57, 52, 47, 40
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Dropped C Tuning",
+            new[]
+            {
+                62, 57, 53, 48, 43, 36
+            },
+            false));
 
-                if (equals)
+        _sixStrings.Add(new Tuning("Guitar Open C Tuning",
+            new[]
+            {
+                64, 60, 55, 48, 43, 36
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open Cm Tuning",
+            new[]
+            {
+                63, 60, 55, 48, 43, 36
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open C6 Tuning",
+            new[]
+            {
+                64, 57, 55, 48, 43, 36
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open Cmaj7 Tuning",
+            new[]
+            {
+                64, 59, 55, 52, 43, 36
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open D Tuning",
+            new[]
+            {
+                62, 57, 54, 50, 45, 38
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open Dm Tuning",
+            new[]
+            {
+                62, 57, 53, 50, 45, 38
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open D5 Tuning",
+            new[]
+            {
+                62, 57, 50, 50, 45, 38
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open D6 Tuning",
+            new[]
+            {
+                62, 59, 54, 50, 45, 38
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open Dsus4 Tuning",
+            new[]
+            {
+                62, 57, 55, 50, 45, 38
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open E Tuning",
+            new[]
+            {
+                64, 59, 56, 52, 47, 40
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open Em Tuning",
+            new[]
+            {
+                64, 59, 55, 52, 47, 40
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open Esus11 Tuning",
+            new[]
+            {
+                64, 59, 55, 52, 45, 40
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open F Tuning",
+            new[]
+            {
+                65, 60, 53, 48, 45, 41
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open G Tuning",
+            new[]
+            {
+                62, 59, 55, 50, 43, 38
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open Gm Tuning",
+            new[]
+            {
+                62, 58, 55, 50, 43, 38
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open G6 Tuning",
+            new[]
+            {
+                64, 59, 55, 50, 43, 38
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open Gsus4 Tuning",
+            new[]
+            {
+                62, 60, 55, 50, 43, 38
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open A Tuning",
+            new[]
+            {
+                64, 61, 57, 52, 45, 40
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Open Am Tuning",
+            new[]
+            {
+                64, 60, 57, 52, 45, 40
+            },
+            false));
+        _sixStrings.Add(new Tuning("Guitar Nashville Tuning",
+            new[]
+            {
+                64, 59, 67, 62, 57, 52
+            },
+            false));
+        _sixStrings.Add(new Tuning("Bass 6 Strings Tuning",
+            new[]
+            {
+                48, 43, 38, 33, 28, 23
+            },
+            false));
+        _sixStrings.Add(new Tuning("Lute or Vihuela Tuning",
+            new[]
+            {
+                64, 59, 54, 50, 45, 40
+            },
+            false));
+
+        _defaultTunings[5] = new Tuning("Bass 5 Strings Tuning",
+            new[]
+            {
+                43, 38, 33, 28, 23
+            },
+            true);
+        _fiveStrings.Add(_defaultTunings[5]);
+        _fiveStrings.Add(new Tuning("Banjo Dropped C Tuning",
+            new[]
+            {
+                62, 59, 55, 48, 67
+            },
+            false));
+        _fiveStrings.Add(new Tuning("Banjo Open D Tuning",
+            new[]
+            {
+                62, 57, 54, 50, 69
+            },
+            false));
+        _fiveStrings.Add(new Tuning("Banjo Open G Tuning",
+            new[]
+            {
+                62, 59, 55, 50, 67
+            },
+            false));
+        _fiveStrings.Add(new Tuning("Banjo G Minor Tuning",
+            new[]
+            {
+                62, 58, 55, 50, 67
+            },
+            false));
+        _fiveStrings.Add(new Tuning("Banjo G Modal Tuning",
+            new[]
+            {
+                62, 57, 55, 50, 67
+            },
+            false));
+
+        _defaultTunings[4] = new Tuning("Bass Standard Tuning",
+            new[]
+            {
+                43, 38, 33, 28
+            },
+            true);
+        _fourStrings.Add(_defaultTunings[4]);
+        _fourStrings.Add(new Tuning("Bass Tune down ½ step",
+            new[]
+            {
+                42, 37, 32, 27
+            },
+            false));
+        _fourStrings.Add(new Tuning("Bass Tune down 1 step",
+            new[]
+            {
+                41, 36, 31, 26
+            },
+            false));
+        _fourStrings.Add(new Tuning("Bass Tune down 2 step",
+            new[]
+            {
+                39, 34, 29, 24
+            },
+            false));
+        _fourStrings.Add(new Tuning("Bass Dropped D Tuning",
+            new[]
+            {
+                43, 38, 33, 26
+            },
+            false));
+        _fourStrings.Add(new Tuning("Ukulele C Tuning",
+            new[]
+            {
+                45, 40, 36, 43
+            },
+            false));
+        _fourStrings.Add(new Tuning("Ukulele G Tuning",
+            new[]
+            {
+                52, 47, 43, 38
+            },
+            false));
+        _fourStrings.Add(new Tuning("Mandolin Standard Tuning",
+            new[]
+            {
+                64, 57, 50, 43
+            },
+            false));
+        _fourStrings.Add(new Tuning("Mandolin or Violin Tuning",
+            new[]
+            {
+                76, 69, 62, 55
+            },
+            false));
+        _fourStrings.Add(new Tuning("Viola Tuning",
+            new[]
+            {
+                69, 62, 55, 48
+            },
+            false));
+        _fourStrings.Add(new Tuning("Cello Tuning",
+            new[]
+            {
+                57, 50, 43, 36
+            },
+            false));
+    }
+
+    /// <summary>
+    /// Tries to find a known tuning by a given list of tuning values. 
+    /// </summary>
+    /// <param name="strings">The values defining the tuning. </param>
+    /// <returns>The known tuning. </returns>
+    public static Tuning FindTuning(int[] strings)
+    {
+        var tunings = GetPresetsFor(strings.Length);
+        for (int t = 0, tc = tunings.Count; t < tc; t++)
+        {
+            var tuning = tunings[t];
+            var equals = true;
+            for (int i = 0, j = strings.Length; i < j; i++)
+            {
+                if (strings[i] != tuning.Tunings[i])
                 {
-                    return tuning;
+                    equals = false;
+                    break;
                 }
             }
 
-            return null;
+            if (equals)
+            {
+                return tuning;
+            }
         }
 
-        /// <summary>
-        /// Gets or sets whether this is the standard tuning for this number of strings. 
-        /// </summary>
-        public bool IsStandard { get; set; }
+        return null;
+    }
 
-        /// <summary>
-        /// Gets or sets the name of the tuning. 
-        /// </summary>
-        public string Name { get; set; }
+    /// <summary>
+    /// Gets or sets whether this is the standard tuning for this number of strings. 
+    /// </summary>
+    public bool IsStandard { get; set; }
 
-        /// <summary>
-        /// Gets or sets the values for each string of the instrument. 
-        /// </summary>
-        public int[] Tunings { get; set; }
+    /// <summary>
+    /// Gets or sets the name of the tuning. 
+    /// </summary>
+    public string Name { get; set; }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Tuning"/> class.
-        /// </summary>
-        /// <param name="name">The name.</param>
-        /// <param name="tuning">The tuning.</param>
-        /// <param name="isStandard">if set to <c>true</c> [is standard].</param>
-        public Tuning(string name, int[] tuning, bool isStandard)
-        {
-            IsStandard = isStandard;
-            Name = name;
-            Tunings = tuning;
-        }
+    /// <summary>
+    /// Gets or sets the values for each string of the instrument. 
+    /// </summary>
+    public int[] Tunings { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Tuning"/> class.
+    /// </summary>
+    /// <param name="name">The name.</param>
+    /// <param name="tuning">The tuning.</param>
+    /// <param name="isStandard">if set to <c>true</c> [is standard].</param>
+    public Tuning(string name, int[] tuning, bool isStandard)
+    {
+        IsStandard = isStandard;
+        Name       = name;
+        Tunings    = tuning;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Tuning.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Tuning.cs
@@ -42,34 +42,24 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
         /// <returns>The tuning for the given string count or null if the string count is not defined. </returns>
         public static Tuning GetDefaultTuningFor(int stringCount)
         {
-            if (_defaultTunings.ContainsKey(stringCount))
-            {
-                return _defaultTunings[stringCount];
-            }
-
-            return null;
+            return _defaultTunings.ContainsKey(stringCount) ? _defaultTunings[stringCount] : null;
         }
 
         /// <summary>
-        /// Gets a list of all tuning presets for a given stirng count. 
+        /// Gets a list of all tuning presets for a given string count. 
         /// </summary>
         /// <param name="stringCount">The string count. </param>
         /// <returns>The list of known tunings for the given string count or an empty list if the string count is not defined. </returns>
         public static FastList<Tuning> GetPresetsFor(int stringCount)
         {
-            switch (stringCount)
+            return stringCount switch
             {
-                case 7:
-                    return _sevenStrings;
-                case 6:
-                    return _sixStrings;
-                case 5:
-                    return _fiveStrings;
-                case 4:
-                    return _fourStrings;
-            }
-
-            return new FastList<Tuning>();
+                7 => _sevenStrings,
+                6 => _sixStrings,
+                5 => _fiveStrings,
+                4 => _fourStrings,
+                _ => new FastList<Tuning>()
+            };
         }
 
         static Tuning()
@@ -79,18 +69,20 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
 
         private static void Initialize()
         {
-            _sevenStrings = new FastList<Tuning>();
-            _sixStrings = new FastList<Tuning>();
-            _fiveStrings = new FastList<Tuning>();
-            _fourStrings = new FastList<Tuning>();
-            _defaultTunings = new FastDictionary<int, Tuning>();
+            _sevenStrings   = new FastList<Tuning>();
+            _sixStrings     = new FastList<Tuning>();
+            _fiveStrings    = new FastList<Tuning>();
+            _fourStrings    = new FastList<Tuning>();
+            _defaultTunings = new FastDictionary<int, Tuning>
+            {
+                [7] = new("Guitar 7 strings",
+                    new[]
+                    {
+                        64, 59, 55, 50, 45, 40, 35
+                    },
+                    true)
+            };
 
-            _defaultTunings[7] = new Tuning("Guitar 7 strings",
-                new[]
-                {
-                    64, 59, 55, 50, 45, 40, 35
-                },
-                true);
             _sevenStrings.Add(_defaultTunings[7]);
 
             _defaultTunings[6] = new Tuning("Guitar Standard Tuning",

--- a/BardMusicPlayer.Siren/AlphaTab/Model/TuningParser.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/TuningParser.cs
@@ -5,132 +5,131 @@
 
 using System.Linq;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
-{
-    internal class TuningParseResult
-    {
-        public string Note { get; set; }
-        public int NoteValue { get; set; }
-        public int Octave { get; set; }
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
 
-        public int RealValue => Octave * 12 + NoteValue;
+internal class TuningParseResult
+{
+    public string Note { get; set; }
+    public int NoteValue { get; set; }
+    public int Octave { get; set; }
+
+    public int RealValue => Octave * 12 + NoteValue;
+}
+
+internal static class TuningParser
+{
+    /// <summary>
+    /// Checks if the given string is a tuning indicator.
+    /// </summary>Checks if the given string is a tuning indicator.
+    /// <param name="name"></param>
+    /// <returns></returns>
+    public static bool IsTuning(string name)
+    {
+        return Parse(name) != null;
     }
 
-    internal static class TuningParser
+    public static TuningParseResult Parse(string name)
     {
-        /// <summary>
-        /// Checks if the given string is a tuning indicator.
-        /// </summary>Checks if the given string is a tuning indicator.
-        /// <param name="name"></param>
-        /// <returns></returns>
-        public static bool IsTuning(string name)
-        {
-            return Parse(name) != null;
-        }
+        var note = "";
+        var octave = "";
 
-        public static TuningParseResult Parse(string name)
+        foreach (var c in name.Select(t => (int)t))
         {
-            var note = "";
-            var octave = "";
-
-            foreach (var c in name.Select(t => (int)t))
+            if (Platform.IsCharNumber(c, false))
             {
-                if (Platform.IsCharNumber(c, false))
-                {
-                    // number without note?
-                    if (string.IsNullOrEmpty(note))
-                    {
-                        return null;
-                    }
-
-                    octave += Platform.StringFromCharCode(c);
-                }
-                else if (c is >= 0x41 and <= 0x5A or >= 0x61 and <= 0x7A or 0x23)
-                {
-                    note += Platform.StringFromCharCode(c);
-                }
-                else
+                // number without note?
+                if (string.IsNullOrEmpty(note))
                 {
                     return null;
                 }
-            }
 
-            if (string.IsNullOrEmpty(octave) || string.IsNullOrEmpty(note))
+                octave += Platform.StringFromCharCode(c);
+            }
+            else if (c is >= 0x41 and <= 0x5A or >= 0x61 and <= 0x7A or 0x23)
+            {
+                note += Platform.StringFromCharCode(c);
+            }
+            else
             {
                 return null;
             }
-
-            var result = new TuningParseResult
-            {
-                Octave = Platform.ParseInt(octave) + 1,
-                Note   = note.ToLower()
-            };
-            result.NoteValue = GetToneForText(result.Note);
-            return result;
         }
 
-        public static int GetTuningForText(string str)
+        if (string.IsNullOrEmpty(octave) || string.IsNullOrEmpty(note))
         {
-            var result = Parse(str);
-            if (result == null)
-            {
-                return -1;
-            }
-
-            return result.RealValue;
+            return null;
         }
 
-        public static int GetToneForText(string note)
+        var result = new TuningParseResult
         {
-            int b;
-            switch (note.ToLower())
-            {
-                case "c":
-                    b = 0;
-                    break;
-                case "c#":
-                case "db":
-                    b = 1;
-                    break;
-                case "d":
-                    b = 2;
-                    break;
-                case "d#":
-                case "eb":
-                    b = 3;
-                    break;
-                case "e":
-                    b = 4;
-                    break;
-                case "f":
-                    b = 5;
-                    break;
-                case "f#":
-                case "gb":
-                    b = 6;
-                    break;
-                case "g":
-                    b = 7;
-                    break;
-                case "g#":
-                case "ab":
-                    b = 8;
-                    break;
-                case "a":
-                    b = 9;
-                    break;
-                case "a#":
-                case "bb":
-                    b = 10;
-                    break;
-                case "b":
-                    b = 11;
-                    break;
-                default:
-                    return 0;
-            }
+            Octave = Platform.ParseInt(octave) + 1,
+            Note   = note.ToLower()
+        };
+        result.NoteValue = GetToneForText(result.Note);
+        return result;
+    }
 
-            return b;
+    public static int GetTuningForText(string str)
+    {
+        var result = Parse(str);
+        if (result == null)
+        {
+            return -1;
         }
+
+        return result.RealValue;
+    }
+
+    public static int GetToneForText(string note)
+    {
+        int b;
+        switch (note.ToLower())
+        {
+            case "c":
+                b = 0;
+                break;
+            case "c#":
+            case "db":
+                b = 1;
+                break;
+            case "d":
+                b = 2;
+                break;
+            case "d#":
+            case "eb":
+                b = 3;
+                break;
+            case "e":
+                b = 4;
+                break;
+            case "f":
+                b = 5;
+                break;
+            case "f#":
+            case "gb":
+                b = 6;
+                break;
+            case "g":
+                b = 7;
+                break;
+            case "g#":
+            case "ab":
+                b = 8;
+                break;
+            case "a":
+                b = 9;
+                break;
+            case "a#":
+            case "bb":
+                b = 10;
+                break;
+            case "b":
+                b = 11;
+                break;
+            default:
+                return 0;
+        }
+
+        return b;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/TuningParser.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/TuningParser.cs
@@ -3,6 +3,8 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
+using System.Linq;
+
 namespace BardMusicPlayer.Siren.AlphaTab.Model
 {
     internal class TuningParseResult
@@ -17,8 +19,8 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
     internal static class TuningParser
     {
         /// <summary>
-        /// Checks if the given string is a tuning inticator.
-        /// </summary>Checks if the given string is a tuning inticator.
+        /// Checks if the given string is a tuning indicator.
+        /// </summary>Checks if the given string is a tuning indicator.
         /// <param name="name"></param>
         /// <returns></returns>
         public static bool IsTuning(string name)
@@ -31,9 +33,8 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
             var note = "";
             var octave = "";
 
-            for (var i = 0; i < name.Length; i++)
+            foreach (var c in name.Select(t => (int)t))
             {
-                var c = (int)name[i];
                 if (Platform.IsCharNumber(c, false))
                 {
                     // number without note?
@@ -44,7 +45,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
 
                     octave += Platform.StringFromCharCode(c);
                 }
-                else if (c >= 0x41 && c <= 0x5A || c >= 0x61 && c <= 0x7A || c == 0x23)
+                else if (c is >= 0x41 and <= 0x5A or >= 0x61 and <= 0x7A or 0x23)
                 {
                     note += Platform.StringFromCharCode(c);
                 }
@@ -59,9 +60,11 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
                 return null;
             }
 
-            var result = new TuningParseResult();
-            result.Octave = Platform.ParseInt(octave) + 1;
-            result.Note = note.ToLower();
+            var result = new TuningParseResult
+            {
+                Octave = Platform.ParseInt(octave) + 1,
+                Note   = note.ToLower()
+            };
             result.NoteValue = GetToneForText(result.Note);
             return result;
         }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/TupletGroup.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/TupletGroup.cs
@@ -5,128 +5,127 @@
 
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Represents a list of beats that are grouped within the same tuplet.
+/// </summary>
+internal class TupletGroup
 {
+    public int _totalDuration;
+    private bool _isEqualLengthTuplet = true;
+
     /// <summary>
-    /// Represents a list of beats that are grouped within the same tuplet.
+    /// Gets or sets the list of beats contained in this group.
     /// </summary>
-    internal class TupletGroup
+    public FastList<Beat> Beats { get; set; }
+
+    /// <summary>
+    /// Gets or sets the voice this group belongs to.
+    /// </summary>
+    public Voice Voice { get; set; }
+
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TupletGroup"/> class.
+    /// </summary>
+    /// <param name="voice">The voice this group belongs to.</param>
+    public TupletGroup(Voice voice)
     {
-        public int _totalDuration;
-        private bool _isEqualLengthTuplet = true;
+        Voice = voice;
+        Beats = new FastList<Beat>();
+    }
 
-        /// <summary>
-        /// Gets or sets the list of beats contained in this group.
-        /// </summary>
-        public FastList<Beat> Beats { get; set; }
+    /// <summary>
+    /// Gets a value indicating whether the tuplet group is fully filled.
+    /// </summary>
+    public bool IsFull
+    {
+        get;
+        private set;
+    }
 
-        /// <summary>
-        /// Gets or sets the voice this group belongs to.
-        /// </summary>
-        public Voice Voice { get; set; }
+
+    private const int HalfTicks = 1920;
+    private const int QuarterTicks = 960;
+    private const int EighthTicks = 480;
+    private const int SixteenthTicks = 240;
+    private const int ThirtySecondTicks = 120;
+    private const int SixtyFourthTicks = 60;
+    private const int OneHundredTwentyEighthTicks = 30;
+    private const int TwoHundredFiftySixthTicks = 15;
 
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TupletGroup"/> class.
-        /// </summary>
-        /// <param name="voice">The voice this group belongs to.</param>
-        public TupletGroup(Voice voice)
+    private static readonly int[] AllTicks =
+    {
+        HalfTicks, QuarterTicks, EighthTicks, SixteenthTicks, ThirtySecondTicks, SixtyFourthTicks,
+        OneHundredTwentyEighthTicks, TwoHundredFiftySixthTicks
+    };
+
+    internal bool Check(Beat beat)
+    {
+        if (Beats.Count == 0)
         {
-            Voice = voice;
-            Beats = new FastList<Beat>();
-        }
-
-        /// <summary>
-        /// Gets a value indicating whether the tuplet group is fully filled.
-        /// </summary>
-        public bool IsFull
-        {
-            get;
-            private set;
-        }
-
-
-        private const int HalfTicks = 1920;
-        private const int QuarterTicks = 960;
-        private const int EighthTicks = 480;
-        private const int SixteenthTicks = 240;
-        private const int ThirtySecondTicks = 120;
-        private const int SixtyFourthTicks = 60;
-        private const int OneHundredTwentyEighthTicks = 30;
-        private const int TwoHundredFiftySixthTicks = 15;
-
-
-        private static readonly int[] AllTicks =
-        {
-            HalfTicks, QuarterTicks, EighthTicks, SixteenthTicks, ThirtySecondTicks, SixtyFourthTicks,
-            OneHundredTwentyEighthTicks, TwoHundredFiftySixthTicks
-        };
-
-        internal bool Check(Beat beat)
-        {
-            if (Beats.Count == 0)
-            {
-                // accept first beat
-                Beats.Add(beat);
-                _totalDuration += beat.PlaybackDuration;
-                return true;
-            }
-
-            if (beat.GraceType != GraceType.None)
-            {
-                // grace notes do not break tuplet group, but also do not contribute to them.
-                return true;
-            }
-
-            if (beat.Voice != Voice
-                || IsFull
-                || beat.TupletNumerator != Beats[0].TupletNumerator
-                || beat.TupletDenominator != Beats[0].TupletDenominator)
-            {
-                // only same tuplets are potentially accepted
-                return false;
-            }
-
-            // TBH: I do not really know how the 100% tuplet grouping of Guitar Pro might work
-            // it sometimes has really strange rules where notes filling 3 quarters, are considered a full 3:2 tuplet
-
-            // in alphaTab we have now 2 rules where we consider a tuplet full:
-            // 1. if all beats have the same length, the tuplet must contain N notes of an N:M tuplet
-            // 2. if we have mixed beats, we check if the current set of beats, matches a N:M tuplet
-            //    by checking all potential note durations.
-
-            // this logic is very likely not 100% correct but for most cases the tuplets
-            // appeared correct.
-
-            if (beat.PlaybackDuration != Beats[0].PlaybackDuration)
-            {
-                _isEqualLengthTuplet = false;
-            }
-
+            // accept first beat
             Beats.Add(beat);
             _totalDuration += beat.PlaybackDuration;
-
-            if (_isEqualLengthTuplet)
-            {
-                if (Beats.Count == Beats[0].TupletNumerator)
-                {
-                    IsFull = true;
-                }
-            }
-            else
-            {
-                var factor = Beats[0].TupletNumerator / Beats[0].TupletDenominator;
-                foreach (var potentialMatch in AllTicks)
-                {
-                    if (_totalDuration == potentialMatch * factor)
-                    {
-                        IsFull = true;
-                        break;
-                    }
-                }
-            }
-
             return true;
         }
+
+        if (beat.GraceType != GraceType.None)
+        {
+            // grace notes do not break tuplet group, but also do not contribute to them.
+            return true;
+        }
+
+        if (beat.Voice != Voice
+            || IsFull
+            || beat.TupletNumerator != Beats[0].TupletNumerator
+            || beat.TupletDenominator != Beats[0].TupletDenominator)
+        {
+            // only same tuplets are potentially accepted
+            return false;
+        }
+
+        // TBH: I do not really know how the 100% tuplet grouping of Guitar Pro might work
+        // it sometimes has really strange rules where notes filling 3 quarters, are considered a full 3:2 tuplet
+
+        // in alphaTab we have now 2 rules where we consider a tuplet full:
+        // 1. if all beats have the same length, the tuplet must contain N notes of an N:M tuplet
+        // 2. if we have mixed beats, we check if the current set of beats, matches a N:M tuplet
+        //    by checking all potential note durations.
+
+        // this logic is very likely not 100% correct but for most cases the tuplets
+        // appeared correct.
+
+        if (beat.PlaybackDuration != Beats[0].PlaybackDuration)
+        {
+            _isEqualLengthTuplet = false;
+        }
+
+        Beats.Add(beat);
+        _totalDuration += beat.PlaybackDuration;
+
+        if (_isEqualLengthTuplet)
+        {
+            if (Beats.Count == Beats[0].TupletNumerator)
+            {
+                IsFull = true;
+            }
+        }
+        else
+        {
+            var factor = Beats[0].TupletNumerator / Beats[0].TupletDenominator;
+            foreach (var potentialMatch in AllTicks)
+            {
+                if (_totalDuration == potentialMatch * factor)
+                {
+                    IsFull = true;
+                    break;
+                }
+            }
+        }
+
+        return true;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/VibratoType.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/VibratoType.cs
@@ -3,26 +3,25 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// This public enum lists all vibrato types that can be performed.
+/// </summary>
+internal enum VibratoType
 {
     /// <summary>
-    /// This public enum lists all vibrato types that can be performed.
+    /// No vibrato.
     /// </summary>
-    internal enum VibratoType
-    {
-        /// <summary>
-        /// No vibrato.
-        /// </summary>
-        None,
+    None,
 
-        /// <summary>
-        /// A slight vibrato. 
-        /// </summary>
-        Slight,
+    /// <summary>
+    /// A slight vibrato. 
+    /// </summary>
+    Slight,
 
-        /// <summary>
-        /// A wide vibrato.
-        /// </summary>
-        Wide
-    }
+    /// <summary>
+    /// A wide vibrato.
+    /// </summary>
+    Wide
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Voice.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Voice.cs
@@ -130,12 +130,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
 
         internal Beat GetBeatAtDisplayStart(int displayStart)
         {
-            if (_beatLookup.ContainsKey(displayStart))
-            {
-                return _beatLookup[displayStart];
-            }
-
-            return null;
+            return _beatLookup.ContainsKey(displayStart) ? _beatLookup[displayStart] : null;
         }
 
         internal void Finish()
@@ -156,7 +151,7 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
                 beat.Index = i;
                 beat.Finish();
 
-                if (beat.GraceType == GraceType.None || beat.GraceType == GraceType.BendGrace)
+                if (beat.GraceType is GraceType.None or GraceType.BendGrace)
                 {
                     beat.DisplayStart = currentDisplayTick;
                     beat.PlaybackStart = currentPlaybackTick;
@@ -176,27 +171,17 @@ namespace BardMusicPlayer.Siren.AlphaTab.Model
                             numberOfGraceBeats++;
                         }
 
-                        var graceDuration = Duration.Eighth;
                         var stolenDuration = 0;
-                        if (numberOfGraceBeats == 1)
+                        var graceDuration = numberOfGraceBeats switch
                         {
-                            graceDuration = Duration.Eighth;
-                        }
-                        else if (numberOfGraceBeats == 2)
-                        {
-                            graceDuration = Duration.Sixteenth;
-                        }
-                        else
-                        {
-                            graceDuration = Duration.ThirtySecond;
-                        }
+                            1 => Duration.Eighth,
+                            2 => Duration.Sixteenth,
+                            _ => Duration.ThirtySecond
+                        };
 
-                        if (nonGrace != null)
-                        {
-                            nonGrace.UpdateDurations();
-                        }
+                        nonGrace?.UpdateDurations();
 
-                        // grace beats have 1/4 size of the non grace beat preceeding them
+                        // grace beats have 1/4 size of the non grace beat preceding them
                         var perGraceDisplayDuration = beat.PreviousBeat == null
                             ? Duration.ThirtySecond.ToTicks()
                             : beat.PreviousBeat.DisplayDuration / 4 / numberOfGraceBeats;

--- a/BardMusicPlayer.Siren/AlphaTab/Model/Voice.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/Voice.cs
@@ -6,236 +6,235 @@
 using BardMusicPlayer.Siren.AlphaTab.Audio;
 using BardMusicPlayer.Siren.AlphaTab.Collections;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// A voice represents a group of beats 
+/// that can be played during a bar. 
+/// </summary>
+internal class Voice
 {
+    private FastDictionary<int, Beat> _beatLookup;
+
     /// <summary>
-    /// A voice represents a group of beats 
-    /// that can be played during a bar. 
+    /// Gets or sets the zero-based index of this voice within the bar. 
     /// </summary>
-    internal class Voice
+    public int Index { get; set; }
+
+    /// <summary>
+    /// Gets or sets the reference to the bar this voice belongs to. 
+    /// </summary>
+    public Bar Bar { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of beats contained in this voice. 
+    /// </summary>
+    public FastList<Beat> Beats { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this voice is empty. 
+    /// </summary>
+    public bool IsEmpty
     {
-        private FastDictionary<int, Beat> _beatLookup;
+        get;
+        set;
+    }
 
-        /// <summary>
-        /// Gets or sets the zero-based index of this voice within the bar. 
-        /// </summary>
-        public int Index { get; set; }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Voice"/> class.
+    /// </summary>
+    public Voice()
+    {
+        Beats   = new FastList<Beat>();
+        IsEmpty = true;
+    }
 
-        /// <summary>
-        /// Gets or sets the reference to the bar this voice belongs to. 
-        /// </summary>
-        public Bar Bar { get; set; }
+    internal static void CopyTo(Voice src, Voice dst)
+    {
+        dst.Index   = src.Index;
+        dst.IsEmpty = src.IsEmpty;
+    }
 
-        /// <summary>
-        /// Gets or sets the list of beats contained in this voice. 
-        /// </summary>
-        public FastList<Beat> Beats { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether this voice is empty. 
-        /// </summary>
-        public bool IsEmpty
+    internal void InsertBeat(Beat after, Beat newBeat)
+    {
+        newBeat.NextBeat = after.NextBeat;
+        if (newBeat.NextBeat != null)
         {
-            get;
-            set;
+            newBeat.NextBeat.PreviousBeat = newBeat;
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Voice"/> class.
-        /// </summary>
-        public Voice()
+        newBeat.PreviousBeat = after;
+        newBeat.Voice        = this;
+        after.NextBeat       = newBeat;
+        Beats.InsertAt(after.Index + 1, newBeat);
+    }
+
+
+    internal void AddBeat(Beat beat)
+    {
+        beat.Voice = this;
+        beat.Index = Beats.Count;
+        Beats.Add(beat);
+        if (!beat.IsEmpty)
         {
-            Beats = new FastList<Beat>();
-            IsEmpty = true;
-        }
-
-        internal static void CopyTo(Voice src, Voice dst)
-        {
-            dst.Index = src.Index;
-            dst.IsEmpty = src.IsEmpty;
-        }
-
-        internal void InsertBeat(Beat after, Beat newBeat)
-        {
-            newBeat.NextBeat = after.NextBeat;
-            if (newBeat.NextBeat != null)
-            {
-                newBeat.NextBeat.PreviousBeat = newBeat;
-            }
-
-            newBeat.PreviousBeat = after;
-            newBeat.Voice = this;
-            after.NextBeat = newBeat;
-            Beats.InsertAt(after.Index + 1, newBeat);
-        }
-
-
-        internal void AddBeat(Beat beat)
-        {
-            beat.Voice = this;
-            beat.Index = Beats.Count;
-            Beats.Add(beat);
-            if (!beat.IsEmpty)
-            {
-                IsEmpty = false;
-            }
-        }
-
-        private void Chain(Beat beat)
-        {
-            if (Bar == null)
-            {
-                return;
-            }
-
-            if (beat.Index < Beats.Count - 1)
-            {
-                beat.NextBeat = Beats[beat.Index + 1];
-                beat.NextBeat.PreviousBeat = beat;
-            }
-            else if (beat.IsLastOfVoice && beat.Voice.Bar.NextBar != null)
-            {
-                var nextVoice = Bar.NextBar.Voices[Index];
-                if (nextVoice.Beats.Count > 0)
-                {
-                    beat.NextBeat = nextVoice.Beats[0];
-                    beat.NextBeat.PreviousBeat = beat;
-                }
-                else
-                {
-                    beat.NextBeat.PreviousBeat = beat;
-                }
-            }
-        }
-
-        internal void AddGraceBeat(Beat beat)
-        {
-            if (Beats.Count == 0)
-            {
-                AddBeat(beat);
-                return;
-            }
-
-            // remove last beat
-            var lastBeat = Beats[Beats.Count - 1];
-            Beats.RemoveAt(Beats.Count - 1);
-
-            // insert grace beat
-            AddBeat(beat);
-            // reinsert last beat
-            AddBeat(lastBeat);
-
             IsEmpty = false;
         }
+    }
 
-        internal Beat GetBeatAtDisplayStart(int displayStart)
+    private void Chain(Beat beat)
+    {
+        if (Bar == null)
         {
-            return _beatLookup.ContainsKey(displayStart) ? _beatLookup[displayStart] : null;
+            return;
         }
 
-        internal void Finish()
+        if (beat.Index < Beats.Count - 1)
         {
-            _beatLookup = new FastDictionary<int, Beat>();
-            for (var index = 0; index < Beats.Count; index++)
+            beat.NextBeat              = Beats[beat.Index + 1];
+            beat.NextBeat.PreviousBeat = beat;
+        }
+        else if (beat.IsLastOfVoice && beat.Voice.Bar.NextBar != null)
+        {
+            var nextVoice = Bar.NextBar.Voices[Index];
+            if (nextVoice.Beats.Count > 0)
             {
-                var beat = Beats[index];
-                beat.Index = index;
-                Chain(beat);
+                beat.NextBeat              = nextVoice.Beats[0];
+                beat.NextBeat.PreviousBeat = beat;
             }
-
-            var currentDisplayTick = 0;
-            var currentPlaybackTick = 0;
-            for (var i = 0; i < Beats.Count; i++)
+            else
             {
-                var beat = Beats[i];
-                beat.Index = i;
-                beat.Finish();
+                beat.NextBeat.PreviousBeat = beat;
+            }
+        }
+    }
 
-                if (beat.GraceType is GraceType.None or GraceType.BendGrace)
+    internal void AddGraceBeat(Beat beat)
+    {
+        if (Beats.Count == 0)
+        {
+            AddBeat(beat);
+            return;
+        }
+
+        // remove last beat
+        var lastBeat = Beats[Beats.Count - 1];
+        Beats.RemoveAt(Beats.Count - 1);
+
+        // insert grace beat
+        AddBeat(beat);
+        // reinsert last beat
+        AddBeat(lastBeat);
+
+        IsEmpty = false;
+    }
+
+    internal Beat GetBeatAtDisplayStart(int displayStart)
+    {
+        return _beatLookup.ContainsKey(displayStart) ? _beatLookup[displayStart] : null;
+    }
+
+    internal void Finish()
+    {
+        _beatLookup = new FastDictionary<int, Beat>();
+        for (var index = 0; index < Beats.Count; index++)
+        {
+            var beat = Beats[index];
+            beat.Index = index;
+            Chain(beat);
+        }
+
+        var currentDisplayTick = 0;
+        var currentPlaybackTick = 0;
+        for (var i = 0; i < Beats.Count; i++)
+        {
+            var beat = Beats[i];
+            beat.Index = i;
+            beat.Finish();
+
+            if (beat.GraceType is GraceType.None or GraceType.BendGrace)
+            {
+                beat.DisplayStart   =  currentDisplayTick;
+                beat.PlaybackStart  =  currentPlaybackTick;
+                currentDisplayTick  += beat.DisplayDuration;
+                currentPlaybackTick += beat.PlaybackDuration;
+            }
+            else
+            {
+                if (beat.PreviousBeat == null || beat.PreviousBeat.GraceType == GraceType.None)
                 {
-                    beat.DisplayStart = currentDisplayTick;
-                    beat.PlaybackStart = currentPlaybackTick;
-                    currentDisplayTick += beat.DisplayDuration;
-                    currentPlaybackTick += beat.PlaybackDuration;
-                }
-                else
-                {
-                    if (beat.PreviousBeat == null || beat.PreviousBeat.GraceType == GraceType.None)
+                    // find note which is not a grace note
+                    var nonGrace = beat;
+                    var numberOfGraceBeats = 0;
+                    while (nonGrace != null && nonGrace.GraceType != GraceType.None)
                     {
-                        // find note which is not a grace note
-                        var nonGrace = beat;
-                        var numberOfGraceBeats = 0;
-                        while (nonGrace != null && nonGrace.GraceType != GraceType.None)
-                        {
-                            nonGrace = nonGrace.NextBeat;
-                            numberOfGraceBeats++;
-                        }
-
-                        var stolenDuration = 0;
-                        var graceDuration = numberOfGraceBeats switch
-                        {
-                            1 => Duration.Eighth,
-                            2 => Duration.Sixteenth,
-                            _ => Duration.ThirtySecond
-                        };
-
-                        nonGrace?.UpdateDurations();
-
-                        // grace beats have 1/4 size of the non grace beat preceding them
-                        var perGraceDisplayDuration = beat.PreviousBeat == null
-                            ? Duration.ThirtySecond.ToTicks()
-                            : beat.PreviousBeat.DisplayDuration / 4 / numberOfGraceBeats;
-
-                        // move all grace beats
-                        var graceBeat = Beats[i];
-                        for (var j = 0; j < numberOfGraceBeats && graceBeat != null; j++)
-                        {
-                            graceBeat.Duration = graceDuration;
-                            graceBeat.UpdateDurations();
-
-                            graceBeat.DisplayStart =
-                                currentDisplayTick - (numberOfGraceBeats - j + 1) * perGraceDisplayDuration;
-                            graceBeat.DisplayDuration = perGraceDisplayDuration;
-
-                            stolenDuration += graceBeat.PlaybackDuration;
-
-                            graceBeat = graceBeat.NextBeat;
-                        }
-
-                        // steal needed duration from beat duration
-                        if (beat.GraceType == GraceType.BeforeBeat)
-                        {
-                            if (beat.PreviousBeat != null)
-                            {
-                                beat.PreviousBeat.PlaybackDuration -= stolenDuration;
-                            }
-
-                            currentPlaybackTick -= stolenDuration;
-                        }
-                        else if (nonGrace != null && beat.GraceType == GraceType.OnBeat)
-                        {
-                            nonGrace.PlaybackDuration -= stolenDuration;
-                        }
+                        nonGrace = nonGrace.NextBeat;
+                        numberOfGraceBeats++;
                     }
 
-                    beat.PlaybackStart = currentPlaybackTick;
-                    currentPlaybackTick = beat.PlaybackStart + beat.PlaybackDuration;
+                    var stolenDuration = 0;
+                    var graceDuration = numberOfGraceBeats switch
+                    {
+                        1 => Duration.Eighth,
+                        2 => Duration.Sixteenth,
+                        _ => Duration.ThirtySecond
+                    };
+
+                    nonGrace?.UpdateDurations();
+
+                    // grace beats have 1/4 size of the non grace beat preceding them
+                    var perGraceDisplayDuration = beat.PreviousBeat == null
+                        ? Duration.ThirtySecond.ToTicks()
+                        : beat.PreviousBeat.DisplayDuration / 4 / numberOfGraceBeats;
+
+                    // move all grace beats
+                    var graceBeat = Beats[i];
+                    for (var j = 0; j < numberOfGraceBeats && graceBeat != null; j++)
+                    {
+                        graceBeat.Duration = graceDuration;
+                        graceBeat.UpdateDurations();
+
+                        graceBeat.DisplayStart =
+                            currentDisplayTick - (numberOfGraceBeats - j + 1) * perGraceDisplayDuration;
+                        graceBeat.DisplayDuration = perGraceDisplayDuration;
+
+                        stolenDuration += graceBeat.PlaybackDuration;
+
+                        graceBeat = graceBeat.NextBeat;
+                    }
+
+                    // steal needed duration from beat duration
+                    if (beat.GraceType == GraceType.BeforeBeat)
+                    {
+                        if (beat.PreviousBeat != null)
+                        {
+                            beat.PreviousBeat.PlaybackDuration -= stolenDuration;
+                        }
+
+                        currentPlaybackTick -= stolenDuration;
+                    }
+                    else if (nonGrace != null && beat.GraceType == GraceType.OnBeat)
+                    {
+                        nonGrace.PlaybackDuration -= stolenDuration;
+                    }
                 }
 
-                beat.FinishTuplet();
-                _beatLookup[beat.DisplayStart] = beat;
+                beat.PlaybackStart  = currentPlaybackTick;
+                currentPlaybackTick = beat.PlaybackStart + beat.PlaybackDuration;
             }
-        }
 
-        public int CalculateDuration()
+            beat.FinishTuplet();
+            _beatLookup[beat.DisplayStart] = beat;
+        }
+    }
+
+    public int CalculateDuration()
+    {
+        if (IsEmpty || Beats.Count == 0)
         {
-            if (IsEmpty || Beats.Count == 0)
-            {
-                return 0;
-            }
-
-            var lastBeat = Beats[Beats.Count - 1];
-            return lastBeat.PlaybackStart + lastBeat.PlaybackDuration;
+            return 0;
         }
+
+        var lastBeat = Beats[Beats.Count - 1];
+        return lastBeat.PlaybackStart + lastBeat.PlaybackDuration;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Model/WhammyType.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Model/WhammyType.cs
@@ -3,48 +3,47 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Model
+namespace BardMusicPlayer.Siren.AlphaTab.Model;
+
+/// <summary>
+/// Lists all types of whammy bars
+/// </summary>
+internal enum WhammyType
 {
     /// <summary>
-    /// Lists all types of whammy bars
+    /// No whammy at all
     /// </summary>
-    internal enum WhammyType
-    {
-        /// <summary>
-        /// No whammy at all
-        /// </summary>
-        None,
+    None,
 
-        /// <summary>
-        /// Individual points define the whammy in a flexible manner. 
-        /// This system was mainly used in Guitar Pro 3-5
-        /// </summary>
-        Custom,
+    /// <summary>
+    /// Individual points define the whammy in a flexible manner. 
+    /// This system was mainly used in Guitar Pro 3-5
+    /// </summary>
+    Custom,
 
-        /// <summary>
-        /// Simple dive to a lower or higher note.
-        /// </summary>
-        Dive,
+    /// <summary>
+    /// Simple dive to a lower or higher note.
+    /// </summary>
+    Dive,
 
-        /// <summary>
-        /// A dive to a lower or higher note and releasing it back to normal. 
-        /// </summary>
-        Dip,
+    /// <summary>
+    /// A dive to a lower or higher note and releasing it back to normal. 
+    /// </summary>
+    Dip,
 
-        /// <summary>
-        /// Continue to hold the whammy at the position from a previous whammy. 
-        /// </summary>
-        Hold,
+    /// <summary>
+    /// Continue to hold the whammy at the position from a previous whammy. 
+    /// </summary>
+    Hold,
 
-        /// <summary>
-        /// Dive to a lower or higher note before playing it. 
-        /// </summary>
-        Predive,
+    /// <summary>
+    /// Dive to a lower or higher note before playing it. 
+    /// </summary>
+    Predive,
 
-        /// <summary>
-        /// Dive to a lower or higher note before playing it, then change to another
-        /// note. 
-        /// </summary>
-        PrediveDive
-    }
+    /// <summary>
+    /// Dive to a lower or higher note before playing it, then change to another
+    /// note. 
+    /// </summary>
+    PrediveDive
 }

--- a/BardMusicPlayer.Siren/AlphaTab/NAudioSynthOutput.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/NAudioSynthOutput.cs
@@ -56,7 +56,7 @@ namespace BardMusicPlayer.Siren.AlphaTab
             _circularBuffer = new CircularSampleBuffer(BufferSize * _bufferCount);
             _context.Init(this);
 
-            Ready();
+            Ready?.Invoke();
         }
 
         /// <inheritdoc />
@@ -129,7 +129,7 @@ namespace BardMusicPlayer.Siren.AlphaTab
             {
                 if (_finished)
                 {
-                    Finished();
+                    Finished?.Invoke();
                 }
             }
             else
@@ -143,7 +143,7 @@ namespace BardMusicPlayer.Siren.AlphaTab
                 }
 
                 var samples = count / 2;
-                SamplesPlayed(samples);
+                SamplesPlayed?.Invoke(samples);
             }
 
             if (!_finished)

--- a/BardMusicPlayer.Siren/AlphaTab/NAudioSynthOutput.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/NAudioSynthOutput.cs
@@ -9,158 +9,157 @@ using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Ds;
 using NAudio.CoreAudioApi;
 using NAudio.Wave;
 
-namespace BardMusicPlayer.Siren.AlphaTab
+namespace BardMusicPlayer.Siren.AlphaTab;
+
+/// <summary>
+/// A <see cref="ISynthOutput"/> implementation that uses NAudio to play the
+/// sound via WasapiOut.
+/// </summary>
+internal class NAudioSynthOutput : WaveProvider32, ISynthOutput, IDisposable
 {
-    /// <summary>
-    /// A <see cref="ISynthOutput"/> implementation that uses NAudio to play the
-    /// sound via WasapiOut.
-    /// </summary>
-    internal class NAudioSynthOutput : WaveProvider32, ISynthOutput, IDisposable
-    {
-        private const int BufferSize = 4096;
+    private const int BufferSize = 4096;
         
-        private const int PreferredSampleRate = 48000;
+    private const int PreferredSampleRate = 48000;
 
-        private WasapiOut _context;
-        private CircularSampleBuffer _circularBuffer;
-        private bool _finished;
-        private readonly MMDevice _device;
-        private readonly byte _latency;
-        private readonly byte _bufferCount;
-        private readonly int _bufferCountSize; 
-        /// <inheritdoc />
-        public int SampleRate => PreferredSampleRate;
+    private WasapiOut _context;
+    private CircularSampleBuffer _circularBuffer;
+    private bool _finished;
+    private readonly MMDevice _device;
+    private readonly byte _latency;
+    private readonly byte _bufferCount;
+    private readonly int _bufferCountSize; 
+    /// <inheritdoc />
+    public int SampleRate => PreferredSampleRate;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NAudioSynthOutput"/> class.
-        /// </summary>
-        public NAudioSynthOutput(MMDevice device, byte bufferCount, byte latency)
-            : base(PreferredSampleRate, 2)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NAudioSynthOutput"/> class.
+    /// </summary>
+    public NAudioSynthOutput(MMDevice device, byte bufferCount, byte latency)
+        : base(PreferredSampleRate, 2)
+    {
+        _device          = device;
+        _context         = new WasapiOut(device, AudioClientShareMode.Shared, true, _latency);
+        _latency         = latency;
+        _bufferCount     = bufferCount;
+        _bufferCountSize = _bufferCount / 2 * BufferSize;
+    }
+
+    /// <inheritdoc />
+    public void Activate()
+    {
+    }
+
+    /// <inheritdoc />
+    public void Open()
+    {
+        _finished       = false;
+        _circularBuffer = new CircularSampleBuffer(BufferSize * _bufferCount);
+        _context.Init(this);
+
+        Ready?.Invoke();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Close();
+    }
+
+    /// <summary>
+    /// Closes the synth output and disposes all resources.
+    /// </summary>
+    public void Close()
+    {
+        _finished = true;
+        _context.Stop();
+        _circularBuffer.Clear();
+        _context.Dispose();
+    }
+
+    /// <inheritdoc />
+    public void Play()
+    {
+        RequestBuffers();
+        _finished = false;
+        _context.Play();
+    }
+
+    /// <inheritdoc />
+    public void Pause()
+    {
+        _context.Pause();
+    }
+
+    /// <inheritdoc />
+    public void Stop()
+    {
+        _finished = true;
+        _context.Stop();
+        _circularBuffer.Clear();
+    }
+
+    /// <inheritdoc />
+    public void SequencerFinished()
+    {
+        _finished = true;
+    }
+
+    /// <inheritdoc />
+    public void AddSamples(float[] f)
+    {
+        _circularBuffer.Write(f, 0, f.Length);
+    }
+
+    /// <inheritdoc />
+    public void ResetSamples()
+    {
+        _circularBuffer.Clear();
+    }
+
+    private void RequestBuffers()
+    {
+        if (_circularBuffer.Count >= _bufferCountSize || SampleRequest == null) return;
+        for (var i = 0; i < _bufferCount / 2; i++) SampleRequest();
+    }
+
+    /// <inheritdoc />
+    public override int Read(float[] buffer, int offset, int count)
+    {
+        if (_circularBuffer.Count < count)
         {
-            _device = device;
-            _context = new WasapiOut(device, AudioClientShareMode.Shared, true, _latency);
-            _latency = latency;
-            _bufferCount = bufferCount;
-            _bufferCountSize = _bufferCount / 2 * BufferSize;
+            if (_finished)
+            {
+                Finished?.Invoke();
+            }
+        }
+        else
+        {
+            var read = new float[count];
+            _circularBuffer.Read(read, 0, read.Length);
+
+            for (var i = 0; i < count; i++)
+            {
+                buffer[offset + i] = read[i];
+            }
+
+            var samples = count / 2;
+            SamplesPlayed?.Invoke(samples);
         }
 
-        /// <inheritdoc />
-        public void Activate()
-        {
-        }
-
-        /// <inheritdoc />
-        public void Open()
-        {
-            _finished = false;
-            _circularBuffer = new CircularSampleBuffer(BufferSize * _bufferCount);
-            _context.Init(this);
-
-            Ready?.Invoke();
-        }
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            Close();
-        }
-
-        /// <summary>
-        /// Closes the synth output and disposes all resources.
-        /// </summary>
-        public void Close()
-        {
-            _finished = true;
-            _context.Stop();
-            _circularBuffer.Clear();
-            _context.Dispose();
-        }
-
-        /// <inheritdoc />
-        public void Play()
+        if (!_finished)
         {
             RequestBuffers();
-            _finished = false;
-            _context.Play();
         }
 
-        /// <inheritdoc />
-        public void Pause()
-        {
-            _context.Pause();
-        }
-
-        /// <inheritdoc />
-        public void Stop()
-        {
-            _finished = true;
-            _context.Stop();
-            _circularBuffer.Clear();
-        }
-
-        /// <inheritdoc />
-        public void SequencerFinished()
-        {
-            _finished = true;
-        }
-
-        /// <inheritdoc />
-        public void AddSamples(float[] f)
-        {
-            _circularBuffer.Write(f, 0, f.Length);
-        }
-
-        /// <inheritdoc />
-        public void ResetSamples()
-        {
-            _circularBuffer.Clear();
-        }
-
-        private void RequestBuffers()
-        {
-            if (_circularBuffer.Count >= _bufferCountSize || SampleRequest == null) return;
-            for (var i = 0; i < _bufferCount / 2; i++) SampleRequest();
-        }
-
-        /// <inheritdoc />
-        public override int Read(float[] buffer, int offset, int count)
-        {
-            if (_circularBuffer.Count < count)
-            {
-                if (_finished)
-                {
-                    Finished?.Invoke();
-                }
-            }
-            else
-            {
-                var read = new float[count];
-                _circularBuffer.Read(read, 0, read.Length);
-
-                for (var i = 0; i < count; i++)
-                {
-                    buffer[offset + i] = read[i];
-                }
-
-                var samples = count / 2;
-                SamplesPlayed?.Invoke(samples);
-            }
-
-            if (!_finished)
-            {
-                RequestBuffers();
-            }
-
-            return count;
-        }
-
-        /// <inheritdoc />
-        public event Action Ready;
-        /// <inheritdoc />
-        public event Action<int> SamplesPlayed;
-        /// <inheritdoc />
-        public event Action SampleRequest;
-        /// <inheritdoc />
-        public event Action Finished;
+        return count;
     }
+
+    /// <inheritdoc />
+    public event Action Ready;
+    /// <inheritdoc />
+    public event Action<int> SamplesPlayed;
+    /// <inheritdoc />
+    public event Action SampleRequest;
+    /// <inheritdoc />
+    public event Action Finished;
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Platform.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Platform.cs
@@ -10,162 +10,161 @@ using System.Text;
 using BardMusicPlayer.Siren.AlphaTab.IO;
 using BardMusicPlayer.Siren.AlphaTab.Util;
 
-namespace BardMusicPlayer.Siren.AlphaTab
+namespace BardMusicPlayer.Siren.AlphaTab;
+
+internal static class Platform
 {
-    internal static class Platform
+    public static bool IsStringNumber(string s, bool allowSign = true)
     {
-        public static bool IsStringNumber(string s, bool allowSign = true)
+        if (s.Length == 0)
         {
-            if (s.Length == 0)
-            {
-                return false;
-            }
-
-            var c = s[0];
-            return IsCharNumber(c, allowSign);
+            return false;
         }
 
-        public static bool IsCharNumber(int c, bool allowSign = true)
+        var c = s[0];
+        return IsCharNumber(c, allowSign);
+    }
+
+    public static bool IsCharNumber(int c, bool allowSign = true)
+    {
+        return allowSign && c == 0x2D || c is >= 0x30 and <= 0x39;
+    }
+
+    public static bool IsWhiteSpace(int c)
+    {
+        return c is 0x20 or 0x0B or 0x0D or 0x0A or 0x09;
+    }
+
+    public static bool IsAlmostEqualTo(this float a, float b)
+    {
+        return Math.Abs(a - b) < 0.00001f;
+    }
+
+    public static string ToHexString(int n, int digits = 0)
+    {
+        var s = "";
+        const string hexChars = "0123456789ABCDEF";
+        do
         {
-            return allowSign && c == 0x2D || c is >= 0x30 and <= 0x39;
+            s =   StringFromCharCode(hexChars[n & 15]) + s;
+            n >>= 4;
+        } while (n > 0);
+
+        while (s.Length < digits)
+        {
+            s = "0" + s;
         }
 
-        public static bool IsWhiteSpace(int c)
+        return s;
+    }
+
+    public static uint ToUInt32(int i)
+    {
+        return (uint)i;
+    }
+
+    public static short ToInt16(int i)
+    {
+        return (short)i;
+    }
+
+    public static ushort ToUInt16(int i)
+    {
+        return (ushort)i;
+    }
+
+    public static byte ToUInt8(int i)
+    {
+        return (byte)i;
+    }
+
+    internal static string DetectEncoding(byte[] data)
+    {
+        return data.Length switch
         {
-            return c is 0x20 or 0x0B or 0x0D or 0x0A or 0x09;
+            > 2 when data[0] == 0xFE && data[1] == 0xFF                                       => "utf-16be",
+            > 2 when data[0] == 0xFF && data[1] == 0xFE                                       => "utf-16le",
+            > 4 when data[0] == 0x00 && data[1] == 0x00 && data[2] == 0xFE && data[3] == 0xFF => "utf-32be",
+            > 4 when data[0] == 0xFF && data[1] == 0xFE && data[2] == 0x00 && data[3] == 0x00 => "utf-32le",
+            _                                                                                 => null
+        };
+    }
+
+    public static void Log(LogLevel logLevel, string category, string msg, object details = null)
+    {
+        Trace.WriteLine($"[AlphaTab][{category}][{logLevel}] {msg} {details}", "AlphaTab");
+    }
+
+    public static float Log2(float s)
+    {
+        return (float)Math.Log(s, 2);
+    }
+
+    public static int ParseInt(string s)
+    {
+        if (!float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var f))
+        {
+            return int.MinValue;
         }
 
-        public static bool IsAlmostEqualTo(this float a, float b)
-        {
-            return Math.Abs(a - b) < 0.00001f;
-        }
+        return (int)f;
+    }
 
-        public static string ToHexString(int n, int digits = 0)
-        {
-            var s = "";
-            const string hexChars = "0123456789ABCDEF";
-            do
-            {
-                s =   StringFromCharCode(hexChars[n & 15]) + s;
-                n >>= 4;
-            } while (n > 0);
+    public static int[] CloneArray(int[] array)
+    {
+        return (int[])array.Clone();
+    }
 
-            while (s.Length < digits)
-            {
-                s = "0" + s;
-            }
+    public static void BlockCopy(byte[] src, int srcOffset, byte[] dst, int dstOffset, int count)
+    {
+        Buffer.BlockCopy(src, srcOffset, dst, dstOffset, count);
+    }
 
-            return s;
-        }
-
-        public static uint ToUInt32(int i)
-        {
-            return (uint)i;
-        }
-
-        public static short ToInt16(int i)
-        {
-            return (short)i;
-        }
-
-        public static ushort ToUInt16(int i)
-        {
-            return (ushort)i;
-        }
-
-        public static byte ToUInt8(int i)
-        {
-            return (byte)i;
-        }
-
-        internal static string DetectEncoding(byte[] data)
-        {
-            return data.Length switch
-            {
-                > 2 when data[0] == 0xFE && data[1] == 0xFF                                       => "utf-16be",
-                > 2 when data[0] == 0xFF && data[1] == 0xFE                                       => "utf-16le",
-                > 4 when data[0] == 0x00 && data[1] == 0x00 && data[2] == 0xFE && data[3] == 0xFF => "utf-32be",
-                > 4 when data[0] == 0xFF && data[1] == 0xFE && data[2] == 0x00 && data[3] == 0x00 => "utf-32le",
-                _                                                                                 => null
-            };
-        }
-
-        public static void Log(LogLevel logLevel, string category, string msg, object details = null)
-        {
-            Trace.WriteLine($"[AlphaTab][{category}][{logLevel}] {msg} {details}", "AlphaTab");
-        }
-
-        public static float Log2(float s)
-        {
-            return (float)Math.Log(s, 2);
-        }
-
-        public static int ParseInt(string s)
-        {
-            if (!float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var f))
-            {
-                return int.MinValue;
-            }
-
-            return (int)f;
-        }
-
-        public static int[] CloneArray(int[] array)
-        {
-            return (int[])array.Clone();
-        }
-
-        public static void BlockCopy(byte[] src, int srcOffset, byte[] dst, int dstOffset, int count)
-        {
-            Buffer.BlockCopy(src, srcOffset, dst, dstOffset, count);
-        }
-
-        public static string StringFromCharCode(int c)
-        {
-            return ((char)c).ToString();
-        }
+    public static string StringFromCharCode(int c)
+    {
+        return ((char)c).ToString();
+    }
         
-        public static sbyte ReadSignedByte(this IReadable readable)
+    public static sbyte ReadSignedByte(this IReadable readable)
+    {
+        return unchecked((sbyte)(byte)readable.ReadByte());
+    }
+
+    public static string ToString(byte[] data, string encoding)
+    {
+        var detectedEncoding = DetectEncoding(data);
+        if (detectedEncoding != null)
         {
-            return unchecked((sbyte)(byte)readable.ReadByte());
+            encoding = detectedEncoding;
         }
 
-        public static string ToString(byte[] data, string encoding)
+        encoding ??= "utf-8";
+
+        Encoding enc;
+        try
         {
-            var detectedEncoding = DetectEncoding(data);
-            if (detectedEncoding != null)
-            {
-                encoding = detectedEncoding;
-            }
-
-            encoding ??= "utf-8";
-
-            Encoding enc;
-            try
-            {
-                enc = Encoding.GetEncoding(encoding);
-            }
-            catch
-            {
-                enc = Encoding.UTF8;
-            }
-
-            return enc.GetString(data, 0, data.Length);
+            enc = Encoding.GetEncoding(encoding);
         }
+        catch
+        {
+            enc = Encoding.UTF8;
+        }
+
+        return enc.GetString(data, 0, data.Length);
+    }
         
-        public static void ClearIntArray(int[] array)
-        {
-            Array.Clear(array, 0, array.Length);
-        }
+    public static void ClearIntArray(int[] array)
+    {
+        Array.Clear(array, 0, array.Length);
+    }
         
-        public static void ArrayCopy<T>(T[] src, int srcOffset, T[] dst, int dstOffset, int count)
-        {
-            Array.Copy(src, srcOffset, dst, dstOffset, count);
-        }
+    public static void ArrayCopy<T>(T[] src, int srcOffset, T[] dst, int dstOffset, int count)
+    {
+        Array.Copy(src, srcOffset, dst, dstOffset, count);
+    }
         
-        public static long GetCurrentMilliseconds()
-        {
-            return Stopwatch.GetTimestamp();
-        }
+    public static long GetCurrentMilliseconds()
+    {
+        return Stopwatch.GetTimestamp();
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Platform.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Platform.cs
@@ -27,12 +27,12 @@ namespace BardMusicPlayer.Siren.AlphaTab
 
         public static bool IsCharNumber(int c, bool allowSign = true)
         {
-            return allowSign && c == 0x2D || c >= 0x30 && c <= 0x39;
+            return allowSign && c == 0x2D || c is >= 0x30 and <= 0x39;
         }
 
         public static bool IsWhiteSpace(int c)
         {
-            return c == 0x20 || c == 0x0B || c == 0x0D || c == 0x0A || c == 0x09;
+            return c is 0x20 or 0x0B or 0x0D or 0x0A or 0x09;
         }
 
         public static bool IsAlmostEqualTo(this float a, float b)
@@ -46,7 +46,7 @@ namespace BardMusicPlayer.Siren.AlphaTab
             const string hexChars = "0123456789ABCDEF";
             do
             {
-                s = StringFromCharCode((int)hexChars[n & 15]) + s;
+                s =   StringFromCharCode(hexChars[n & 15]) + s;
                 n >>= 4;
             } while (n > 0);
 
@@ -80,27 +80,14 @@ namespace BardMusicPlayer.Siren.AlphaTab
 
         internal static string DetectEncoding(byte[] data)
         {
-            if (data.Length > 2 && data[0] == 0xFE && data[1] == 0xFF)
+            return data.Length switch
             {
-                return "utf-16be";
-            }
-
-            if (data.Length > 2 && data[0] == 0xFF && data[1] == 0xFE)
-            {
-                return "utf-16le";
-            }
-
-            if (data.Length > 4 && data[0] == 0x00 && data[1] == 0x00 && data[2] == 0xFE && data[3] == 0xFF)
-            {
-                return "utf-32be";
-            }
-
-            if (data.Length > 4 && data[0] == 0xFF && data[1] == 0xFE && data[2] == 0x00 && data[3] == 0x00)
-            {
-                return "utf-32le";
-            }
-
-            return null;
+                > 2 when data[0] == 0xFE && data[1] == 0xFF                                       => "utf-16be",
+                > 2 when data[0] == 0xFF && data[1] == 0xFE                                       => "utf-16le",
+                > 4 when data[0] == 0x00 && data[1] == 0x00 && data[2] == 0xFE && data[3] == 0xFF => "utf-32be",
+                > 4 when data[0] == 0xFF && data[1] == 0xFE && data[2] == 0x00 && data[3] == 0x00 => "utf-32le",
+                _                                                                                 => null
+            };
         }
 
         public static void Log(LogLevel logLevel, string category, string msg, object details = null)
@@ -115,8 +102,7 @@ namespace BardMusicPlayer.Siren.AlphaTab
 
         public static int ParseInt(string s)
         {
-            float f;
-            if (!float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out f))
+            if (!float.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var f))
             {
                 return int.MinValue;
             }
@@ -146,16 +132,13 @@ namespace BardMusicPlayer.Siren.AlphaTab
 
         public static string ToString(byte[] data, string encoding)
         {
-            var detectedEncoding = Platform.DetectEncoding(data);
+            var detectedEncoding = DetectEncoding(data);
             if (detectedEncoding != null)
             {
                 encoding = detectedEncoding;
             }
 
-            if (encoding == null)
-            {
-                encoding = "utf-8";
-            }
+            encoding ??= "utf-8";
 
             Encoding enc;
             try

--- a/BardMusicPlayer.Siren/AlphaTab/ProgressEventArgs.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/ProgressEventArgs.cs
@@ -3,32 +3,31 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab
+namespace BardMusicPlayer.Siren.AlphaTab;
+
+/// <summary>
+/// Represents the progress of any data being loaded.
+/// </summary>
+internal class ProgressEventArgs
 {
     /// <summary>
-    /// Represents the progress of any data being loaded.
+    /// Gets the currently loaded bytes.
     /// </summary>
-    internal class ProgressEventArgs
+    public int Loaded { get; }
+
+    /// <summary>
+    /// Gets the total number of bytes to load.
+    /// </summary>
+    public int Total { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProgressEventArgs"/> class.
+    /// </summary>
+    /// <param name="loaded"></param>
+    /// <param name="total"></param>
+    public ProgressEventArgs(int loaded, int total)
     {
-        /// <summary>
-        /// Gets the currently loaded bytes.
-        /// </summary>
-        public int Loaded { get; }
-
-        /// <summary>
-        /// Gets the total number of bytes to load.
-        /// </summary>
-        public int Total { get; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ProgressEventArgs"/> class.
-        /// </summary>
-        /// <param name="loaded"></param>
-        /// <param name="total"></param>
-        public ProgressEventArgs(int loaded, int total)
-        {
-            Loaded = loaded;
-            Total = total;
-        }
+        Loaded = loaded;
+        Total  = total;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Util/JsonProperty.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Util/JsonProperty.cs
@@ -7,17 +7,17 @@ using System;
 
 namespace BardMusicPlayer.Siren.AlphaTab.Util
 {
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum, Inherited = false, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum, Inherited = false)]
     internal sealed class JsonSerializableAttribute : Attribute
     {
     }
 
-    [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
     internal sealed class JsonImmutableAttribute : Attribute
     {
     }
 
-    [AttributeUsage(System.AttributeTargets.Property)]
+    [AttributeUsage(AttributeTargets.Property)]
     internal sealed class JsonNameAttribute : Attribute
     {
         public string[] Names { get; }

--- a/BardMusicPlayer.Siren/AlphaTab/Util/JsonProperty.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Util/JsonProperty.cs
@@ -5,26 +5,25 @@
 
 using System;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Util
+namespace BardMusicPlayer.Siren.AlphaTab.Util;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum, Inherited = false)]
+internal sealed class JsonSerializableAttribute : Attribute
 {
-    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Enum, Inherited = false)]
-    internal sealed class JsonSerializableAttribute : Attribute
-    {
-    }
+}
 
-    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
-    internal sealed class JsonImmutableAttribute : Attribute
-    {
-    }
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+internal sealed class JsonImmutableAttribute : Attribute
+{
+}
 
-    [AttributeUsage(AttributeTargets.Property)]
-    internal sealed class JsonNameAttribute : Attribute
-    {
-        public string[] Names { get; }
+[AttributeUsage(AttributeTargets.Property)]
+internal sealed class JsonNameAttribute : Attribute
+{
+    public string[] Names { get; }
 
-        public JsonNameAttribute(params string[] names)
-        {
-            Names = names;
-        }
+    public JsonNameAttribute(params string[] names)
+    {
+        Names = names;
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Util/Lazy.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Util/Lazy.cs
@@ -5,31 +5,30 @@
 
 using System;
 
-namespace BardMusicPlayer.Siren.AlphaTab.Util
+namespace BardMusicPlayer.Siren.AlphaTab.Util;
+
+internal class Lazy<T>
 {
-    internal class Lazy<T>
+    private readonly Func<T> _factory;
+    private bool _created;
+    private T _value;
+
+    public Lazy(Func<T> factory)
     {
-        private readonly Func<T> _factory;
-        private bool _created;
-        private T _value;
+        _factory = factory;
+    }
 
-        public Lazy(Func<T> factory)
+    public T Value
+    {
+        get
         {
-            _factory = factory;
-        }
-
-        public T Value
-        {
-            get
+            if (!_created)
             {
-                if (!_created)
-                {
-                    _value = _factory();
-                    _created = true;
-                }
-
-                return _value;
+                _value   = _factory();
+                _created = true;
             }
+
+            return _value;
         }
     }
 }

--- a/BardMusicPlayer.Siren/AlphaTab/Util/Logger.cs
+++ b/BardMusicPlayer.Siren/AlphaTab/Util/Logger.cs
@@ -3,77 +3,76 @@
  * Licensed under the MPL-2.0 license. See https://github.com/CoderLine/alphaTab/blob/develop/LICENSE for full license information.
  */
 
-namespace BardMusicPlayer.Siren.AlphaTab.Util
+namespace BardMusicPlayer.Siren.AlphaTab.Util;
+
+internal class Logger
 {
-    internal class Logger
+    public static LogLevel LogLevel { get; set; }
+
+    static Logger()
     {
-        public static LogLevel LogLevel { get; set; }
-
-        static Logger()
-        {
-            LogLevel = LogLevel.Info;
-        }
-
-        public static void Debug(string category, string msg, object details = null)
-        {
-            Log(LogLevel.Debug, category, msg, details);
-        }
-
-        public static void Warning(string category, string msg, object details = null)
-        {
-            Log(LogLevel.Warning, category, msg, details);
-        }
-
-        public static void Info(string category, string msg, object details = null)
-        {
-            Log(LogLevel.Info, category, msg, details);
-        }
-
-        public static void Error(string category, string msg, object details = null)
-        {
-            Log(LogLevel.Error, category, msg, details);
-        }
-
-        public static void Log(LogLevel logLevel, string category, string msg, object details = null)
-        {
-            if (logLevel < LogLevel || LogLevel == LogLevel.None)
-            {
-                return;
-            }
-
-            Platform.Log(logLevel, category, msg, details);
-        }
+        LogLevel = LogLevel.Info;
     }
+
+    public static void Debug(string category, string msg, object details = null)
+    {
+        Log(LogLevel.Debug, category, msg, details);
+    }
+
+    public static void Warning(string category, string msg, object details = null)
+    {
+        Log(LogLevel.Warning, category, msg, details);
+    }
+
+    public static void Info(string category, string msg, object details = null)
+    {
+        Log(LogLevel.Info, category, msg, details);
+    }
+
+    public static void Error(string category, string msg, object details = null)
+    {
+        Log(LogLevel.Error, category, msg, details);
+    }
+
+    public static void Log(LogLevel logLevel, string category, string msg, object details = null)
+    {
+        if (logLevel < LogLevel || LogLevel == LogLevel.None)
+        {
+            return;
+        }
+
+        Platform.Log(logLevel, category, msg, details);
+    }
+}
+
+/// <summary>
+/// Defines all loglevels. 
+/// </summary>
+[JsonSerializable]
+internal enum LogLevel
+{
+    /// <summary>
+    /// No logging
+    /// </summary>
+    None = 0,
 
     /// <summary>
-    /// Defines all loglevels. 
+    /// Debug level (internal details are displayed).
     /// </summary>
-    [JsonSerializable]
-    internal enum LogLevel
-    {
-        /// <summary>
-        /// No logging
-        /// </summary>
-        None = 0,
+    Debug = 1,
 
-        /// <summary>
-        /// Debug level (internal details are displayed).
-        /// </summary>
-        Debug = 1,
+    /// <summary>
+    /// Info level (only important details are shown)
+    /// </summary>
+    Info = 2,
 
-        /// <summary>
-        /// Info level (only important details are shown)
-        /// </summary>
-        Info = 2,
+    /// <summary>
+    /// Warning level
+    /// </summary>
+    Warning = 3,
 
-        /// <summary>
-        /// Warning level
-        /// </summary>
-        Warning = 3,
-
-        /// <summary>
-        /// Error level.
-        /// </summary>
-        Error = 4
-    }
+    /// <summary>
+    /// Error level.
+    /// </summary>
+    Error = 4
 }

--- a/BardMusicPlayer.Siren/BmpSiren.cs
+++ b/BardMusicPlayer.Siren/BmpSiren.cs
@@ -16,201 +16,200 @@ using BardMusicPlayer.Siren.Properties;
 using BardMusicPlayer.Transmogrify.Song;
 using NAudio.CoreAudioApi;
 
-namespace BardMusicPlayer.Siren
+namespace BardMusicPlayer.Siren;
+
+public class BmpSiren
 {
-    public class BmpSiren
+    public string CurrentSongTitle { get; private set; } = "";
+    public BmpSong CurrentSong { get; private set; }
+
+    private IAlphaSynth _player;
+    private Dictionary<int, Dictionary<long, string>> _lyrics;
+    private double _lyricIndex;
+    private MMDevice _mdev;
+
+    private static readonly Lazy<BmpSiren> LazyInstance = new(() => new BmpSiren());
+    public static BmpSiren Instance => LazyInstance.Value;
+
+    internal BmpSiren()
     {
-        public string CurrentSongTitle { get; private set; } = "";
-        public BmpSong CurrentSong { get; private set; }
+    }
 
-        private IAlphaSynth _player;
-        private Dictionary<int, Dictionary<long, string>> _lyrics;
-        private double _lyricIndex;
-        private MMDevice _mdev;
+    ~BmpSiren()
+    {
+        ShutDown();
+    }
 
-        private static readonly Lazy<BmpSiren> LazyInstance = new(() => new BmpSiren());
-        public static BmpSiren Instance => LazyInstance.Value;
+    /// <summary>
+    /// Gets a collection of available MMDevice objects
+    /// </summary>
+    public MMDeviceCollection AudioDevices => new MMDeviceEnumerator().EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
 
-        internal BmpSiren()
-        {
-        }
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="device"></param>
+    /// <param name="defaultVolume"></param>
+    /// <param name="bufferCount"></param>
+    /// <param name="latency"></param>
+    public void Setup(MMDevice device, float defaultVolume = 0.8f, byte bufferCount = 3, byte latency = 100)
+    {
+        ShutDown();
+        _mdev = device;
+        _player = new ManagedThreadAlphaSynthWorkerApi(new NAudioSynthOutput(device, bufferCount, latency), AlphaTab.Util.LogLevel.None, BeginInvoke);
+        foreach (var resource in Resources.ResourceManager.GetResourceSet(CultureInfo.CurrentUICulture, true, true))
+            _player.LoadSoundFont((byte[])((DictionaryEntry)resource).Value, true);
+        _player.PositionChanged += NotifyTimePosition;
+        _player.MasterVolume    =  defaultVolume;
+    }
 
-        ~BmpSiren()
-        {
-            ShutDown();
-        }
+    /// <summary>
+    /// Sets the volume
+    /// </summary>
+    /// <param name="x"></param>
+    public int GetVolume()
+    {
+        return (int)(_mdev.AudioSessionManager.AudioSessionControl.SimpleAudioVolume.Volume * 100);
+    }
 
-        /// <summary>
-        /// Gets a collection of available MMDevice objects
-        /// </summary>
-        public MMDeviceCollection AudioDevices => new MMDeviceEnumerator().EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
+    /// <summary>
+    /// Sets the volume
+    /// </summary>
+    /// <param name="x"></param>
+    public void SetVolume(float x)
+    {
+        _mdev.AudioSessionManager.AudioSessionControl.SimpleAudioVolume.Volume = x / 100;
+    }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="device"></param>
-        /// <param name="defaultVolume"></param>
-        /// <param name="bufferCount"></param>
-        /// <param name="latency"></param>
-        public void Setup(MMDevice device, float defaultVolume = 0.8f, byte bufferCount = 3, byte latency = 100)
-        {
-            ShutDown();
-            _mdev = device;
-            _player = new ManagedThreadAlphaSynthWorkerApi(new NAudioSynthOutput(device, bufferCount, latency), AlphaTab.Util.LogLevel.None, BeginInvoke);
-            foreach (var resource in Resources.ResourceManager.GetResourceSet(CultureInfo.CurrentUICulture, true, true))
-                _player.LoadSoundFont((byte[])((DictionaryEntry)resource).Value, true);
-            _player.PositionChanged += NotifyTimePosition;
-            _player.MasterVolume = defaultVolume;
-        }
+    /// <summary>
+    /// 
+    /// </summary>
+    public bool IsReady => _player is { IsReady: true };
 
-        /// <summary>
-        /// Sets the volume
-        /// </summary>
-        /// <param name="x"></param>
-        public int GetVolume()
-        {
-            return (int)(_mdev.AudioSessionManager.AudioSessionControl.SimpleAudioVolume.Volume * 100);
-        }
+    /// <summary>
+    /// 
+    /// </summary>
+    public bool IsReadyForPlayback => IsReady && _player.IsReadyForPlayback;
 
-        /// <summary>
-        /// Sets the volume
-        /// </summary>
-        /// <param name="x"></param>
-        public void SetVolume(float x)
-        {
-            _mdev.AudioSessionManager.AudioSessionControl.SimpleAudioVolume.Volume = x / 100;
-        }
+    private readonly TaskQueue _taskQueue = new();
+    internal void BeginInvoke(Action action) => _taskQueue.Enqueue(() => Task.Run(action));
 
-        /// <summary>
-        /// 
-        /// </summary>
-        public bool IsReady => _player is { IsReady: true };
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="defaultVolume"></param>
+    /// <param name="bufferCount"></param>
+    /// <param name="latency"></param>
+    public void Setup(float defaultVolume = 0.8f, byte bufferCount = 2, byte latency = 100)
+    {
+        var mmAudio = new MMDeviceEnumerator().GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+        Setup(mmAudio, defaultVolume, bufferCount, latency);
+    }
 
-        /// <summary>
-        /// 
-        /// </summary>
-        public bool IsReadyForPlayback => IsReady && _player.IsReadyForPlayback;
-
-        private readonly TaskQueue _taskQueue = new();
-        internal void BeginInvoke(Action action) => _taskQueue.Enqueue(() => Task.Run(action));
-
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="defaultVolume"></param>
-        /// <param name="bufferCount"></param>
-        /// <param name="latency"></param>
-        public void Setup(float defaultVolume = 0.8f, byte bufferCount = 2, byte latency = 100)
-        {
-            var mmAudio = new MMDeviceEnumerator().GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
-            Setup(mmAudio, defaultVolume, bufferCount, latency);
-        }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public void ShutDown()
-        {
-            if (_player == null) return;
-            _player.Stop();
-            _player.PositionChanged -= NotifyTimePosition;
-            _player.Destroy();
-        }
+    /// <summary>
+    /// 
+    /// </summary>
+    public void ShutDown()
+    {
+        if (_player == null) return;
+        _player.Stop();
+        _player.PositionChanged -= NotifyTimePosition;
+        _player.Destroy();
+    }
         
-        /// <summary>
-        /// Loads a BmpSong into the synthesizer
-        /// </summary>
-        /// <param name="song"></param> 
-        /// <returns>This BmpSiren</returns>
-        public async Task<BmpSiren> Load(BmpSong song)
-        {
-            if (!IsReady) throw new BmpException("Siren not initialized.");
-            if (_player.State == PlayerState.Playing) _player.Stop();
-            (var midiFile, _lyrics) = await song.GetSynthMidi();
-            _lyricIndex = 0;
-            _player.LoadMidiFile(midiFile);
-            CurrentSongTitle = song.Title;
-            CurrentSong = song;
-            return this;
-        }
+    /// <summary>
+    /// Loads a BmpSong into the synthesizer
+    /// </summary>
+    /// <param name="song"></param> 
+    /// <returns>This BmpSiren</returns>
+    public async Task<BmpSiren> Load(BmpSong song)
+    {
+        if (!IsReady) throw new BmpException("Siren not initialized.");
+        if (_player.State == PlayerState.Playing) _player.Stop();
+        (var midiFile, _lyrics) = await song.GetSynthMidi();
+        _lyricIndex             = 0;
+        _player.LoadMidiFile(midiFile);
+        CurrentSongTitle = song.Title;
+        CurrentSong      = song;
+        return this;
+    }
 
-        /// <summary>
-        /// Starts the playback if possible
-        /// </summary>
-        /// <returns>This BmpSiren</returns>
-        public BmpSiren Play()
-        {
-            if (!IsReadyForPlayback) throw new BmpException("Siren not loaded with a song.");
-            _player.Play();
-            return this;
-        }
+    /// <summary>
+    /// Starts the playback if possible
+    /// </summary>
+    /// <returns>This BmpSiren</returns>
+    public BmpSiren Play()
+    {
+        if (!IsReadyForPlayback) throw new BmpException("Siren not loaded with a song.");
+        _player.Play();
+        return this;
+    }
 
-        /// <summary>
-        /// Pauses the playback if was running
-        /// </summary>
-        /// <returns>This BmpSiren</returns>
-        public BmpSiren Pause()
-        {
-            if (!IsReadyForPlayback) throw new BmpException("Siren not loaded with a song.");
-            _player.Pause();
-            return this;
-        }
+    /// <summary>
+    /// Pauses the playback if was running
+    /// </summary>
+    /// <returns>This BmpSiren</returns>
+    public BmpSiren Pause()
+    {
+        if (!IsReadyForPlayback) throw new BmpException("Siren not loaded with a song.");
+        _player.Pause();
+        return this;
+    }
         
-        /// <summary>
-        /// Stops the playback
-        /// </summary>
-        /// <returns>This BmpSiren</returns>
-        public BmpSiren Stop()
+    /// <summary>
+    /// Stops the playback
+    /// </summary>
+    /// <returns>This BmpSiren</returns>
+    public BmpSiren Stop()
+    {
+        if (!IsReadyForPlayback) throw new BmpException("Siren not loaded with a song.");
+        _player.Stop();
+        _lyricIndex = 0;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the current position of this song in milliseconds
+    /// </summary>
+    /// <returns>This BmpSiren</returns>
+    public BmpSiren SetPosition(int time)
+    {
+        if (!IsReadyForPlayback) return this; // throw new BmpException("Siren not loaded with a song.");
+        if (time < 0) time = 0;
+        //if (time > _player.PlaybackRange.EndTick) return Stop();
+        _player.TickPosition = time;
+        _lyricIndex          = time;
+        return this;
+    }
+
+    /// <summary>
+    /// Event fired when there is a lyric line.
+    /// </summary>
+    /// <param name="singer"></param>
+    /// <param name="line"></param>
+    public delegate void Lyric(int singer, string line);
+
+    public event Lyric LyricTrigger;
+
+    /// <summary>
+    /// Event fired when the position of a synthesized song changes.
+    /// </summary>
+    /// <param name="songTitle">The title of the current song.</param>
+    /// <param name="currentTime">The current time of this song in milliseconds</param>
+    /// <param name="endTime">The total length of this song in milliseconds</param>
+    /// <param name="activeVoices">Active voice count.</param>
+    public delegate void SynthTimePosition(string songTitle, double currentTime, double endTime, int activeVoices);
+
+    public event SynthTimePosition SynthTimePositionChanged;
+
+    internal void NotifyTimePosition(PositionChangedEventArgs obj)
+    {
+        SynthTimePositionChanged?.Invoke(CurrentSongTitle, obj.CurrentTime, obj.EndTime, obj.ActiveVoices);
+        for (var singer = 0; singer < _lyrics.Count; singer++)
         {
-            if (!IsReadyForPlayback) throw new BmpException("Siren not loaded with a song.");
-            _player.Stop();
-            _lyricIndex = 0;
-            return this;
+            var line = _lyrics[singer].FirstOrDefault(x => x.Key > _lyricIndex && x.Key < obj.CurrentTime).Value;
+            if (!string.IsNullOrWhiteSpace(line)) LyricTrigger?.Invoke(singer, line);
         }
-
-        /// <summary>
-        /// Sets the current position of this song in milliseconds
-        /// </summary>
-        /// <returns>This BmpSiren</returns>
-        public BmpSiren SetPosition(int time)
-        {
-            if (!IsReadyForPlayback) return this; // throw new BmpException("Siren not loaded with a song.");
-            if (time < 0) time = 0;
-            //if (time > _player.PlaybackRange.EndTick) return Stop();
-            _player.TickPosition = time;
-            _lyricIndex = time;
-            return this;
-        }
-
-        /// <summary>
-        /// Event fired when there is a lyric line.
-        /// </summary>
-        /// <param name="singer"></param>
-        /// <param name="line"></param>
-        public delegate void Lyric(int singer, string line);
-
-        public event Lyric LyricTrigger;
-
-        /// <summary>
-        /// Event fired when the position of a synthesized song changes.
-        /// </summary>
-        /// <param name="songTitle">The title of the current song.</param>
-        /// <param name="currentTime">The current time of this song in milliseconds</param>
-        /// <param name="endTime">The total length of this song in milliseconds</param>
-        /// <param name="activeVoices">Active voice count.</param>
-        public delegate void SynthTimePosition(string songTitle, double currentTime, double endTime, int activeVoices);
-
-        public event SynthTimePosition SynthTimePositionChanged;
-
-        internal void NotifyTimePosition(PositionChangedEventArgs obj)
-        {
-            SynthTimePositionChanged?.Invoke(CurrentSongTitle, obj.CurrentTime, obj.EndTime, obj.ActiveVoices);
-            for (var singer = 0; singer < _lyrics.Count; singer++)
-            {
-                var line = _lyrics[singer].FirstOrDefault(x => x.Key > _lyricIndex && x.Key < obj.CurrentTime).Value;
-                if (!string.IsNullOrWhiteSpace(line)) LyricTrigger?.Invoke(singer, line);
-            }
-            _lyricIndex = obj.CurrentTime;
-        }
+        _lyricIndex = obj.CurrentTime;
     }
 }

--- a/BardMusicPlayer.Siren/BmpSiren.cs
+++ b/BardMusicPlayer.Siren/BmpSiren.cs
@@ -12,7 +12,6 @@ using System.Threading.Tasks;
 using BardMusicPlayer.Quotidian;
 using BardMusicPlayer.Siren.AlphaTab;
 using BardMusicPlayer.Siren.AlphaTab.Audio.Synth;
-using BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi;
 using BardMusicPlayer.Siren.Properties;
 using BardMusicPlayer.Transmogrify.Song;
 using NAudio.CoreAudioApi;
@@ -22,12 +21,12 @@ namespace BardMusicPlayer.Siren
     public class BmpSiren
     {
         public string CurrentSongTitle { get; private set; } = "";
-        public BmpSong CurrentSong { get; private set; } = null;
+        public BmpSong CurrentSong { get; private set; }
 
         private IAlphaSynth _player;
         private Dictionary<int, Dictionary<long, string>> _lyrics;
         private double _lyricIndex;
-        private MMDevice _mdev = null;
+        private MMDevice _mdev;
 
         private static readonly Lazy<BmpSiren> LazyInstance = new(() => new BmpSiren());
         public static BmpSiren Instance => LazyInstance.Value;
@@ -85,7 +84,7 @@ namespace BardMusicPlayer.Siren
         /// <summary>
         /// 
         /// </summary>
-        public bool IsReady => _player != null && _player.IsReady;
+        public bool IsReady => _player is { IsReady: true };
 
         /// <summary>
         /// 
@@ -127,8 +126,7 @@ namespace BardMusicPlayer.Siren
         {
             if (!IsReady) throw new BmpException("Siren not initialized.");
             if (_player.State == PlayerState.Playing) _player.Stop();
-            MidiFile midiFile;
-            (midiFile, _lyrics) = await song.GetSynthMidi();
+            (var midiFile, _lyrics) = await song.GetSynthMidi();
             _lyricIndex = 0;
             _player.LoadMidiFile(midiFile);
             CurrentSongTitle = song.Title;

--- a/BardMusicPlayer.Siren/Utils.cs
+++ b/BardMusicPlayer.Siren/Utils.cs
@@ -80,33 +80,62 @@ namespace BardMusicPlayer.Siren
             switch (instrument.Index)
             {
                 case 1: // Harp
-                    if (note <= 9) return 1338;
-                    else if (note <= 19) return 1338;
-                    else if (note <= 28) return 1334;
-                    else return 1136;
+                    switch (note)
+                    {
+                        case <= 9:
+                        case <= 19:
+                            return 1338;
+                        case <= 28:
+                            return 1334;
+                        default:
+                            return 1136;
+                    }
 
                 case 2: // Piano
-                    if (note <= 11) return 1531;
-                    else if (note <= 18) return 1531;
-                    else if (note <= 25) return 1530;
-                    else if (note <= 28) return 1332;
-                    else return 1531;
+                    switch (note)
+                    {
+                        case <= 11:
+                        case <= 18:
+                            return 1531;
+                        case <= 25:
+                            return 1530;
+                        case <= 28:
+                            return 1332;
+                        default:
+                            return 1531;
+                    }
 
                 case 3: // Lute
-                    if (note <= 14) return 1728;
-                    else if (note <= 21) return 1727;
-                    else if (note <= 28) return 1727;
-                    else return 1528;
+                    switch (note)
+                    {
+                        case <= 14:
+                            return 1728;
+                        case <= 21:
+                        case <= 28:
+                            return 1727;
+                        default:
+                            return 1528;
+                    }
 
                 case 4: // Fiddle
-                    if (note <= 3) return 634;
-                    else if (note <= 6) return 632;
-                    else if (note <= 11) return 633;
-                    else if (note <= 15) return 634;
-                    else if (note <= 18) return 633;
-                    else if (note <= 23) return 635;
-                    else if (note <= 30) return 635;
-                    else return 635;
+                    switch (note)
+                    {
+                        case <= 3:
+                            return 634;
+                        case <= 6:
+                            return 632;
+                        case <= 11:
+                            return 633;
+                        case <= 15:
+                            return 634;
+                        case <= 18:
+                            return 633;
+                        case <= 23:
+                        case <= 30:
+                            return 635;
+                        default:
+                            return 635;
+                    }
 
                 case 5: // Flute
                 case 6: // Oboe
@@ -117,20 +146,29 @@ namespace BardMusicPlayer.Siren
                     return duration < 500 ? 500 : duration;
 
                 case 10: // Timpani
-                    if (note <= 15) return 1193;
-                    else if (note <= 23) return 1355;
-                    else return 1309;
+                    return note switch
+                    {
+                        <= 15 => 1193,
+                        <= 23 => 1355,
+                        _     => 1309
+                    };
 
                 case 11: // Bongo
-                    if (note <= 7) return 720;
-                    else if (note <= 21) return 544;
-                    else return 275;
+                    return note switch
+                    {
+                        <= 7  => 720,
+                        <= 21 => 544,
+                        _     => 275
+                    };
 
                 case 12: // BassDrum
-                    if (note <= 6) return 448;
-                    else if (note <= 11) return 335;
-                    else if (note <= 23) return 343;
-                    else return 254;
+                    return note switch
+                    {
+                        <= 6  => 448,
+                        <= 11 => 335,
+                        <= 23 => 343,
+                        _     => 254
+                    };
 
                 case 13: // SnareDrum
                     return 260;

--- a/BardMusicPlayer.Siren/Utils.cs
+++ b/BardMusicPlayer.Siren/Utils.cs
@@ -14,191 +14,190 @@ using Melanchall.DryWetMidi.Core;
 using Melanchall.DryWetMidi.Interaction;
 using MidiFile = BardMusicPlayer.Siren.AlphaTab.Audio.Synth.Midi.MidiFile;
 
-namespace BardMusicPlayer.Siren
+namespace BardMusicPlayer.Siren;
+
+internal static class Utils
 {
-    internal static class Utils
+    internal static async Task<(MidiFile, Dictionary<int, Dictionary<long, string>>)> GetSynthMidi(this BmpSong song)
     {
-        internal static async Task<(MidiFile, Dictionary<int, Dictionary<long, string>>)> GetSynthMidi(this BmpSong song)
-        {
-            var file = new MidiFile {Division = 600};
-            var events = new AlphaSynthMidiFileHandler(file);
-            events.AddTempo(0, 100);
+        var file = new MidiFile {Division = 600};
+        var events = new AlphaSynthMidiFileHandler(file);
+        events.AddTempo(0, 100);
 
-            var trackCounter = byte.MinValue;
-            var veryLast = 0L;
+        var trackCounter = byte.MinValue;
+        var veryLast = 0L;
 
-            var midiFile = await song.GetProcessedMidiFile();
+        var midiFile = await song.GetProcessedMidiFile();
 
-            var trackChunks = midiFile.GetTrackChunks().ToList();
+        var trackChunks = midiFile.GetTrackChunks().ToList();
             
-            var lyrics = new Dictionary<int, Dictionary<long, string>>();
-            var lyricNum = 0;
+        var lyrics = new Dictionary<int, Dictionary<long, string>>();
+        var lyricNum = 0;
 
-            foreach (var trackChunk in trackChunks)
+        foreach (var trackChunk in trackChunks)
+        {
+            var options = trackChunk.Events.OfType<SequenceTrackNameEvent>().First().Text.Split(':');
+            switch (options[0])
             {
-                var options = trackChunk.Events.OfType<SequenceTrackNameEvent>().First().Text.Split(':');
-                switch (options[0])
+                case "lyric":
                 {
-                    case "lyric":
+                    if (!lyrics.ContainsKey(lyricNum)) lyrics.Add(lyricNum, new Dictionary<long, string>(int.Parse(options[1])));
+
+                    foreach (var lyric in trackChunk.GetTimedEvents().Where(x => x.Event.EventType == MidiEventType.Lyric))
+                        lyrics[lyricNum].Add(lyric.Time, ((LyricEvent) lyric.Event).Text);
+
+                    lyricNum++;
+
+                    break;
+                }
+
+                case "tone":
+                {
+                    var tone = InstrumentTone.Parse(options[1]);
+                    foreach (var note in trackChunk.GetNotes())
                     {
-                        if (!lyrics.ContainsKey(lyricNum)) lyrics.Add(lyricNum, new Dictionary<long, string>(int.Parse(options[1])));
-
-                        foreach (var lyric in trackChunk.GetTimedEvents().Where(x => x.Event.EventType == MidiEventType.Lyric))
-                            lyrics[lyricNum].Add(lyric.Time, ((LyricEvent) lyric.Event).Text);
-
-                        lyricNum++;
-
-                        break;
+                        var instrument = tone.GetInstrumentFromChannel(note.Channel);
+                        var noteNum = note.NoteNumber;
+                        var dur = (int) MinimumLength(instrument, noteNum-48, note.Length);
+                        var time = (int) note.Time;
+                        events.AddProgramChange(trackCounter, time, trackCounter, (byte) instrument.MidiProgramChangeCode);
+                        events.AddNote(trackCounter, time, dur,noteNum, DynamicValue.FFF, trackCounter);
+                        if (trackCounter == byte.MaxValue) trackCounter = byte.MinValue;
+                        else trackCounter++;
+                        if (time + dur > veryLast) veryLast = time + dur;
                     }
 
-                    case "tone":
-                    {
-                        var tone = InstrumentTone.Parse(options[1]);
-                        foreach (var note in trackChunk.GetNotes())
-                        {
-                            var instrument = tone.GetInstrumentFromChannel(note.Channel);
-                            var noteNum = note.NoteNumber;
-                            var dur = (int) MinimumLength(instrument, noteNum-48, note.Length);
-                            var time = (int) note.Time;
-                            events.AddProgramChange(trackCounter, time, trackCounter, (byte) instrument.MidiProgramChangeCode);
-                            events.AddNote(trackCounter, time, dur,noteNum, DynamicValue.FFF, trackCounter);
-                            if (trackCounter == byte.MaxValue) trackCounter = byte.MinValue;
-                            else trackCounter++;
-                            if (time + dur > veryLast) veryLast = time + dur;
-                        }
-
-                        break;
-                    }
+                    break;
                 }
             }
-            events.FinishTrack(byte.MaxValue, (byte) veryLast);
-            return (file, lyrics);
         }
+        events.FinishTrack(byte.MaxValue, (byte) veryLast);
+        return (file, lyrics);
+    }
         
-        private static long MinimumLength(Instrument instrument, int note, long duration)
+    private static long MinimumLength(Instrument instrument, int note, long duration)
+    {
+        switch (instrument.Index)
         {
-            switch (instrument.Index)
-            {
-                case 1: // Harp
-                    switch (note)
-                    {
-                        case <= 9:
-                        case <= 19:
-                            return 1338;
-                        case <= 28:
-                            return 1334;
-                        default:
-                            return 1136;
-                    }
+            case 1: // Harp
+                switch (note)
+                {
+                    case <= 9:
+                    case <= 19:
+                        return 1338;
+                    case <= 28:
+                        return 1334;
+                    default:
+                        return 1136;
+                }
 
-                case 2: // Piano
-                    switch (note)
-                    {
-                        case <= 11:
-                        case <= 18:
-                            return 1531;
-                        case <= 25:
-                            return 1530;
-                        case <= 28:
-                            return 1332;
-                        default:
-                            return 1531;
-                    }
+            case 2: // Piano
+                switch (note)
+                {
+                    case <= 11:
+                    case <= 18:
+                        return 1531;
+                    case <= 25:
+                        return 1530;
+                    case <= 28:
+                        return 1332;
+                    default:
+                        return 1531;
+                }
 
-                case 3: // Lute
-                    switch (note)
-                    {
-                        case <= 14:
-                            return 1728;
-                        case <= 21:
-                        case <= 28:
-                            return 1727;
-                        default:
-                            return 1528;
-                    }
+            case 3: // Lute
+                switch (note)
+                {
+                    case <= 14:
+                        return 1728;
+                    case <= 21:
+                    case <= 28:
+                        return 1727;
+                    default:
+                        return 1528;
+                }
 
-                case 4: // Fiddle
-                    switch (note)
-                    {
-                        case <= 3:
-                            return 634;
-                        case <= 6:
-                            return 632;
-                        case <= 11:
-                            return 633;
-                        case <= 15:
-                            return 634;
-                        case <= 18:
-                            return 633;
-                        case <= 23:
-                        case <= 30:
-                            return 635;
-                        default:
-                            return 635;
-                    }
+            case 4: // Fiddle
+                switch (note)
+                {
+                    case <= 3:
+                        return 634;
+                    case <= 6:
+                        return 632;
+                    case <= 11:
+                        return 633;
+                    case <= 15:
+                        return 634;
+                    case <= 18:
+                        return 633;
+                    case <= 23:
+                    case <= 30:
+                        return 635;
+                    default:
+                        return 635;
+                }
 
-                case 5: // Flute
-                case 6: // Oboe
-                case 7: // Clarinet
-                case 8: // Fife
-                case 9: // Panpipes
-                    if (duration > 4500) return 4500;
-                    return duration < 500 ? 500 : duration;
+            case 5: // Flute
+            case 6: // Oboe
+            case 7: // Clarinet
+            case 8: // Fife
+            case 9: // Panpipes
+                if (duration > 4500) return 4500;
+                return duration < 500 ? 500 : duration;
 
-                case 10: // Timpani
-                    return note switch
-                    {
-                        <= 15 => 1193,
-                        <= 23 => 1355,
-                        _     => 1309
-                    };
+            case 10: // Timpani
+                return note switch
+                {
+                    <= 15 => 1193,
+                    <= 23 => 1355,
+                    _     => 1309
+                };
 
-                case 11: // Bongo
-                    return note switch
-                    {
-                        <= 7  => 720,
-                        <= 21 => 544,
-                        _     => 275
-                    };
+            case 11: // Bongo
+                return note switch
+                {
+                    <= 7  => 720,
+                    <= 21 => 544,
+                    _     => 275
+                };
 
-                case 12: // BassDrum
-                    return note switch
-                    {
-                        <= 6  => 448,
-                        <= 11 => 335,
-                        <= 23 => 343,
-                        _     => 254
-                    };
+            case 12: // BassDrum
+                return note switch
+                {
+                    <= 6  => 448,
+                    <= 11 => 335,
+                    <= 23 => 343,
+                    _     => 254
+                };
 
-                case 13: // SnareDrum
-                    return 260;
+            case 13: // SnareDrum
+                return 260;
 
-                case 14: // Cymbal
-                    return 700;
+            case 14: // Cymbal
+                return 700;
 
-                case 15: // Trumpet
-                case 16: // Trombone
-                case 17: // Tuba
-                case 18: // Horn
-                case 19: // Saxophone
-                case 20: // Violin
-                case 21: // Viola
-                case 22: // Cello
-                case 23: // DoubleBass
-                case 24: // ElectricGuitarOverdriven
-                case 25: // ElectricGuitarClean
-                case 27: // ElectricGuitarPowerChords
-                    if (duration > 4500) return 4500;
-                    return duration < 300 ? 300 : duration;
+            case 15: // Trumpet
+            case 16: // Trombone
+            case 17: // Tuba
+            case 18: // Horn
+            case 19: // Saxophone
+            case 20: // Violin
+            case 21: // Viola
+            case 22: // Cello
+            case 23: // DoubleBass
+            case 24: // ElectricGuitarOverdriven
+            case 25: // ElectricGuitarClean
+            case 27: // ElectricGuitarPowerChords
+                if (duration > 4500) return 4500;
+                return duration < 300 ? 300 : duration;
 
-                case 26: // ElectricGuitarMuted
-                    return 400;
+            case 26: // ElectricGuitarMuted
+                return 400;
 
-                case 28: // ElectricGuitarSpecial
-                    return 1500;
+            case 28: // ElectricGuitarSpecial
+                return 1500;
 
-                default: return duration;
-            }
+            default: return duration;
         }
     }
 }


### PR DESCRIPTION
WARNING
- Redundancies in Symbol Declarations
  * Redundant member initializer
      Initializing property by default value is redundant (3)
      Initializing field by default value is redundant (2)
  * Redundant 'partial' modifier on type declaration
      Partial class with single part (1)
- Redundancies in Code
  * Redundant cast
      Type cast is redundant (19)
  * Redundant name qualifier
      Qualifier is redundant (2)
  * Redundant using directive
      Using directive is not required by the code and can be safely removed (1)
  * Redundant control flow jump statement
      Redundant control flow jump statement (1)
  * Expression is always 'true' or always 'false'
      Expression is always true (1)
	  Expression is always false (1)
  * Assignment is not used
      Value assigned is not used in any execution path (1)
  * Heuristically unreachable code
      Code is heuristically unreachable (1)
- Potential Code Quality Issues
  * Possible 'System.NullReferenceException'
      Possible 'System.NullReferenceException' (9)
- Compiler Warnings
  * Non-accessed local variable
      Local variable 'isSongBook' is only assigned but its value is never used (1)

SUGGESTION
- Spelling Issues
  * Typo in comment
      Various (?)
  * Typo in identifier
      Various (?)
- Language Usage Opportunities
  * Merge null/pattern checks into complex pattern
      Merge into pattern (14)
  * Inline 'out' variable declaration
      Inline 'out' variable declaration (1)
  * 'if' statement can be rewritten as '??=' assignment
      Convert into '??=' (3)
  * Use object or collection initializer when possible
      Use object initializer (17)
  * Merge conditional ?: expression into conditional access
      Merge conditional expression (5)
  * For-loop can be converted into foreach-loop
      For-loop can be converted into foreach-loop (3)
  * 'if' statement can be rewritten as '?:' expression
      Convert into '?:' expression (3)
- Redundancies in Code
  * Redundant [AttributeUsage] attribute property assignment
      Redundant [AttributeUsage] property assignment: provided value is equal to default (2)
- Syntax Style
  * Use preferred style of 'new' expression when created type is evident
      Redundant type specification (4)
- Redundancies in Symbol Declarations
  * Virtual (overridable) member is never overridden
      Virtual method 'OnReady' is never overridden
	  Virtual method 'OnReadyForPlayback' is never overridden
	  Virtual method 'OnFinished' is never overridden
	  Virtual method 'OnSoundFontLoaded' is never overridden
	  Virtual method 'OnMidiLoaded' is never overridden
	  Virtual method 'OnMidiLoadFailed' is never overridden
	  Virtual method 'OnStateChanged' is never overridden
	  Virtual Method 'OnPositionChanged' is never overridden
  * Class with virtual (overridable) members never inherited
      Class 'ByteBuffer' has some virtual members but no inheritors
	  Class 'MidiFileSequencer' has some virtual members but no inheritors
	  Class 'TinySoundFont' has some virtual members but no inheritors
- Common Practices and Code Improvements
  * Join local variable declaration and assignment
      Join declaration and assignment (3)
  * Use 'Array.Empty<T>()'
      Use 'Array<int>.Empty()' (1)
	  Use 'Array<byte>.Empty()' (1)

HINT
- Syntax Style
  * Use preferred namespace body style
      Convert to file-scoped namespace (104)
  * Add/remove qualifier for static members
      Qualifier is redundant (2)
  * Remove redundant parentheses
      Redundant parentheses (71)
  * Add/remove 'this.' qualifier
      Qualifier 'this.' is redundant (4)
  * Use preferred 'var' style
      Use 'var' (built-in types)/(simple types) (22)
- Language Usage Opportunities
  * Convert 'if' statement into 'switch'
      Convert 'if' statement into 'switch' statement (19)
	  Convert 'if' statement into 'switch' (7)
  * Merge negated null/pattern checks into complex pattern
      Merge into pattern (2)
  * Merge null/pattern/value checks into 'or'/'and' patterns
      Merge into logical pattern (8)
  * 'if-return' statement can be rewritten as 'return' statement
      Convert into 'return' statement (10)
  * Replace if statement with null-propagating code
      Use null propagation (11)
  * Part of foreach loop can be converted into LINQ-expression but another 'GetEnumerator' method will be used
      Part of foreach loop can be converted into LINQ-expression but another 'GetEnumerator' method will be used (11)
  * Replace 'switch' statement with 'switch' expression
      Convert 'switch' statement to 'switch' expression (2)
  * Loop can be converted into LINQ-expression
      Loop can be converted into LINQ-expression (3)
  * Use compound assignment
      Convert into compound assignment (1)
- Common Practices and Code Improvements
  * Member can be made static (shared)
      Method 'PrepareChunk' can be made static
	  Method 'MakeCommand' can be made static
	  Method 'Parse' can be made static