### PR TITLE
Keep on Top Setting

### DIFF
--- a/BardMusicPlayer.Pigeonhole/BmpPigeonhole.cs
+++ b/BardMusicPlayer.Pigeonhole/BmpPigeonhole.cs
@@ -140,6 +140,11 @@ public class BmpPigeonhole : JsonSettings.JsonSettings
     public virtual bool DarkStyle { get; set; }
 
     /// <summary>
+    /// Bring BMP to front
+    /// </summary>
+    public virtual bool KeepOnTop { get; set; }
+
+    /// <summary>
     /// Midi download path
     /// </summary>
     public virtual string MidiDownloadPath { get; set; } = "";

--- a/BardMusicPlayer/MainWindow.xaml.cs
+++ b/BardMusicPlayer/MainWindow.xaml.cs
@@ -16,20 +16,27 @@ public partial class MainWindow
 {
     public MainWindow()
     {
-        InitializeComponent();
-
-        Title              = "BardMusicPlayer - " + Assembly.GetExecutingAssembly().GetName().Version;
-        DataContext        = new ClassicMainView();
+        // Set properties before initializing components
         AllowsTransparency = false;
         WindowStyle        = WindowStyle.SingleBorderWindow;
         Height             = 620;
         Width              = 900;
         ResizeMode         = ResizeMode.CanResizeWithGrip;
 
+        InitializeComponent();
+
+        Title       = "BardMusicPlayer - " + Assembly.GetExecutingAssembly().GetName().Version;
+        DataContext = new ClassicMainView();
+
         if (!BmpPigeonhole.Instance.DarkStyle)
             LightModeStyle();
         else
             DarkModeStyle();
+
+        if (!BmpPigeonhole.Instance.KeepOnTop)
+            KeepOnTop_Disabled();
+        else
+            KeepOnTop_Enabled();
     }
 
     public static void LightModeStyle()
@@ -62,6 +69,68 @@ public partial class MainWindow
         var paletteHelper = new PaletteHelper();
         theme.Background = Color.FromRgb(30, 30, 30);
         paletteHelper.SetTheme(theme);
+    }
+
+    /// <summary>
+    /// Helper to bring the player to front
+    /// </summary>
+    public static void KeepOnTop_Enabled()
+    {
+        try
+        {
+            var mainWindow = Application.Current.MainWindow;
+            if (mainWindow is { IsVisible: false })
+            {
+                mainWindow.Show();
+            }
+
+            if (mainWindow is { WindowState: WindowState.Minimized })
+            {
+                mainWindow.WindowState = WindowState.Normal;
+            }
+
+            if (mainWindow != null)
+            {
+                mainWindow.Activate();
+                mainWindow.Topmost = true;
+                mainWindow.Focus();
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+    }
+
+    /// <summary>
+    /// Helper to bring the player to front
+    /// </summary>
+    public static void KeepOnTop_Disabled()
+    {
+        try
+        {
+            var mainWindow = Application.Current.MainWindow;
+            if (mainWindow is { IsVisible: false })
+            {
+                mainWindow.Show();
+            }
+
+            if (mainWindow is { WindowState: WindowState.Minimized })
+            {
+                mainWindow.WindowState = WindowState.Normal;
+            }
+
+            if (mainWindow != null)
+            {
+                mainWindow.Activate();
+                mainWindow.Topmost = false;
+                mainWindow.Focus();
+            }
+        }
+        catch
+        {
+            // ignored
+        }
     }
 
     protected override void OnClosing(CancelEventArgs e)

--- a/BardMusicPlayer/Resources/ToolTips.xaml
+++ b/BardMusicPlayer/Resources/ToolTips.xaml
@@ -37,4 +37,5 @@
     <sys:String x:Key="ExportSong" xml:space="preserve">Export the current loaded song to MIDI&#13;Helpful to convert .mmsong or .gp files to .mid</sys:String>
     <sys:String x:Key="LyricsTrackNumber" xml:space="preserve">Enables lyrics parsing &#13;0 means stop lyric parsing &#13;1 the first lyrics track (lyric tracks are separate from the music tracks)</sys:String>
     <sys:String x:Key="Multibox" xml:space="preserve">Start more than two game instances</sys:String>
+    <sys:String x:Key="KeepOnTop" xml:space="preserve">Keep BMP window on top</sys:String>
 </ResourceDictionary>

--- a/BardMusicPlayer/UI_Classic/Classic_MainView.xaml
+++ b/BardMusicPlayer/UI_Classic/Classic_MainView.xaml
@@ -279,12 +279,19 @@
                                 <Grid>
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
                                     </Grid.RowDefinitions>
                                     <Label Margin="0,10,80,0" Grid.Row="0" Content="Dark Mode"
                                            HorizontalAlignment="Right" ToolTip="{StaticResource DarkMode}" />
                                     <ToggleButton Margin="0,10,20,0" Grid.Row="0" x:Name="EnableDarkMode"
                                                   Unchecked="EnableDarkMode_Checked" Checked="EnableDarkMode_Checked"
                                                   HorizontalAlignment="Right" ToolTip="{StaticResource DarkMode}"
+                                                  Padding="0" Width="60" Height="25" />
+                                    <Label Margin="0,10,80,0" Grid.Row="1" Content="Keep on Top"
+                                           HorizontalAlignment="Right" ToolTip="{StaticResource KeepOnTop}" />
+                                    <ToggleButton Margin="0,10,20,0" Grid.Row="1" x:Name="KeepOnTop"
+                                                  Unchecked="KeepOnTop_Checked" Checked="KeepOnTop_Checked"
+                                                  HorizontalAlignment="Right" ToolTip="{StaticResource KeepOnTop}"
                                                   Padding="0" Width="60" Height="25" />
                                 </Grid>
                             </GroupBox>

--- a/BardMusicPlayer/UI_Classic/Classic_Settings.cs
+++ b/BardMusicPlayer/UI_Classic/Classic_Settings.cs
@@ -39,6 +39,7 @@ public partial class ClassicMainView
         //UI
         // MidiLoaderSelection.SelectedIndex = BmpPigeonhole.Instance.MidiLoaderType;
         EnableDarkMode.IsChecked = BmpPigeonhole.Instance.DarkStyle;
+        KeepOnTop.IsChecked      = BmpPigeonhole.Instance.KeepOnTop;
     }
 
     #region Playback
@@ -117,7 +118,7 @@ public partial class ClassicMainView
         else
             MainWindow.DarkModeStyle();
     }
-    
+
     private void MultiBoxChecked(object sender, RoutedEventArgs e)
     {
         if (!BmpPigeonhole.Instance.EnableMultibox)
@@ -129,6 +130,16 @@ public partial class ClassicMainView
             });
         }
         BmpPigeonhole.Instance.EnableMultibox = MultiBox.IsChecked ?? false;
+    }
+
+    private void KeepOnTop_Checked(object sender, RoutedEventArgs e)
+    {
+        BmpPigeonhole.Instance.KeepOnTop = KeepOnTop.IsChecked ?? false;
+
+        if (Application.Current.MainWindow is MainWindow mainWindow)
+        {
+            mainWindow.Topmost = BmpPigeonhole.Instance.KeepOnTop;
+        }
     }
     #endregion
 }


### PR DESCRIPTION
* Fixed up and implemented old setting to allow BMP window to stay on top on application start-up & button toggle.
* Now setting some component properties before window initializing to fix crash from AllowsTransparency when KeepOnTop is enabled from saved settings on startup.