### PR TITLE
Browser Improvements

### DIFF
--- a/BardMusicPlayer/Controls/SongBrowser.xaml.cs
+++ b/BardMusicPlayer/Controls/SongBrowser.xaml.cs
@@ -4,8 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Windows;
-using System.Windows.Input;
 using System.Windows.Controls;
+using System.Windows.Input;
 using BardMusicPlayer.Pigeonhole;
 using BardMusicPlayer.Resources;
 
@@ -69,7 +69,7 @@ public partial class SongBrowser
             {
                 return Uri.UnescapeDataString(GetRelativePath(SongPath.Text, file));
             }
-            
+
             return Path.GetFileName(file);
         }).ToList();
         if (SongSearch.Text != "")

--- a/BardMusicPlayer/Controls/SongBrowser.xaml.cs
+++ b/BardMusicPlayer/Controls/SongBrowser.xaml.cs
@@ -33,14 +33,17 @@ public partial class SongBrowser
     /// <param name="e"></param>
     private void SongBrowserContainer_PreviewMouseDoubleClick(object sender, MouseButtonEventArgs e)
     {
-        var filename = SongBrowserContainer.SelectedItem as string;
-        if (!File.Exists(filename) || filename == null)
+        if (SongBrowserContainer.SelectedItem is not string selectedFile)
             return;
 
-        OnLoadSongFromBrowser?.Invoke(this, filename);
+        var fullPath = Path.Combine(SongPath.Text, selectedFile);
+        if (File.Exists(fullPath))
+        {
+            OnLoadSongFromBrowser?.Invoke(this, fullPath);
+        }
     }
 
-    private string GetRelativePath(string basePath, string fullPath)
+    private static string GetRelativePath(string basePath, string fullPath)
     {
         var baseUri = new Uri(basePath);
         var fullUri = new Uri(fullPath);
@@ -57,16 +60,16 @@ public partial class SongBrowser
         if (!Directory.Exists(SongPath.Text))
             return;
 
-        var files = Directory.EnumerateFiles(SongPath.Text, "*.*", SearchOption.AllDirectories).Where(s => s.EndsWith(".mid") || s.EndsWith(".mml") || s.EndsWith(".mmsong")).ToArray();
+        var files = Directory.EnumerateFiles(SongPath.Text, "*.*", SearchOption.AllDirectories).Where(s => s.EndsWith(".mid") || s.EndsWith(".mml") || s.EndsWith(".mmsong") || s.EndsWith(".gp*")).ToArray();
         var list = new List<string>(files);
         list = list.Select(file => 
         {
             var directory = Path.GetDirectoryName(file);
-            if (!directory.Equals(SongPath.Text, StringComparison.OrdinalIgnoreCase))
+            if (directory != null && !directory.Equals(SongPath.Text, StringComparison.OrdinalIgnoreCase))
             {
                 return Uri.UnescapeDataString(GetRelativePath(SongPath.Text, file));
             }
-
+            
             return Path.GetFileName(file);
         }).ToList();
         if (SongSearch.Text != "")


### PR DESCRIPTION
* Load song browser list on initialization.

Fixes https://github.com/BardMusicPlayer/BardMusicPlayer/issues/245

* Update song list on any text change. This way backspacing characters in the search field can update the list and display songs again without needing to _enter_ a new character after erasing. There is some lag when filtering the list when the displayed list has many songs (10k+) but most people probably would not have this many songs. Further improvements would have to be made in the future to fix this (by indexing?) but this is beyond my capability.

Fixes https://github.com/BardMusicPlayer/BardMusicPlayer/issues/113

* Song list no longer displays the full absolute path in the name. For folders the song may be inside if the absolute path at the top does not scope into it fully, the relative path is displayed with the song file. The relative path is using forward slashes because this seems to be more proper in a display, while the absolute path at the top search field uses back slashes because of Windows. A URL, standardized in RFC 1738, and Unix-like systems, always uses forward slashes.

This can be changed into back slashes by changing; ``return baseUri.MakeRelativeUri(fullUri).ToString();`` into
``return baseUri.MakeRelativeUri(fullUri).ToString().Replace('/', '\\');``

But I decided to keep relative normal since it looked weird with backslashes and didn't change the absolute path display because that's how windows handles it and future OS support may handle it with forward slashes?

Fixes https://github.com/BardMusicPlayer/BardMusicPlayer/issues/93

The likelihood of a very long path being used by someone is rare and probably would never happen. Since most people wouldn't normally have long paths and the absolute path is no longer displayed with the song name, the below issue can probably safely be ignored.

Fixes (can ignore) https://github.com/BardMusicPlayer/BardMusicPlayer/issues/150

In a similar manner, the vast majority of people would probably just have the main search directory in a folder where songs are actually located. Such as a songs folder or the folder where the app is located. Most people are probably not going to point the directory to the root of a drive, having BMP search thousands of folders for songs. Thus, the below issue can probably safely be ignored.

Fixes (can ignore) https://github.com/BardMusicPlayer/BardMusicPlayer/issues/149

Also extremely unlikely, the vast majority of people probably would not have songs deeper than 5 folders inside each other for organization with long folder names. Thus, the below issue can probably safely be ignored.

Fixes (can ignore) https://github.com/BardMusicPlayer/BardMusicPlayer/issues/151