### PR TITLE
Fix external lyric performing

### DIFF
--- a/BardMusicPlayer.Maestro/Performance/Performer.cs
+++ b/BardMusicPlayer.Maestro/Performance/Performer.cs
@@ -16,7 +16,7 @@ using BardMusicPlayer.Pigeonhole;
 using BardMusicPlayer.Quotidian.Enums;
 using BardMusicPlayer.Quotidian.Structs;
 using BardMusicPlayer.Seer;
-using BardMusicPlayer.Transmogrify;
+using BardMusicPlayer.Transmogrify.Song.Config;
 using Sanford.Multimedia.Midi;
 using Sequencer = BardMusicPlayer.Maestro.Sequencing.Sequencer;
 

--- a/BardMusicPlayer.Maestro/Performance/Performer.cs
+++ b/BardMusicPlayer.Maestro/Performance/Performer.cs
@@ -16,7 +16,7 @@ using BardMusicPlayer.Pigeonhole;
 using BardMusicPlayer.Quotidian.Enums;
 using BardMusicPlayer.Quotidian.Structs;
 using BardMusicPlayer.Seer;
-using BardMusicPlayer.Transmogrify.Song.Config;
+using BardMusicPlayer.Transmogrify;
 using Sanford.Multimedia.Midi;
 using Sequencer = BardMusicPlayer.Maestro.Sequencing.Sequencer;
 
@@ -646,7 +646,7 @@ public class Performer
         var builder = new MetaTextBuilder(e.Message);
         var text = builder.Text;
         var t = mainSequencer.MaxTrack;
-        if (_sequencer.GetTrackNum(e.MidiTrack) == SingerTrackNr+ Sequencer.LyricStartTrack-1)
+        if (_sequencer.GetTrackNum(e.MidiTrack) == SingerTrackNr + mainSequencer.LyricStartTrack - 1)
             game.SendText(ChatMessageChannelType.Say, text);
     }
     #endregion


### PR DESCRIPTION
* Fixes saved lyric files from preview tab not performing when a song is loaded and ``Lyrics Track Number`` is set to 1 on a performer in their performer settings.

External lyrics are said in say chat and can't be changed.

This _should_ be the final thing to match parity with LightAmp now, excluding MidiUtil.