### PR TITLE
Playlist Improvements

### DIFF
--- a/BardMusicPlayer/Functions/PlaylistFunctions.cs
+++ b/BardMusicPlayer/Functions/PlaylistFunctions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -32,15 +32,18 @@ public static class PlaylistFunctions
         if (openFileDialog.ShowDialog() != true)
             return false;
 
-        foreach (var d in openFileDialog.FileNames)
+        foreach (var filePath in openFileDialog.FileNames)
         {
-            var song = BmpSong.OpenFile(d).Result;
+            var song = BmpSong.OpenFile(filePath).Result;
 
-            if(currentPlaylist.SingleOrDefault(x => x.Title.Equals(song.Title)) == null)
+            // Check if the song title is not empty or null
+            if (!string.IsNullOrEmpty(song.Title) && currentPlaylist.SingleOrDefault(x => x.FilePath.Equals(song.FilePath)) == null)
+            {
                 currentPlaylist.Add(song);
-
-            BmpCoffer.Instance.SaveSong(song);
+                BmpCoffer.Instance.SaveSong(song);
+            }
         }
+
         BmpCoffer.Instance.SavePlaylist(currentPlaylist);
         return true;
     }
@@ -110,23 +113,22 @@ public static class PlaylistFunctions
     /// </summary>
     /// <param name="playlist"></param>
     /// used: classic view
-    public static List<string> GetCurrentPlaylistItems(IPlaylist playlist)
+
+    // public static List<string> GetCurrentPlaylistItems(IPlaylist playlist)
+    // {
+    //     var data = new List<string>();
+    //     if (playlist == null)
+    //         return data;
+    //
+    //     data.AddRange(playlist.Select(item => item.Title));
+    //     return data;
+    // }
+
+    public static IEnumerable<string> GetCurrentPlaylistItems(IPlaylist playlist)
     {
         var data = new List<string>();
         if (playlist == null)
             return data;
-
-        data.AddRange(playlist.Select(item => item.Title));
-        return data;
-    }
-
-    public static IEnumerable<string> GetCurrentPlaylistItems(IPlaylist playlist, bool withupselector = false)
-    {
-        var data = new List<string>();
-        if (playlist == null)
-            return data;
-        if (withupselector)
-            data.Add("..");
         data.AddRange(playlist.Select(item => item.Title));
         return data;
     }

--- a/BardMusicPlayer/UI_Classic/Classic_MainView.xaml.cs
+++ b/BardMusicPlayer/UI_Classic/Classic_MainView.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -27,8 +27,9 @@ public partial class Classic_MainView
         //Always start with the playlists
         _showingPlaylists = true;
         //Fill the list
-        PlaylistContainer.ItemsSource = BmpCoffer.Instance.GetPlaylistNames();
-        Playlist_Header.Header        = "Playlists";
+        Playlist_Header.Header             =  "Playlists";
+        PlaylistContainer.ItemsSource      =  BmpCoffer.Instance.GetPlaylistNames();
+        PlaylistContainer.SelectionChanged += PlaylistContainer_SelectionChanged;
 
         SongName.Text                              =  PlaybackFunctions.GetSongName();
         BmpMaestro.Instance.OnPlaybackTimeChanged  += Instance_PlaybackTimeChanged;
@@ -152,12 +153,27 @@ public partial class Classic_MainView
         if (_directLoaded)
             return;
 
-        if (BmpPigeonhole.Instance.PlaylistAutoPlay)
+        if (_autoPlay)
         {
-            playNextSong();
             var rnd = new Random();
-            PlaybackFunctions.PlaySong(rnd.Next(15, 35)*100);
-            Play_Button_State(true);
+            if (PlaylistContainer.SelectedIndex == PlaylistContainer.Items.Count - 1)
+            {
+                if (_playlistRepeat)
+                {
+                    PlaylistContainer.SelectedIndex = 0;
+                    PlaybackFunctions.LoadSongFromPlaylist(PlaylistFunctions.GetSongFromPlaylist(_currentPlaylist, (string)PlaylistContainer.SelectedItem));
+                    SongName.Text          = PlaybackFunctions.GetSongName();
+                    InstrumentInfo.Content = PlaybackFunctions.GetInstrumentNameForHostPlayer();
+                    PlaybackFunctions.PlaySong(rnd.Next(15, 35) * 100);
+                    Play_Button_State(true);
+                }
+            }
+            else
+            {
+                playNextSong();
+                PlaybackFunctions.PlaySong(rnd.Next(15, 35) * 100);
+                Play_Button_State(true);
+            }
         }
     }
 


### PR DESCRIPTION
* Add songs to the playlist by file path not name. This fixes being able to add a song with the same name but different extensions such as example.mid and example.mmsong.

Fixes https://github.com/BardMusicPlayer/BardMusicPlayer/issues/108

* Shuffle mode now no longer repeats songs until it completes the full playlist. This fixes the issue with songs sometimes randomizing into itself again immediately or very soon after.

* Shuffle button when toggled inside a playlist container will now shuffle the current playlist randomly. It reshuffles the displayed list from top-down so you can visually see the order of songs shuffled. Toggling shuffle off will revert to the original saved playlist order. Toggling shuffle on again will pick a new random song order. 

Fixes https://github.com/BardMusicPlayer/BardMusicPlayer/issues/122

* Shuffle button disables itself when you head back to the playlist selection menu by header click and shuffle can only be toggled on/off when inside a playlist container. This is to prevent an issue if shuffle is enabled inside a container and then you leave the container and re-enter it, the list order is re-randomized but not visually shown in the correct play order.

* Repeat button now has functional logic so it actually behaves as intended by restarting the playlist from the top and added condition checks if using auto-play or skip. Repeat will not re-shuffle playlists if shuffle is enabled and it reaches the end of the playlist - just toggle the shuffle button if you want it to reshuffle. Repeat only repeats the playlist list order from the top again.

* Fixed exception crash when drag reordering a playlist item to the top of the list. Checking if the source and target indices are within the bounds of the list before calling the Move method. If either index is out of bounds, the method simply returns without doing anything.

* Prevent reordering playlist songs by dragging when shuffle mode is enabled.

* Removed ``..`` return selection inside the playlist song list. This is because shuffle was sometimes randomizing into it and with shuffling now showing the list order correctly, it moves away from being at the top of the list. Since you can return to the root playlist selection menu by clicking on the playlist title, the ``..`` option is redundant. There's no need to save or display ``..``.

* Prevent adding songs to a playlist if it has no name. This fixes the crash that happens when loading a playlist with files without a name since it is now impossible to save empty named files to it. If anyone has a corrupted playlist (very very unlikely), they will need to just reset their playlist file manually.

Fixes https://github.com/BardMusicPlayer/BardMusicPlayer/issues/148

* Skip button no longer crashes when at the end of a playlist with shuffle mode enabled. Similarly, skip button will now stop when at the end of the playlist instead of looping indefinitely and hitting skip with auto-play enabled will no longer repeat the last song in the list if at the end of the list. Skip button will also now load the first song in the playlist if hit when there is no song loaded instead of skipping to the 2nd in the list.

* Fixed skip button not working if you manually selected a location in the playlist with shuffle mode enabled and then tried to skip next down the line.

* Fixed auto-play not automatically starting when enabled if the skip button is hit. Auto-play will not automatically start if you manually load a song from a playlist by double clicking - you must click play yourself. However once it is started, it will automatically continue to play down the playlist.

* Fixed auto-play button repeating the playlist instead of stopping at the end of the list unless repeat mode is enabled.

Maybe fixes https://github.com/BardMusicPlayer/BardMusicPlayer/issues/112