### PR TITLE
Added Midi Repository tab to download song from original bmp website

### DIFF
--- a/BardMusicPlayer.Pigeonhole/BmpPigeonhole.cs
+++ b/BardMusicPlayer.Pigeonhole/BmpPigeonhole.cs
@@ -126,4 +126,9 @@ public class BmpPigeonhole : JsonSettings.JsonSettings
     /// Enable Dark Mode theme.
     /// </summary>
     public virtual bool DarkStyle { get; set; }
+
+    /// <summary>
+    /// Midi download path
+    /// </summary>
+    public virtual string MidiDownloadPath { get; set; } = "";
 }

--- a/BardMusicPlayer/BardMusicPlayer.csproj
+++ b/BardMusicPlayer/BardMusicPlayer.csproj
@@ -42,6 +42,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="MaterialDesignThemes" Version="4.8.0-ci172" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.0" />
     <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />

--- a/BardMusicPlayer/Controls/MidiRepository.xaml
+++ b/BardMusicPlayer/Controls/MidiRepository.xaml
@@ -1,0 +1,64 @@
+﻿<UserControl x:Class="BardMusicPlayer.Controls.MidiRepository"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             mc:Ignorable="d" 
+             Margin="10,10,10,0"
+             Background="{DynamicResource MaterialDesignBackground}"
+             d:DesignHeight="450" d:DesignWidth="800">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="32" />
+            <RowDefinition Height="25" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="140" />
+        </Grid.RowDefinitions>
+
+        <Button Grid.Row="0" x:Name="BtnGetSongList" Content="Get Song List" Grid.Column="1" Click="Button_Click"/>
+
+        <ProgressBar Grid.Row="1" x:Name="LoadingProgressBar" Grid.Column="1" IsIndeterminate="True"/>
+
+        <ListView Grid.Row="2"
+                    x:Name="MidiRepoContainer"
+                    VerticalAlignment="Stretch" HorizontalAlignment="Stretch" BorderThickness="0"
+                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                    ScrollViewer.VerticalScrollBarVisibility="Visible"
+                    ScrollViewer.CanContentScroll="True" SelectionChanged="MidiRepoContainer_SelectionChanged" MouseDoubleClick="MidiRepoContainer_MouseDoubleClick" />
+
+        <Grid Grid.Row="3" x:Name="DownloadPanel" Background="{DynamicResource MaterialDesignPaper}">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="10"/>
+                <RowDefinition Height="24"/>
+                <RowDefinition Height="30"/>
+                <RowDefinition Height="30"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <TextBlock Grid.Row="1" x:Name="SongTitle" VerticalAlignment="Top" Text="song_title" FontWeight="Bold" />
+
+            <TextBlock Grid.Row="2" x:Name="SongComment" TextWrapping="WrapWithOverflow" Text="song_comment" VerticalAlignment="Top" />
+
+            <Grid Grid.Row="3">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="99" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="25" />
+                </Grid.ColumnDefinitions>
+
+                <Label Grid.Column="0" Margin="-4,0,0,0" Content="Download Path:" VerticalAlignment="Center" HorizontalAlignment="Left" />
+                <TextBox IsReadOnly="True" Grid.Column="1" Margin="0,0,4,0" x:Name="DownloadPath" Text="" Padding="5" VerticalAlignment="Center" HorizontalAlignment="Stretch" />
+                <Button x:Name="BtnDownloadPath" Grid.Column="2" Content="..." Margin="0,0 4,0"
+                    Click="SelectPath_Button_Click" Height="18" Padding="5" />
+            </Grid>
+            <Grid Grid.Row="4" >
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="100" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Button x:Name="DownloadButton" Grid.Column="0" Content="Download" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,6,0,0" Click="DownloadButtonClick"/>
+                <ProgressBar x:Name="DownloadProgressBar" Grid.Column="1" Height="20" Background="White" />
+                <Label x:Name="DownloadProgressLabel" Grid.Column="1" Content="Download Complete" HorizontalAlignment="Center" VerticalAlignment="Center" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" Foreground="#DDFFFFFF"/>
+            </Grid>
+        </Grid>
+    </Grid>
+</UserControl>

--- a/BardMusicPlayer/Controls/MidiRepository.xaml.cs
+++ b/BardMusicPlayer/Controls/MidiRepository.xaml.cs
@@ -1,0 +1,213 @@
+﻿using BardMusicPlayer.Pigeonhole;
+using BardMusicPlayer.Resources;
+using HtmlAgilityPack;
+using System.IO;
+using System.Net.Http;
+using System.Reflection;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace BardMusicPlayer.Controls;
+
+/// <summary>
+/// Web scraper to scrape the song list from https://songs.bardmusicplayer.com and populate in the listview
+/// </summary>
+public partial class MidiRepository : UserControl
+{
+    private const string songNodeXpath = "//div[contains(@class, 'midi-entry')]";
+    private const string titleNodeXpath = ".//a[contains(@class, 'mtitle')]";
+    private const string authorNodeXpath = ".//span[contains(@class, 'mauthor')]";
+    private const string commentNodeXpath = ".//span[contains(@class, 'r4')]";
+    private readonly HttpClient httpClient;
+    private readonly string midiRepoUrl = "https://songs.bardmusicplayer.com";
+    private List<Song> listSong = new List<Song>();
+    public MidiRepository()
+    {
+        InitializeComponent();
+        httpClient = new HttpClient();
+        LoadingProgressBar.Visibility = Visibility.Hidden;
+        DownloadPanel.Visibility = Visibility.Hidden;
+        DownloadPath.Text = BmpPigeonhole.Instance.MidiDownloadPath;
+        DownloadProgressLabel.Visibility = Visibility.Hidden;
+        DownloadProgressBar.Visibility = Visibility.Hidden;
+    }
+    private class Song
+    {
+        public string Title { get; set; } = "";
+        public string Author { get; set; } = "";
+        public string Comment { get; set; } = "";
+        public string Url { get; set; } = "";
+    }
+
+    /// <summary>
+    /// Fetch the html from https://songs.bardmusicplayer.com
+    /// </summary>
+    /// <returns></returns>
+    private async Task<string> FetchSongData()
+    {
+        var response = await httpClient.GetStringAsync(midiRepoUrl);
+        return response;
+    }
+
+    /// <summary>
+    /// Get midi meta data from html result using web scraper
+    /// </summary>
+    /// <param name="html"></param>
+    private void RefreshSongList(string html)
+    {
+        listSong.Clear();
+        HtmlDocument htmlDoc = new HtmlDocument();
+        htmlDoc.LoadHtml(html);
+
+        var songNodes = htmlDoc.DocumentNode.SelectNodes(songNodeXpath);
+
+        foreach (var songNode in songNodes)
+        {
+            var titleNode = songNode.SelectSingleNode(titleNodeXpath);
+            var authorNode = songNode.SelectSingleNode(authorNodeXpath);
+            var commentNode = songNode.SelectSingleNode(commentNodeXpath);
+
+            if (titleNode != null && authorNode != null && commentNode != null)
+            {
+                listSong.Add(new Song
+                {
+                    Title = titleNode.GetAttributeValue("title", ""),
+                    Author = authorNode.InnerText,
+                    Comment = commentNode.InnerText,
+                    Url = titleNode.GetAttributeValue("href", ""),
+                });
+            }
+        }
+    }
+
+    /// <summary>
+    /// Click button to scrape the web and put the result to listSong
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private async void Button_Click(object sender, RoutedEventArgs e)
+    {
+        BtnGetSongList.IsEnabled = false;
+        LoadingProgressBar.Visibility = Visibility.Visible;
+
+        var songData = await FetchSongData();
+        
+        RefreshSongList(songData);
+        MidiRepoContainer.ItemsSource = listSong.Select(song => song.Title).ToList();
+
+        BtnGetSongList.IsEnabled = true;
+        BtnGetSongList.Content = "Refresh";
+        LoadingProgressBar.Visibility = Visibility.Hidden;
+    }
+
+    /// <summary>
+    /// Show midi details when clicking the listview
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void MidiRepoContainer_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        DownloadPanel.Visibility = Visibility.Visible;
+        Song song = listSong[MidiRepoContainer.SelectedIndex];
+        SongTitle.Text = $"({song.Author}) {song.Title}";
+        SongComment.Text = song.Comment;
+    }
+
+    /// <summary>
+    /// Select download path on click button
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void SelectPath_Button_Click(object sender, RoutedEventArgs e)
+    {
+        var dlg = new FolderPicker
+        {
+            InputPath = Directory.Exists(BmpPigeonhole.Instance.SongDirectory) ? Path.GetFullPath(BmpPigeonhole.Instance.SongDirectory) : Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
+        };
+
+        if (dlg.ShowDialog() == true)
+        {
+            var path = dlg.ResultPath;
+            if (!Directory.Exists(path))
+                return;
+
+            path += path.EndsWith("\\") ? "" : "\\";
+            DownloadPath.Text = path;
+            BmpPigeonhole.Instance.MidiDownloadPath = path;
+        }
+    }
+
+    /// <summary>
+    /// Start download process
+    /// </summary>
+    /// <param name="url"></param>
+    /// <param name="fileName"></param>
+    private async void DownloadFile(string url, string fileName)
+    {
+        HttpClient client = new HttpClient();
+        HttpResponseMessage response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+        long? contentLength = response.Content.Headers.ContentLength;
+        string tempFilePath = Path.GetTempFileName();
+
+        using (FileStream tempFileStream = new FileStream(tempFilePath, FileMode.Create, FileAccess.Write, FileShare.None))
+        {
+            using (Stream contentStream = await response.Content.ReadAsStreamAsync())
+            {
+                byte[] buffer = new byte[4096];
+                long totalBytesRead = 0;
+                int bytesRead = 0;
+                while ((bytesRead = await contentStream.ReadAsync(buffer, 0, buffer.Length)) > 0)
+                {
+                    await tempFileStream.WriteAsync(buffer, 0, bytesRead);
+                    totalBytesRead += bytesRead;
+                    double percentComplete = (double)totalBytesRead / (contentLength ?? totalBytesRead) * 100;
+                    Dispatcher.Invoke(() => DownloadProgressBar.Value = percentComplete);
+                }
+            }
+        }
+        string downloadsPath = BmpPigeonhole.Instance.MidiDownloadPath;
+        string finalFilePath = $"{downloadsPath}/{fileName}.mid";
+
+        File.Move(tempFilePath, finalFilePath, true);
+        DownloadButton.IsEnabled = true;
+        DownloadProgressLabel.Visibility = Visibility.Visible;
+    }
+
+    /// <summary>
+    /// Download selected midi in the listview by clicking download button
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void DownloadButtonClick(object sender, RoutedEventArgs e)
+    {
+        DownloadSelectedMidi();
+    }
+
+    /// <summary>
+    /// Download selected midi by double click the list item
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void MidiRepoContainer_MouseDoubleClick(object sender, MouseButtonEventArgs e)
+    {
+        DownloadSelectedMidi();
+    }
+
+    /// <summary>
+    /// Download current selected midi in the listview
+    /// </summary>
+    private void DownloadSelectedMidi()
+    {
+        if (!Directory.Exists(BmpPigeonhole.Instance.MidiDownloadPath))
+        {
+            MessageBox.Show("The downloads directory is not valid.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            return;
+        }
+        Song selectedSong = listSong[MidiRepoContainer.SelectedIndex];
+        DownloadButton.IsEnabled = false;
+        DownloadProgressBar.Visibility = Visibility.Visible;
+        DownloadProgressBar.Value = 0;
+        DownloadFile($"{midiRepoUrl}/{selectedSong.Url}", $"({selectedSong.Author}) {selectedSong.Title}");
+    }
+}

--- a/BardMusicPlayer/Controls/MidiRepository.xaml.cs
+++ b/BardMusicPlayer/Controls/MidiRepository.xaml.cs
@@ -123,7 +123,7 @@ public partial class MidiRepository : UserControl
     {
         var dlg = new FolderPicker
         {
-            InputPath = Directory.Exists(BmpPigeonhole.Instance.SongDirectory) ? Path.GetFullPath(BmpPigeonhole.Instance.SongDirectory) : Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
+            InputPath = Directory.Exists(BmpPigeonhole.Instance.MidiDownloadPath) ? Path.GetFullPath(BmpPigeonhole.Instance.MidiDownloadPath) : Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
         };
 
         if (dlg.ShowDialog() == true)

--- a/BardMusicPlayer/MainWindow.xaml.cs
+++ b/BardMusicPlayer/MainWindow.xaml.cs
@@ -20,7 +20,7 @@ public partial class MainWindow
         AllowsTransparency = false;
         WindowStyle        = WindowStyle.SingleBorderWindow;
         Height             = 738;
-        Width              = 910;
+        Width              = 930;
         ResizeMode         = ResizeMode.CanResizeWithGrip;
         
         if (!BmpPigeonhole.Instance.DarkStyle)

--- a/BardMusicPlayer/UI_Classic/Classic_MainView.xaml
+++ b/BardMusicPlayer/UI_Classic/Classic_MainView.xaml
@@ -399,6 +399,11 @@
                             <controls:SongBrowser x:Name="SongBrowser" />
                         </Grid>
                     </TabItem>
+                    <TabItem Header="Midi Repo" Width="Auto" Height="35" Padding="0">
+                        <Grid Background="{DynamicResource MaterialDesignBackground}">
+                            <controls:MidiRepository x:Name="MidiRepository" />
+                        </Grid>
+                    </TabItem>
                 </TabControl>
             </Grid>
 


### PR DESCRIPTION
I added the "midi repo" tab to show all song from official bmp website https://songs.bardmusicplayer.com/,
what i did here is just simply web scrape the website using "htmlagilitypack" + xpath, and populate the data to the listview, and download using simple httpclient, you can download the midi with "download" button or simply by double click the song.

maybe there are some bug that i didnt found yet or maybe you dont like my code let me know, and let me know if you interested with this feature, im very appreciate any feedback for this PR, and sorry for bad english ^^

now im currently working for the search bar, i will update this PR when i finish it

i provide the gif demo below,

![midi-repo-tab](https://user-images.githubusercontent.com/129674267/229361228-8bb8bcf5-d728-4fbd-8edc-f4fa9891520e.gif)
