### PR TITLE
UI Improvements

### DIFF
--- a/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml
+++ b/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml
@@ -57,14 +57,14 @@
                         <Label Grid.Row="0" Grid.ColumnSpan="3" Content="Post song title:" />
                         <ComboBox Grid.Row="1" Grid.Column="0" x:Name="Songtitle_Chat_Type" HorizontalAlignment="Left"
                                   Background="White"
-                                  VerticalAlignment="Stretch" Width="80" Padding="5px"
+                                  VerticalAlignment="Stretch" Width="80" Padding="5"
                                   SelectionChanged="SongTitle_Post_Type_SelectionChanged">
                             <ComboBoxItem>Say</ComboBoxItem>
                             <ComboBoxItem>Yell</ComboBoxItem>
                             <ComboBoxItem>Party</ComboBoxItem>
                         </ComboBox>
                         <TextBox Grid.Row="1" Grid.Column="2" x:Name="Songtitle_Chat_Prefix" Text="♪" Width="30"
-                                 Padding="5px" Background="White"
+                                 Padding="5" Background="White"
                                  HorizontalAlignment="Left" VerticalAlignment="Stretch" />
                         <Button Grid.Row="1" Grid.Column="4" Content="Send Title" Click="PostSongTitle_Click"
                                 Background="White" />
@@ -72,7 +72,7 @@
                                VerticalAlignment="Top" />
                         <ComboBox Grid.Row="1" Grid.Column="8" x:Name="Songtitle_Post_Type" Text="AutoPost via"
                                   Background="White"
-                                  HorizontalAlignment="Left" VerticalAlignment="Stretch" MinWidth="45" Padding="5px"
+                                  HorizontalAlignment="Left" VerticalAlignment="Stretch" MinWidth="45" Padding="5"
                                   SelectionChanged="SongTitle_Post_Type_SelectionChanged">
                             <ComboBoxItem>Off</ComboBoxItem>
                             <ComboBoxItem>On</ComboBoxItem>
@@ -104,7 +104,7 @@
                         <Label Grid.Row="1" Grid.Column="0" Content="Chat Type:" VerticalAlignment="Center" />
                         <ComboBox Grid.Row="1" Grid.Column="1" x:Name="Chat_Type" HorizontalAlignment="Left"
                                   Background="White"
-                                  VerticalAlignment="Top" Width="120" Padding="5px">
+                                  VerticalAlignment="Top" Width="120" Padding="5">
                             <ComboBoxItem>Say</ComboBoxItem>
                             <ComboBoxItem>Yell</ComboBoxItem>
                             <ComboBoxItem>Shout</ComboBoxItem>
@@ -115,7 +115,7 @@
                         <Label Grid.Row="2" Grid.Column="0" Content="Text Message:" />
                         <TextBox Grid.Row="2" Grid.Column="1" x:Name="ChatInputText" KeyDown="ChatInputText_KeyDown"
                                  Background="White"
-                                 Height="Auto" Width="240" Padding="5px" />
+                                 Height="Auto" Width="240" Padding="5" />
                         <Separator Grid.Row="4" Grid.ColumnSpan="8" Grid.Column="0" />
                     </Grid>
 

--- a/BardMusicPlayer/Controls/BardView.xaml
+++ b/BardMusicPlayer/Controls/BardView.xaml
@@ -62,8 +62,8 @@
                 <DataTemplate DataType="{x:Type performance:Performer}">
                     <Grid>
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="*" />
-                            <RowDefinition Height="*" />
+                            <RowDefinition Height="12" />
+                            <RowDefinition Height="25" />
                         </Grid.RowDefinitions>
 
                         <Grid.ColumnDefinitions>
@@ -82,13 +82,12 @@
                             <ColumnDefinition Width="10" />     <!-- 12 spacer-->
                             <ColumnDefinition Width="Auto" />   <!-- 13 -->
                         </Grid.ColumnDefinitions>
-
-                        <materialDesign:PackIcon
-                            Grid.Column="1" Grid.Row="0" Grid.RowSpan="2"
-                            MouseDown="Bard_MouseDown"
-                            VerticalAlignment="Center" HorizontalAlignment="Center"
-                            Kind="MenuOpen" Padding="0" />
-
+                        <Button Grid.Column="1" Grid.Row="1" Height="Auto" Width="Auto"
+                                Padding="0" Margin="0,-5,0,0"
+                                VerticalAlignment="Top" HorizontalAlignment="Center"
+                                MouseDown="Bard_MouseClick">
+                                <materialDesign:PackIcon Kind="MenuOpen" />
+                        </Button>
                         <TextBlock Grid.Column="3" Grid.Row="0" Text="{Binding PlayerName}" MouseDown="Bard_MouseDown" />
                         <TextBlock Grid.Column="3" Grid.Row="1"
                                    Text="{Binding HomeWorld, Mode=OneTime, StringFormat=m\\:ss}"
@@ -129,14 +128,14 @@
                                                      PreviewMouseUp="TrackNumericUpDown_MouseUp"
                                                      Value="{Binding TrackNumber}"
                                                      Padding="0" Width="Auto" Height="12"
-                                                     HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                     HorizontalAlignment="Center" VerticalAlignment="Top"
                                                      Margin="0,0,1,0" />
                         <!--<TextBlock Grid.Column="9" Grid.Row="0" Text="Octave" HorizontalAlignment="Center" />-->
                         <controls:OctaveNumericUpDown Grid.Column="9" Grid.Row="1" x:Name="OctaveControl"
                                                       PreviewMouseUp="OctaveControl_PreviewMouseUp"
                                                       Value="{Binding OctaveShift}"
                                                       Padding="0" Width="Auto" Height="12"
-                                                      HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                                      HorizontalAlignment="Center" VerticalAlignment="Top" />
 
                         <TextBlock Grid.Column="11" Grid.Row="0" Text="Host" HorizontalAlignment="Center"
                                    VerticalAlignment="Center" Padding="0" Width="Auto" />

--- a/BardMusicPlayer/Controls/BardView.xaml.cs
+++ b/BardMusicPlayer/Controls/BardView.xaml.cs
@@ -174,6 +174,15 @@ public partial class BardView
         if ((sender as CheckBox)?.DataContext is Performer game) game.PerformerEnabled = ctl.IsChecked ?? false;
     }
 
+    private void Bard_MouseClick(object sender, MouseButtonEventArgs e)
+    {
+        if (SelectedBard == null)
+                return;
+        
+        var bardExtSettings = new BardExtSettingsWindow(SelectedBard);
+        bardExtSettings.Activate();
+        bardExtSettings.Visibility = Visibility.Visible;
+    }
     private void Bard_MouseDown(object sender, MouseButtonEventArgs e)
     {
         if (e.ClickCount == 2)

--- a/BardMusicPlayer/Controls/MacroEditWindow.xaml
+++ b/BardMusicPlayer/Controls/MacroEditWindow.xaml
@@ -5,31 +5,39 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
         ResizeMode="NoResize"
-        Title="MacroEditWindow" WindowStyle="ToolWindow" Height="100" Width="400">
+        Title="MacroEditWindow" WindowStyle="ToolWindow" Height="200" Width="400" Background="{StaticResource BMPSuiteLightGrey}">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="25" />
+            <RowDefinition Height="10" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="10" />
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="10" />
         </Grid.ColumnDefinitions>
 
-        <Label Grid.Row="0" Grid.Column="0" Content="Macro Name" />
-        <TextBox Grid.Row="0" Grid.Column="1" x:Name="MacroName" HorizontalAlignment="Stretch"
-                 TextChanged="MacroName_TextChanged" Padding="5" Background="White" />
+        <Label Grid.Row="0" Grid.Column="1" Content="Macro Name:" />
+        <TextBox Grid.Row="1" Grid.Column="1" x:Name="MacroName" HorizontalAlignment="Stretch"
+                 TextChanged="MacroName_TextChanged" Background="White" Padding="5"/>
 
-        <Label Grid.Row="1" Grid.Column="0" Content="Macro File" Background="White" />
+        <Label Grid.Row="2" Grid.Column="1" Content="Macro Path:"/>
 
-        <Grid Grid.Row="1" Grid.Column="1">
+        <Grid Grid.Row="3" Grid.Column="1">
+            <Label x:Name="MacroFileName" Background="White" Padding="5"/>
+        </Grid>
+        <Grid Grid.Row="5" Grid.Column="1">
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="10" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <Label Grid.Column="0" x:Name="MacroFileName" />
-            <Button Grid.Column="1" Click="Button_Click" Content="Select File" Background="White" />
+            <Button Grid.Column="0" Content="Select File" Click="Button_Click" Background="White" />
+            <Button Grid.Column="2" Content="Close" Click="Cancel_Click" Background="White" />
         </Grid>
     </Grid>
 </Window>

--- a/BardMusicPlayer/Controls/MacroEditWindow.xaml.cs
+++ b/BardMusicPlayer/Controls/MacroEditWindow.xaml.cs
@@ -43,6 +43,11 @@ public sealed partial class MacroEditWindow
         MacroFileName.Content = openFileDialog.FileName;
     }
 
+    private void Cancel_Click(object sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+    
     private void MacroName_TextChanged(object sender, TextChangedEventArgs e)
     {
         _macro.DisplayedText = MacroName.Text;

--- a/BardMusicPlayer/Controls/NetworkWindow.xaml
+++ b/BardMusicPlayer/Controls/NetworkWindow.xaml
@@ -20,7 +20,7 @@
     <Grid>
         <TabControl TabStripPlacement="Top" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
             <TabItem Header="Network Party">
-                <Grid Background="#FFE5E5E5">
+                <Grid Background="{StaticResource BMPSuiteLightGrey}">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="10" />
                         <ColumnDefinition Width="70" />
@@ -35,7 +35,7 @@
                         <RowDefinition Height="50" />
                     </Grid.RowDefinitions>
                     <Label Grid.Row="1" Grid.Column="1" Content="Party Token" Padding="0" />
-                    <TextBox Grid.Row="1" Grid.Column="2" x:Name="PartyToken_Text" />
+                    <TextBox Grid.Row="1" Grid.Column="2" x:Name="PartyToken_Text" Background="White" Padding="5"/>
                     <Button Grid.Row="2" Grid.Column="1" Content="Join" Click="Join_Click" Padding="0" Height="Auto"
                             Background="White" />
                     <Button Grid.Row="2" Grid.Column="2" Content="Leave" Click="Leave_Click" Padding="0" Height="Auto"
@@ -44,7 +44,7 @@
                             Height="Auto" Background="White" Width="60" HorizontalAlignment="Left" Margin="60,0,0,0"
                             FontSize="12" />
                     <TextBox Grid.Row="3" Grid.ColumnSpan="2" Grid.Column="1" x:Name="PartyMessage_Text"
-                             VerticalScrollBarVisibility="Visible" />
+                             VerticalScrollBarVisibility="Visible" Background="White"/>
                 </Grid>
             </TabItem>
             <TabItem Header="Debug">

--- a/BardMusicPlayer/Controls/SongBrowser.xaml
+++ b/BardMusicPlayer/Controls/SongBrowser.xaml
@@ -23,7 +23,7 @@
 
             <Label Grid.Column="0" Content="Path:" HorizontalAlignment="Left" />
             <TextBox Grid.Column="1" x:Name="SongPath" Background="White" Text=""
-                     Margin="-50,0 10,0" Padding="5px" VerticalAlignment="Center" HorizontalAlignment="Stretch"
+                     Margin="-50,0 10,0" Padding="5" VerticalAlignment="Center" HorizontalAlignment="Stretch"
                      PreviewTextInput="SongPath_PreviewTextInput" />
             <Button Grid.Column="2" Content="..." Background="White" Margin="-4,0 4,0"
                     Click="Button_Click" Height="18" Padding="5" />
@@ -36,7 +36,7 @@
             </Grid.ColumnDefinitions>
             <Label Grid.Column="0" Content="Search:" HorizontalAlignment="Left" />
             <TextBox Grid.Column="1" Text="" x:Name="SongSearch" Background="White"
-                     Margin="-50,0 10,0" Padding="5px" VerticalAlignment="Center"
+                     Margin="-50,0 10,0" Padding="5" VerticalAlignment="Center"
                      PreviewTextInput="SongSearch_PreviewTextInput" />
         </Grid>
         <Grid Grid.Row="2" Background="White">

--- a/BardMusicPlayer/Controls/SongEditWindow.xaml
+++ b/BardMusicPlayer/Controls/SongEditWindow.xaml
@@ -4,7 +4,8 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d"
-        Title="Edit song" Height="200" Width="400" ResizeMode="NoResize">
+        Title="Edit song" Height="250" Width="400" ResizeMode="NoResize"
+        Background="{StaticResource BMPSuiteLightGrey}">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="10" />
@@ -22,18 +23,18 @@
             <ColumnDefinition Width="10" />
         </Grid.ColumnDefinitions>
         <Label Grid.Row="1" Grid.Column="1" Content="Internal track name:" />
-        <TextBox Grid.Row="2" Grid.Column="1" x:Name="Internal_TrackName" Text="" IsReadOnly="True" />
-        <Button Grid.Row="3" Grid.Column="1" Content="Copy internal to displayed" Click="CopyI_D_Click" />
+        <TextBox Grid.Row="2" Grid.Column="1" x:Name="Internal_TrackName" Text="" IsReadOnly="True" Background="White" Padding="5" />
+        <Button Grid.Row="3" Grid.Column="1" Content="Copy internal to displayed" Click="CopyI_D_Click" Background="White" />
         <Label Grid.Row="4" Grid.Column="1" Content="Displayed track name:" />
-        <TextBox Grid.Row="5" Grid.Column="1" x:Name="Displayed_TrackName" Text="" />
+        <TextBox Grid.Row="5" Grid.Column="1" x:Name="Displayed_TrackName" Text="" Background="White" Padding="5" />
         <Grid Grid.Row="7" Grid.Column="1">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="10" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <Button Grid.Column="0" Content="Save" Click="Save_Click" />
-            <Button Grid.Column="2" Content="Close" Click="Cancel_Click" />
+            <Button Grid.Column="0" Content="Save" Click="Save_Click" Background="White" />
+            <Button Grid.Column="2" Content="Close" Click="Cancel_Click" Background="White" />
         </Grid>
     </Grid>
 </Window>

--- a/BardMusicPlayer/MainWindow.xaml
+++ b/BardMusicPlayer/MainWindow.xaml
@@ -12,8 +12,7 @@
         TextOptions.TextFormattingMode="Ideal"
         TextOptions.TextRenderingMode="Auto"
         Background="{DynamicResource MaterialDesignPaper}"
-        WindowStartupLocation="CenterScreen"
-        Height="665" Width="880">
+        WindowStartupLocation="CenterScreen">
 
     <Grid Margin="2">
         <ContentControl Content="{Binding}" />

--- a/BardMusicPlayer/MainWindow.xaml.cs
+++ b/BardMusicPlayer/MainWindow.xaml.cs
@@ -20,8 +20,8 @@ public partial class MainWindow
         DataContext        = new Classic_MainView();
         AllowsTransparency = false;
         WindowStyle        = WindowStyle.SingleBorderWindow;
-        Height             = 665;
-        Width              = 880;
+        Height             = 738;
+        Width              = 910;
         ResizeMode         = ResizeMode.CanResizeWithGrip;
     }
 }

--- a/BardMusicPlayer/Resources/Defaults.xaml
+++ b/BardMusicPlayer/Resources/Defaults.xaml
@@ -1,4 +1,5 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes">
 
     <ResourceDictionary.MergedDictionaries>
@@ -19,4 +20,17 @@
 
     <Style TargetType="GroupBox" BasedOn="{StaticResource DefaultGroupBoxStyle}" />
     <Style TargetType="Button" BasedOn="{StaticResource MaterialDesignOutlinedLightButton}" />
+    <Style TargetType="TabItem" BasedOn="{StaticResource MaterialDesignTabItem}" />
+
+    <Style x:Key="PlayButton" TargetType="Button" BasedOn="{StaticResource MaterialDesignOutlinedLightButton}">
+        <Setter Property="ContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <StackPanel>
+                        <TextBlock Text="{Binding}" FontSize="24" />
+                    </StackPanel>
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
 </ResourceDictionary>

--- a/BardMusicPlayer/Resources/TextInputWindow.xaml
+++ b/BardMusicPlayer/Resources/TextInputWindow.xaml
@@ -5,6 +5,7 @@
         SizeToContent="WidthAndHeight"
         MinWidth="300"
         MinHeight="100"
+        Background="{StaticResource BMPSuiteLightGrey}"
         WindowStyle="SingleBorderWindow"
         ResizeMode="CanMinimize">
     <Grid>
@@ -22,7 +23,7 @@
         </Grid.ColumnDefinitions>
 
         <TextBlock Grid.Row="0" Grid.Column="1" x:Name="InfoText" />
-        <TextBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" x:Name="ResponseTextBox" />
+        <TextBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" x:Name="ResponseTextBox" Background="White" Padding="5"/>
         <Grid Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
@@ -31,9 +32,9 @@
                 <ColumnDefinition Width="55" />
             </Grid.ColumnDefinitions>
             <Button Grid.Column="1" Content="_Okay" IsDefault="True" Click="OKButton_Click" Margin="0,20,0,0"
-                    Padding="0" />
+                    Padding="0" Background="White"/>
             <Button Grid.Column="3" Content="_Cancel" IsCancel="True" Click="CancelButton_Click" Margin="0,20,0,0"
-                    Padding="0" />
+                    Padding="0" Background="White"/>
         </Grid>
     </Grid>
 </Window>

--- a/BardMusicPlayer/UI_Classic/Classic_MainView.xaml
+++ b/BardMusicPlayer/UI_Classic/Classic_MainView.xaml
@@ -167,7 +167,7 @@
                 </Grid.ColumnDefinitions>
                 <TabControl Grid.ColumnSpan="2">
                     <TabItem Header="Performers" Width="Auto" Height="35" Padding="0">
-                    <Grid Background="White">
+                        <Grid Background="White">
                             <controls:BardView x:Name="BardsList" />
                         </Grid>
                     </TabItem>

--- a/BardMusicPlayer/UI_Classic/Classic_MainView.xaml
+++ b/BardMusicPlayer/UI_Classic/Classic_MainView.xaml
@@ -6,7 +6,7 @@
              xmlns:controls="clr-namespace:BardMusicPlayer.Controls"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              mc:Ignorable="d"
-             d:DesignHeight="665" d:DesignWidth="880"
+             d:DesignHeight="738" d:DesignWidth="910"
              TextElement.FontWeight="Regular"
              TextElement.FontSize="13"
              Width="Auto" Height="Auto" Loaded="Window_Loaded"
@@ -156,7 +156,6 @@
                                   HorizontalAlignment="Right" ToolTip="{StaticResource PLAYLIST_AUTO}" />
                         <Label Content="Auto-play" Grid.Column="9" Height="Auto" VerticalAlignment="Center"
                                ToolTip="{StaticResource PLAYLIST_AUTO}" />
-
                     </Grid>
                 </Grid>
             </Grid>
@@ -168,7 +167,7 @@
                 </Grid.ColumnDefinitions>
                 <TabControl Grid.ColumnSpan="2">
                     <TabItem Header="Performers" Width="Auto" Height="35" Padding="0">
-                        <Grid Background="White">
+                    <Grid Background="White">
                             <controls:BardView x:Name="BardsList" />
                         </Grid>
                     </TabItem>
@@ -202,7 +201,7 @@
                                     <ComboBox Margin="90,28,0,0" Grid.Row="2" x:Name="Autostart_source"
                                               SelectionChanged="Autostart_source_SelectionChanged" Background="White"
                                               HorizontalAlignment="Left" VerticalAlignment="Top" Width="100"
-                                              Padding="5px" ToolTip="{StaticResource LO_AUTOSTART}">
+                                              Padding="5" ToolTip="{StaticResource LO_AUTOSTART}">
                                         <ComboBoxItem>Disabled</ComboBoxItem>
                                         <ComboBoxItem>Metronome</ComboBoxItem>
                                     </ComboBox>
@@ -210,7 +209,6 @@
                                               Content="Hypnotoad Compatibility" Unchecked="AutoequipDalamud_Checked"
                                               Checked="AutoequipDalamud_Checked"
                                               ToolTip="{StaticResource LO_AUTOEQPLGN}" />
-
                                 </Grid>
                             </GroupBox>
                             <GroupBox Grid.Row="0" Grid.Column="1" Header="Playback">
@@ -241,7 +239,7 @@
                                               DisplayMemberPath="Value" Background="White"
                                               SelectionChanged="MIDI_Input_Device_SelectionChanged"
                                               HorizontalAlignment="Left" VerticalAlignment="Top" MinWidth="120"
-                                              Padding="5px" ToolTip="{StaticResource PL_MIDIINPUT}">
+                                              Padding="5" ToolTip="{StaticResource PL_MIDIINPUT}">
                                         <ComboBoxItem>None</ComboBoxItem>
                                     </ComboBox>
                                     <CheckBox Margin="10,10,0,0" Grid.Row="5" x:Name="LiveMidiDelay"
@@ -271,7 +269,7 @@
                             <!--
                             <Label Grid.Row="1" Grid.Column="0" Content="Beats per minute" />
                             <Label Grid.Row="1" Grid.Column="1" x:Name="Statistics_BPM_Label" />
--->
+                            -->
                             <Label Grid.Row="1" Grid.Column="0" Content="Total tracks" />
                             <Label Grid.Row="1" Grid.Column="1" x:Name="Statistics_Total_Tracks_Label" />
 
@@ -283,7 +281,7 @@
                             <!--
                             <Label Grid.Row="5" Grid.Column="0" Content="Note per second" />
                             <Label Grid.Row="5" Grid.Column="1" x:Name="Statistics_Note_Per_Second_Label" />
--->
+                            -->
                             <Label Grid.Row="7" Grid.Column="0" Content="Song functions:" />
                             <Button Grid.Row="7" Grid.Column="1" Content="Export current song as Midi"
                                     Click="ExportAsMidi" Height="Auto" Width="250" Background="White" />
@@ -459,7 +457,7 @@
                 </Grid>
                 <!-- End Track Selection-->
                 <Button Grid.Column="4" Content="All tracks" x:Name="all_tracks_button" Click="all_tracks_button_Click"
-                        Background="White" Height="Auto" HorizontalAlignment="Right" Width="80" FontSize="12"
+                        Background="White" Height="Auto" HorizontalAlignment="Right" Width="80"
                         Padding="0" />
             </Grid>
             <!-- Playbar Row -->
@@ -497,18 +495,18 @@
             </Grid>
 
 
-            <!-- Play Control Row-->
+            <!-- Play Control Row -->
             <Grid Grid.Row="3" Grid.Column="2" HorizontalAlignment="Right" Margin="0,0,10,0">
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="50" />
-                    <RowDefinition Height="25" />
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
                 <!-- Controls -->
-                <Button Grid.Row="0" x:Name="Play_Button" Content="▶" Background="White" FontSize="26"
-                        HorizontalAlignment="Left" VerticalAlignment="Center" Height="50" Width="75"
+                <Button Grid.Row="0" x:Name="Play_Button" Content="▶" Style="{StaticResource PlayButton}" Background="White"
+                        HorizontalAlignment="Center" VerticalAlignment="Top" Height="60" Width="75"
                         Click="Play_Button_Click" PreviewMouseRightButtonDown="Play_Button_MouseRightButtonDown" />
                 <Button Grid.Row="1" x:Name="Macro_Button" Content="Macro" Background="White"
-                        HorizontalAlignment="Left" VerticalAlignment="Center" Height="25" Width="75"
+                        HorizontalAlignment="Center" VerticalAlignment="Bottom" Height="25" Width="75"
                         Click="Macro_Button_Click" />
             </Grid>
             <!-- Instrument Info Row -->

--- a/BardMusicPlayer/UI_Classic/MacroLaunchpad.xaml
+++ b/BardMusicPlayer/UI_Classic/MacroLaunchpad.xaml
@@ -22,14 +22,14 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
-            <Button Grid.Column="0" Content="Add" Click="Add_Click" />
-            <Button Grid.Column="1" Content="Remove" Click="Remove_Click" />
+            <Button Grid.Column="0" Content="Add" Click="Add_Click" Background="White" />
+            <Button Grid.Column="1" Content="Remove" Click="Remove_Click" Background="White" />
 
             <Button Grid.Column="3" x:Name="StopIndicator" Content="Idle" Click="StopIndicator_Click" Width="40"
-                    Padding="0" />
+                    Padding="0" Background="White" />
 
-            <Button Grid.Column="5" Content="Load" Click="Load_Click" />
-            <Button Grid.Column="6" Content="Save" Click="Save_Click" />
+            <Button Grid.Column="5" Content="Load" Click="Load_Click" Background="White" />
+            <Button Grid.Column="6" Content="Save" Click="Save_Click" Background="White" />
         </Grid>
 
         <ListView x:Name="MacroList" Grid.Row="1" SelectedItem="{Binding SelectedMacro}"


### PR DESCRIPTION
- Increased default application height / width again to show up to 8 performers by default without any vertical or horizontal scroll bar, as well as reduced grid row height to bring it closer to pre-styling performer height.

Fixes https://github.com/BardMusicPlayer/BardMusicPlayer/issues/250

- Added overriding style for play button so font can be larger again.

Fixes https://github.com/BardMusicPlayer/BardMusicPlayer/issues/248

- Turned performer leftside icon into a button and added single click function to open bard settings in one click.

Left click seems to get absorbed by the theme selection hold animation but right clicking the button immediately opens the settings.

If there are no plans for drag re-ordering performers in the future with new maestro and remote bards, the button could perhaps be removed to clean up the UI a bit and replaced with just right clicking on a local performer name to open the settings.

Partially fixes https://github.com/BardMusicPlayer/BardMusicPlayer/issues/249

- Cleaned up macro adding UI a bit.
- Various other minor UI adjustments and fixes to match light styling.