### PR TITLE
Autopost Changes

### DIFF
--- a/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml
+++ b/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml
@@ -61,7 +61,6 @@
                                   SelectionChanged="SongTitle_Post_Type_SelectionChanged">
                             <ComboBoxItem>Say</ComboBoxItem>
                             <ComboBoxItem>Yell</ComboBoxItem>
-                            <ComboBoxItem>Shout</ComboBoxItem>
                             <ComboBoxItem>Party</ComboBoxItem>
                         </ComboBox>
                         <TextBox Grid.Row="1" Grid.Column="2" x:Name="Songtitle_Chat_Prefix" Text="♪" Width="30"

--- a/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml.cs
+++ b/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml.cs
@@ -40,7 +40,7 @@ public sealed partial class BardExtSettingsWindow
                     Songtitle_Chat_Type.SelectedIndex = 0;
                 else if (tpBard.Key.channelType.ChannelCode == ChatMessageChannelType.Yell.ChannelCode)
                     Songtitle_Chat_Type.SelectedIndex = 1;
-                else if (tpBard.Key.channelType.ChannelCode == ChatMessageChannelType.Shout.ChannelCode)
+                else if (tpBard.Key.channelType.ChannelCode == ChatMessageChannelType.Party.ChannelCode)
                     Songtitle_Chat_Type.SelectedIndex = 2;
 
                 Songtitle_Post_Type.SelectedIndex = tpBard.Key.channelType.Equals(ChatMessageChannelType.None) ? 0 : 1;
@@ -58,8 +58,7 @@ public sealed partial class BardExtSettingsWindow
         {
             0 => ChatMessageChannelType.Say,
             1 => ChatMessageChannelType.Yell,
-            2 => ChatMessageChannelType.Shout,
-            3 => ChatMessageChannelType.Party,
+            2 => ChatMessageChannelType.Party,
             _ => ChatMessageChannelType.None
         };
 
@@ -83,6 +82,7 @@ public sealed partial class BardExtSettingsWindow
         {
             0 => ChatMessageChannelType.Say,
             1 => ChatMessageChannelType.Yell,
+            2 => ChatMessageChannelType.Party,
             _ => ChatMessageChannelType.None
         };
         var songName = $"{Songtitle_Chat_Prefix.Text} {_performer.SongName} {Songtitle_Chat_Prefix.Text}";


### PR DESCRIPTION
Possibly a controversial change.

* Don't allow people to autopost their song title in shout. Primarily to prevent abuse and zone wide spam.
* Fix autoposting to party. Useful if you are remote playing with someone and you want to tell them which song to load. Or just keep track of songs you've played if people ask what was played.