### PR TITLE
🎷

### DIFF
--- a/BardMusicPlayer.Quotidian/Structs/Instrument.cs
+++ b/BardMusicPlayer.Quotidian/Structs/Instrument.cs
@@ -336,7 +336,7 @@ public readonly struct Instrument : IComparable, IConvertible, IComparable<Instr
         /*if (Equals(Lute) && note < 15) return 0;
         if (Equals(Lute) && note > 14) return 50;*/ 
 
-        if (Equals(Clarinet) && note <= 7) return -50;
+        if (Equals(Clarinet) && note <= 10) return -50;
 
         return 0;
     }


### PR DESCRIPTION
Still no clue how these note ranges are being deciphered. I thought it was embedded in the sf2 samples but apparently the originals were always incorrect? Oddly, not all samples inside an instrument had note range updates and not every instrument received an update. Likewise, pitch keycenter was not changed. Hoping newer corrections aren't just left unfinished.

No padding offsets need updating except a larger clarinet range correction for the one extra bad sample now containing more notes. Still assuming 50ms rounding for ensemble note packet spacing unless otherwise clarified or desired more precise.

Updated note range comparing old vst to new vst can be found below.

https://docs.google.com/spreadsheets/d/e/2PACX-1vSDIT3O0z0LWfiMe0XfSuZ9K5vGQqK0DTsdW4Cm4F60TmRvhqGr5jqCiBvzLDbLj7KNUVRoNwBix6OM/pubhtml#

Siren Utils.cs note lengths may need future corrections.