### PR TITLE
Clean up chat types

### DIFF
--- a/BardMusicPlayer.Quotidian/Structs/ChatMessageStructs.cs
+++ b/BardMusicPlayer.Quotidian/Structs/ChatMessageStructs.cs
@@ -8,18 +8,18 @@ public readonly struct ChatMessageChannelType
 {
     public static readonly ChatMessageChannelType None  = new("None",   0x0000, "");
     public static readonly ChatMessageChannelType Say   = new("Say",    0x000A, "/s");
-    public static readonly ChatMessageChannelType Shout = new("Shout",  0x000B, "/sh");
-    public static readonly ChatMessageChannelType Group = new("Group",  0x000E, "/p");
-    public static readonly ChatMessageChannelType FC    = new("FC",     0x0018, "/fc");
     public static readonly ChatMessageChannelType Yell  = new("Yell",   0x001E, "/y");
+    public static readonly ChatMessageChannelType Shout = new("Shout",  0x000B, "/sh");
+    public static readonly ChatMessageChannelType Party = new("Party",  0x000E, "/p");
+    public static readonly ChatMessageChannelType FC    = new("FC",     0x0018, "/fc");
     public static readonly IReadOnlyList<ChatMessageChannelType> All = new ReadOnlyCollection<ChatMessageChannelType>(new List<ChatMessageChannelType>
     {
         None,
         Say,
+        Yell,
         Shout,
-        Group,
-        FC,
-        Yell
+        Party,
+        FC
     });
 
     public string Name { get; }

--- a/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml
+++ b/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml
@@ -55,11 +55,12 @@
                         </Grid.ColumnDefinitions>
                         <Label Grid.Row="0" Grid.ColumnSpan="3" Content="Post song title:" />
                         <ComboBox Grid.Row="1" Grid.Column="0" x:Name="Songtitle_Chat_Type" HorizontalAlignment="Left"
-                                  VerticalAlignment="Stretch" Width="50"
+                                  VerticalAlignment="Stretch" Width="80"
                                   SelectionChanged="SongTitle_Post_Type_SelectionChanged">
-                            <ComboBoxItem>say</ComboBoxItem>
-                            <ComboBoxItem>yell</ComboBoxItem>
-                            <ComboBoxItem>shout</ComboBoxItem>
+                            <ComboBoxItem>Say</ComboBoxItem>
+                            <ComboBoxItem>Yell</ComboBoxItem>
+                            <ComboBoxItem>Shout</ComboBoxItem>
+                            <ComboBoxItem>Party</ComboBoxItem>
                         </ComboBox>
                         <TextBox Grid.Row="1" Grid.Column="2" x:Name="Songtitle_Chat_Prefix" Text="♪" Width="30"
                                  HorizontalAlignment="Left" VerticalAlignment="Stretch" />
@@ -67,10 +68,10 @@
                         <Label Grid.Row="1" Grid.Column="6" Content="AutoPost" HorizontalAlignment="Left"
                                VerticalAlignment="Top" />
                         <ComboBox Grid.Row="1" Grid.Column="8" x:Name="Songtitle_Post_Type" Text="AutoPost via"
-                                  HorizontalAlignment="Left" VerticalAlignment="Stretch" MinWidth="90"
+                                  HorizontalAlignment="Left" VerticalAlignment="Stretch" MinWidth="45"
                                   SelectionChanged="SongTitle_Post_Type_SelectionChanged">
-                            <ComboBoxItem>off</ComboBoxItem>
-                            <ComboBoxItem>on</ComboBoxItem>
+                            <ComboBoxItem>Off</ComboBoxItem>
+                            <ComboBoxItem>On</ComboBoxItem>
                         </ComboBox>
                         <Separator Grid.Row="3" Grid.ColumnSpan="10" Grid.Column="0" />
                     </Grid>
@@ -99,11 +100,11 @@
                         <Label Grid.Row="1" Grid.Column="0" Content="Chat Type:" VerticalAlignment="Center" />
                         <ComboBox Grid.Row="1" Grid.Column="1" x:Name="Chat_Type" HorizontalAlignment="Left"
                                   VerticalAlignment="Top" Width="120">
-                            <ComboBoxItem>say</ComboBoxItem>
-                            <ComboBoxItem>yell</ComboBoxItem>
-                            <ComboBoxItem>party</ComboBoxItem>
-                            <ComboBoxItem>company</ComboBoxItem>
-                            <ComboBoxItem>macro</ComboBoxItem>
+                            <ComboBoxItem>Say</ComboBoxItem>
+                            <ComboBoxItem>Yell</ComboBoxItem>
+                            <ComboBoxItem>Shout</ComboBoxItem>
+                            <ComboBoxItem>Party</ComboBoxItem>
+                            <ComboBoxItem>Free Company</ComboBoxItem>
                         </ComboBox>
 
                         <Label Grid.Row="2" Grid.Column="0" Content="Text Message:" />

--- a/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml.cs
+++ b/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml.cs
@@ -59,6 +59,7 @@ public sealed partial class BardExtSettingsWindow
             0 => ChatMessageChannelType.Say,
             1 => ChatMessageChannelType.Yell,
             2 => ChatMessageChannelType.Shout,
+            3 => ChatMessageChannelType.Party,
             _ => ChatMessageChannelType.None
         };
 
@@ -96,9 +97,9 @@ public sealed partial class BardExtSettingsWindow
             {
                 0 => ChatMessageChannelType.Say,
                 1 => ChatMessageChannelType.Yell,
-                2 => ChatMessageChannelType.Group,
-                3 => ChatMessageChannelType.FC,
-                4 => ChatMessageChannelType.None,
+                2 => ChatMessageChannelType.Shout,
+                3 => ChatMessageChannelType.Party,
+                4 => ChatMessageChannelType.FC,
                 _ => ChatMessageChannelType.None
             };
             var text = new string(ChatInputText.Text.ToCharArray());


### PR DESCRIPTION
* Removed 'macro' type since it wasn't name clarified as using whatever the client had set as default.
* Renamed group to party.
* Added missing party option.
* Capitalized to match in-game categories.