### PR TITLE
Spacebar play toggle

### DIFF
--- a/BardMusicPlayer/UI_Classic/Classic_MainView.xaml.cs
+++ b/BardMusicPlayer/UI_Classic/Classic_MainView.xaml.cs
@@ -54,7 +54,7 @@ public partial class ClassicMainView
         BmpCoffer.Instance.OnPlaylistDataUpdated   += OnPlaylistDataUpdated;
         BmpSeer.Instance.InstrumentHeldChanged     += InstrumentOpenCloseState;
 
-        //PreviewKeyDown += PlaybackToggle_PreviewKeyDown;
+        PreviewKeyDown += PlaybackToggle_PreviewKeyDown;
         LoadConfig();
     }
 
@@ -210,7 +210,7 @@ public partial class ClassicMainView
         }
     }
 
-    /*private void PlaybackToggle_PreviewKeyDown(object sender, KeyEventArgs e)
+    private void PlaybackToggle_PreviewKeyDown(object sender, KeyEventArgs e)
     {
         if (e.Key == Key.Space)
         {
@@ -234,7 +234,7 @@ public partial class ClassicMainView
 
             e.Handled = true;
         }
-    }*/
+    }
 
     private void TrackNumberChanged(TrackNumberChangedEvent e)
     {


### PR DESCRIPTION
* Highly requested "solo" feature. This is a bit silly of an addition because you have to alt tab anyways when loading songs if you wanted to open instruments (not using auto-equip) or send ensemble. You would normally think clicking to load a song and then clicking play isn't that big of an extra step.. but solo performers and old 1.x users love to hit spacebar instead. It doesn't hurt to have this I suppose and didn't run into any issues testing.

To use it, you have to alt tab / click into BMP so its window is in focus, then click space.