### PR TITLE
Avoid build warning.

### DIFF
--- a/.github/workflows/MERGE-develop.yml
+++ b/.github/workflows/MERGE-develop.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        submodules: recursive
 
     - name: Install .NET
       uses: actions/setup-dotnet@v3

--- a/.github/workflows/PR-develop.yml
+++ b/.github/workflows/PR-develop.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        submodules: recursive
 
     - name: Install .NET
       uses: actions/setup-dotnet@v3

--- a/BardMusicPlayer.Jamboree.ApiTest/BardMusicPlayer.Jamboree.ApiTest.csproj
+++ b/BardMusicPlayer.Jamboree.ApiTest/BardMusicPlayer.Jamboree.ApiTest.csproj
@@ -18,6 +18,13 @@
     <Version>2.0.0.0</Version>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <NoWarn>1701;1702; MSB3246</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <NoWarn>1701;1702; MSB3246</NoWarn>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\BardMusicPlayer.Jamboree\BardMusicPlayer.Jamboree.csproj" />


### PR DESCRIPTION
* Prevents this build warning. Same "fix" as in main Jamboree library.

C:\Program Files\dotnet\sdk\7.0.200\Microsoft.Common.CurrentVersion.targets(2352,5): warning MSB3246: Resolved file has a bad image, no metadata, or is otherwise inaccessible. PE image does not have metadata. PE image does not have metadata. [D:\a\BardMusicPlayer\BardMusicPlayer\BardMusicPlayer.Jamboree.ApiTest\BardMusicPlayer.Jamboree.ApiTest.csproj]

* Also updated workflows to remove submodule check since there are no more submodules. Workflow back to normal pre-submodules.