### PR TITLE
Crash Fix

### DIFF
--- a/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml.cs
+++ b/BardMusicPlayer/Controls/BardExtSettingsWindow.xaml.cs
@@ -163,14 +163,14 @@ public sealed partial class BardExtSettingsWindow
 
     private void Save_CPU_Click(object sender, RoutedEventArgs e)
     {
-        long mask = 0;
+        ulong mask = 0;
         var idx = 0;
         foreach (var box in _cpuBoxes)
         {
             if (box.IsChecked != null && (bool)box.IsChecked)
-                mask += 0b1 << idx;
+                mask += 0b1ul << idx;
             else
-                mask += 0b0 << idx;
+                mask += 0b0ul << idx;
             idx++;
         }
         //If mask == 0 show an error
@@ -181,7 +181,7 @@ public sealed partial class BardExtSettingsWindow
                 return;
         }
         else
-            _performer.game.SetAffinity(mask);
+            _performer.game.SetAffinity((long)mask);
     }
 
     private void Clear_CPU_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
* Fix crash when setting cpu affinity to all cores if you have 32+ cores. For example setting cpu affinity to 1 core, then clicking All Processors -> Set. Prior it crashed when the last core listed with 32 CPU available was checked.