### PR TITLE
Don't send title unless a song is loaded.

### DIFF
--- a/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml.cs
+++ b/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml.cs
@@ -85,8 +85,12 @@ public sealed partial class BardExtSettingsWindow
             2 => ChatMessageChannelType.Party,
             _ => ChatMessageChannelType.None
         };
-        var songName = $"{Songtitle_Chat_Prefix.Text} {_performer.SongName} {Songtitle_Chat_Prefix.Text}";
-        _performer.game.SendText(chanType, songName);
+
+        if (_performer.SongName != null)
+        {
+            var songName = $"{Songtitle_Chat_Prefix.Text} {_performer.SongName} {Songtitle_Chat_Prefix.Text}";
+            _performer.game.SendText(chanType, songName);
+        }
     }
 
     private void ChatInputText_KeyDown(object sender, KeyEventArgs e)


### PR DESCRIPTION
* Crash fix. Prevent the Send Title button from working and crashing bmp if used on the 2nd+ hooked performer before a song is loaded.

Fixes https://github.com/BardMusicPlayer/BardMusicPlayer/issues/123