### PR TITLE
Playback Speed Shifting

### DIFF
--- a/BardMusicPlayer.Maestro/Old/BmpMaestro.cs
+++ b/BardMusicPlayer.Maestro/Old/BmpMaestro.cs
@@ -109,11 +109,33 @@ public partial class BmpMaestro : IDisposable
     /// sets the octave shift for host performer
     /// </summary>
     /// <param name="octave"></param>
-    public void SetOctaveshiftOnHost(int octave)
+    public void SetOctaveShiftOnHost(int octave)
     {
         _orchestrator?.SetOctaveshiftOnHost(octave);
     }
         
+    /// <summary>
+    /// sets the speed for bard
+    /// </summary>
+    public void SetSpeedShiftAll(float percentage)
+    {
+        if (_orchestrator == null)
+            return;
+
+        var performers = _orchestrator.GetAllPerformers();
+        Parallel.ForEach(performers, perf =>
+        {
+            _orchestrator.SetSpeedShift(perf, percentage);
+        });
+    }
+
+    /// <summary>
+    /// sets the speed for host performer
+    /// </summary>
+    public void SetSpeedShiftOnHost(float percentage)
+    {
+        _orchestrator?.SetSpeedShiftOnHost(percentage);
+    }
 
     /// <summary>
     /// Sets the playback at position (timeindex in ticks)

--- a/BardMusicPlayer.Maestro/Old/BmpMaestroEvents.cs
+++ b/BardMusicPlayer.Maestro/Old/BmpMaestroEvents.cs
@@ -18,6 +18,7 @@ public partial class BmpMaestro
     public EventHandler<bool> OnPerformerChanged;
     public EventHandler<TrackNumberChangedEvent> OnTrackNumberChanged;
     public EventHandler<OctaveShiftChangedEvent> OnOctaveShiftChanged;
+    public EventHandler<SpeedShiftEvent> OnSpeedChanged;
     public EventHandler<PerformerUpdate> OnPerformerUpdate;
     private ConcurrentQueue<MaestroEvent> _eventQueue;
     private bool _eventQueueOpen;
@@ -59,10 +60,12 @@ public partial class BmpMaestro
                         case OctaveShiftChangedEvent octaveShiftChanged:
                             OnOctaveShiftChanged?.Invoke(this, octaveShiftChanged);
                             break;
+                        case SpeedShiftEvent speedChanged:
+                            OnSpeedChanged?.Invoke(this, speedChanged);
+                            break;
                         case PerformerUpdate performerUpdate:
                             OnPerformerUpdate?.Invoke(this, performerUpdate);
                             break;
-
                     }
                 }
                 catch

--- a/BardMusicPlayer.Maestro/Old/Events/SpeedShiftEvent.cs
+++ b/BardMusicPlayer.Maestro/Old/Events/SpeedShiftEvent.cs
@@ -1,0 +1,25 @@
+﻿/*
+ * Copyright(c) 2023 GiR-Zippo
+ * Licensed under the GPL v3 license. See https://github.com/GiR-Zippo/LightAmp/blob/main/LICENSE for full license information.
+ */
+
+using BardMusicPlayer.Maestro.Events;
+using BardMusicPlayer.Seer;
+
+namespace BardMusicPlayer.Maestro.Old.Events;
+
+public sealed class SpeedShiftEvent : MaestroEvent
+{
+    internal SpeedShiftEvent(Game g, float speedShift, bool isHost = false)
+    {
+        EventType  = GetType();
+        SpeedShift = speedShift;
+        game       = g;
+        IsHost     = isHost;
+    }
+
+    public Game game { get; }
+    public float SpeedShift { get; }
+    public bool IsHost { get; }
+    public override bool IsValid() => true;
+}

--- a/BardMusicPlayer.Maestro/Old/Orchestrator.cs
+++ b/BardMusicPlayer.Maestro/Old/Orchestrator.cs
@@ -211,6 +211,35 @@ public class Orchestrator : IDisposable
     }
 
     /// <summary>
+    /// sets the speed shift for performer
+    /// </summary>
+    /// <param name="performer"></param>
+    /// <param name="speed"></param>
+    public void SetSpeedShift(Performer p, float speed)
+    {
+        if (p == null)
+            return;
+
+        p.OldSequencer.Speed = speed;
+        BmpMaestro.Instance.PublishEvent(new SpeedShiftEvent(p.game, speed, p.HostProcess));
+    }
+
+    /// <summary>
+    /// sets the speed for host performer (used for Ui)
+    /// </summary>
+    /// <param name="performer"></param>
+    /// <param name="speed"></param>
+    public void SetSpeedShiftOnHost(float speed)
+    {
+        foreach (var perf in _performers.Where(perf => perf.Value.HostProcess))
+        {
+            perf.Value.OldSequencer.Speed = speed;
+            BmpMaestro.Instance.PublishEvent(new SpeedShiftEvent(perf.Value.game, speed, perf.Value.HostProcess));
+            return;
+        }
+    }
+
+    /// <summary>
     /// Seeks the song to absolute position
     /// </summary>
     /// <param name="ticks"></param>

--- a/BardMusicPlayer/UI_Classic/Classic_MainView.xaml
+++ b/BardMusicPlayer/UI_Classic/Classic_MainView.xaml
@@ -523,6 +523,41 @@
                     <ColumnDefinition Width="40" />
                 </Grid.ColumnDefinitions>
                 <Label Grid.Row="0" Grid.ColumnSpan="3" FontSize="10" Content="Performing" />
+                <!-- Speed Selection-->
+                <Grid Grid.Row="0" Grid.Column="1" HorizontalAlignment="Right" Width="Auto">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="10"/>
+                        <ColumnDefinition Width="10"/>
+                    </Grid.ColumnDefinitions>
+                    <TextBox Grid.Column="0" x:Name="SpeedTxtNum" Padding="0" Margin="0,0,-16,0"
+                             x:FieldModifier="private" Text="100%" TextChanged="speed_txtNum_TextChanged" 
+                             TextAlignment="Center" FontSize="14"
+                             HorizontalAlignment="Right" Width="55" Height="25" VerticalAlignment="Center"
+                             VerticalContentAlignment="Center" />
+                    <Grid Grid.Column="1" Margin="0,0,-23,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="12"/>
+                            <RowDefinition Height="12"/>
+                        </Grid.RowDefinitions>
+                        <Button Grid.Row="0" x:Name="SpeedCmdUp" FontSize="8" Padding="2"
+                                HorizontalAlignment="Right" VerticalAlignment="Center" FontFamily="Segoe MDL2 Assets"
+                                Content="&#xE70E;" Click="speed_cmdUp_Click" Width="Auto"
+                                TextOptions.TextHintingMode="Fixed" />
+                        <Button Grid.Row="1" x:Name="SpeedCmdDown" FontSize="8" Padding="2"
+                                HorizontalAlignment="Right" VerticalAlignment="Center" FontFamily="Segoe MDL2 Assets"
+                                Content="&#xE70D;" Click="speed_cmdDown_Click" Width="Auto"
+                                TextOptions.TextHintingMode="Fixed" />
+                    </Grid>
+                    <Button Grid.Row="0" Grid.Column="2" x:Name="SpeedReset" FontSize="8" Padding="2" Margin="0,0,-35,0"
+                            HorizontalAlignment="Right" VerticalAlignment="Center"
+                            Click="speed_cmdReset_Click" Width="20"
+                            TextOptions.TextHintingMode="Fixed">
+                        <StackPanel Orientation="Horizontal">
+                            <materialDesign:PackIcon Kind="Loop" />
+                        </StackPanel>
+                    </Button>
+                </Grid>
                 <Label Grid.Row="1" Grid.Column="0" x:Name="ElapsedTime" Content="00:00" Height="25"
                        HorizontalAlignment="Right" VerticalAlignment="Center" HorizontalContentAlignment="Center"
                        VerticalContentAlignment="Center" />

--- a/BardMusicPlayer/UI_Classic/Classic_MainView.xaml.cs
+++ b/BardMusicPlayer/UI_Classic/Classic_MainView.xaml.cs
@@ -3,6 +3,7 @@
  * Licensed under the GPL v3 license. See https://github.com/GiR-Zippo/LightAmp/blob/main/LICENSE for full license information.
  */
 
+using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -11,6 +12,7 @@ using BardMusicPlayer.Functions;
 using BardMusicPlayer.Maestro.Old;
 using BardMusicPlayer.Maestro.Old.Events;
 using BardMusicPlayer.Pigeonhole;
+using BardMusicPlayer.Quotidian;
 using BardMusicPlayer.Seer;
 using BardMusicPlayer.Seer.Events;
 using BardMusicPlayer.Siren;
@@ -45,6 +47,7 @@ public partial class ClassicMainView
         BmpMaestro.Instance.OnPlaybackStopped     += Instance_PlaybackStopped;
         BmpMaestro.Instance.OnTrackNumberChanged  += Instance_TrackNumberChanged;
         BmpMaestro.Instance.OnOctaveShiftChanged  += Instance_OctaveShiftChanged;
+        BmpMaestro.Instance.OnSpeedChanged        += Instance_OnSpeedChange;
         //SirenVolume.Value                          =  BmpSiren.Instance.GetVolume();
         BmpSiren.Instance.SynthTimePositionChanged += Instance_SynthTimePositionChanged;
         BmpSiren.Instance.SongLoaded               += Instance_SongLoaded;
@@ -92,6 +95,11 @@ public partial class ClassicMainView
     private void Instance_OctaveShiftChanged(object? sender, OctaveShiftChangedEvent e)
     {
         Dispatcher.BeginInvoke(new Action(() => OctaveShiftChanged(e)));
+    }
+
+    private void Instance_OnSpeedChange(object? sender, SpeedShiftEvent e)
+    {
+        Dispatcher.BeginInvoke(new Action(() => SpeedShiftChange(e)));
     }
 
     private void Instance_SynthTimePositionChanged(string songTitle, double currentTime, double endTime, int activeVoices)
@@ -155,6 +163,8 @@ public partial class ClassicMainView
             _allTracks             = false;
             //BmpMaestro.Instance.SetTracknumberOnHost(_maxTracks);
         }
+
+        speed_cmdReset_Click(null, e: null);
     }
 
     private void PlaybackStarted()
@@ -250,6 +260,12 @@ public partial class ClassicMainView
         if (e.IsHost)
             OctaveNumValue = e.OctaveShift;
     }
+
+    private void SpeedShiftChange(SpeedShiftEvent e)
+    {
+        if (e.IsHost)
+            SpeedNumValue = e.SpeedShift;
+    }
     #endregion
 
     #region Track UP/Down
@@ -343,7 +359,7 @@ public partial class ClassicMainView
             return;
         
         OctaveNumValue++;
-        BmpMaestro.Instance.SetOctaveshiftOnHost(OctaveNumValue);
+        BmpMaestro.Instance.SetOctaveShiftOnHost(OctaveNumValue);
     }
 
     private void octave_cmdDown_Click(object sender, RoutedEventArgs e)
@@ -352,7 +368,7 @@ public partial class ClassicMainView
             return;
         
         OctaveNumValue--;
-        BmpMaestro.Instance.SetOctaveshiftOnHost(OctaveNumValue);
+        BmpMaestro.Instance.SetOctaveShiftOnHost(OctaveNumValue);
     }
 
     private void octave_txtNum_TextChanged(object sender, TextChangedEventArgs e)
@@ -369,7 +385,7 @@ public partial class ClassicMainView
         if (int.TryParse(OctaveTxtNum.Text.Replace(@"ø", ""), out _octaveNumValue))
         {
             OctaveTxtNum.Text = @"ø" + _octaveNumValue;
-            BmpMaestro.Instance.SetOctaveshiftOnHost(_octaveNumValue);
+            BmpMaestro.Instance.SetOctaveShiftOnHost(_octaveNumValue);
         }
     }
     private void octave_txtNum_KeyUp(object sender, KeyEventArgs e)
@@ -386,6 +402,58 @@ public partial class ClassicMainView
     }
     #endregion
 
+    #region Speed shift
+    private float _speedNumValue = 1.0f;
+
+    private float SpeedNumValue
+    {
+        get => _speedNumValue;
+        set
+        {
+            _speedNumValue = value;
+            var roundedPercentage = (int)Math.Round(value * 100); // Round to the nearest whole number
+            SpeedTxtNum.Text = $"{roundedPercentage}%";           // Use string interpolation for formatting
+        }
+    }
+
+    private void speed_txtNum_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        if (SpeedTxtNum == null)
+            return;
+
+        if (int.TryParse(SpeedTxtNum.Text.Replace(@"%", ""), out var t))
+        {
+            var speedShift = (Convert.ToDouble(t) / 100).Clamp(0.20f, 2.00f);
+            BmpMaestro.Instance.SetSpeedShiftAll((float)speedShift);
+        }
+    }
+
+    private void speed_cmdUp_Click(object sender, RoutedEventArgs e)
+    {
+        var increment = Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift) ? 0.10f : 0.01f;
+        var newSpeedShift = SpeedNumValue + increment;
+        if (newSpeedShift < 2.01f) // Ensure the value is not increase above 200% to fix visual bouncing
+        {
+            BmpMaestro.Instance.SetSpeedShiftAll(newSpeedShift);
+        }
+    }
+
+    private void speed_cmdDown_Click(object sender, RoutedEventArgs e)
+    {
+        var increment = Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift) ? 0.10f : 0.01f;
+        var newSpeedShift = SpeedNumValue - increment;
+        if (newSpeedShift > 0.19f) // Ensure the value is not decreased below 20% to prevent crash
+        {
+            BmpMaestro.Instance.SetSpeedShiftAll(newSpeedShift);
+        }
+    }
+
+    private void speed_cmdReset_Click(object? sender, RoutedEventArgs? e)
+    {
+        const float speedShift = 1.0f;
+        BmpMaestro.Instance.SetSpeedShiftAll(speedShift);
+    }
+    #endregion
 
     private void Macro_Button_Click(object sender, RoutedEventArgs e)
     {


### PR DESCRIPTION
Another highly requested feature, primarily by solo performers.

* Added playback speed text box, up/down buttons, and reset button to UI.

Can shift speed 1% at a time by clicking up/down arrows or holding shift to go 10% at a time. Stops at 200% speed and prevents going below 20% due to a sanford sequencer bug.
Can reset speed back to 100% by clicking the reset button next to up/down arrows.

* Rounding to whole numbers to prevent .99999% randomly due to no tolerance when shifting below 70%.
* Resetting speed back to 100% on song load.
* Small name refactor for consistency cleanup.