### PR TITLE
Siren Volume Normalizing

### DIFF
--- a/BardMusicPlayer/UI_Classic/Classic_MainView.xaml
+++ b/BardMusicPlayer/UI_Classic/Classic_MainView.xaml
@@ -350,7 +350,7 @@
                                     <RowDefinition Height="*" />
                                 </Grid.RowDefinitions>
                                 <Label Grid.Row="0" Content="Volume" HorizontalAlignment="Center" />
-                                <Slider Grid.Row="1" x:Name="Siren_Volume" Minimum="0" Maximum="100"
+                                <Slider Grid.Row="1" x:Name="Siren_Volume" Minimum="0" Maximum="30"
                                         Orientation="Vertical" HorizontalAlignment="Center"
                                         ValueChanged="Siren_Volume_ValueChanged" />
                             </Grid>

--- a/BardMusicPlayer/UI_Classic/Classic_Siren.cs
+++ b/BardMusicPlayer/UI_Classic/Classic_Siren.cs
@@ -147,7 +147,12 @@ public sealed partial class Classic_MainView
     /// <param name="e"></param>
     private void Siren_Volume_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
     {
-        if (e.OriginalSource is Slider slider) BmpSiren.Instance.SetVolume((float)slider.Value);
+        if (e.OriginalSource is Slider slider)
+        {
+            slider.Minimum = 0;
+            slider.Maximum = 30;
+            BmpSiren.Instance.SetVolume((float)slider.Value, max:20);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
* Normalize audio in song previewer. The VST wav files are way too loud by default and peak absurdly high, making the usable maximum volume closer to around 20ish percent. Since these files are not being edited and clamped directly, this is an alternative way to normalize.

I did notice one of the guitars sounds noticeably quieter than other instruments but assuming it's just a bad audio sample problem since samples have lots of problems in them. The new maximum volume is still loud but significantly more tolerable.

Fixes https://github.com/BardMusicPlayer/BardMusicPlayer/issues/137