### PR TITLE
Fix matching octave shifted instruments as none

### DIFF
--- a/BardMusicPlayer.Quotidian/Structs/Instrument.cs
+++ b/BardMusicPlayer.Quotidian/Structs/Instrument.cs
@@ -281,6 +281,9 @@ public readonly struct Instrument : IComparable, IConvertible, IComparable<Instr
         // Remove numeric characters at the end (e.g. Harp 2)
         instrument = Regex.Replace(instrument, @"\d+$", "").Trim();
 
+        // Remove plus or minus characters at the end
+        instrument = Regex.Replace(instrument, @"[-+]?$", "").Trim();
+
         // Split the input string by spaces
         var parts = instrument.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 


### PR DESCRIPTION
* For some reason the newer bmpsong loader processes notes multiple times when loading (causing slower scrubbing). Even more confusing, octave shifted notes seem to get processed in numerous places. If a track title uses ±# to octave shift, it correctly was identifying a match for the instrument to use (previewing / in-game opening) and what octave the new notes should be played at, but internally saw the instrument as none because of a lingering +/- in the instrument name ending. This caused offsets to use None's 100ms delay for those tracks instead of the proper instrument offset, which by happenstance created slightly delayed playback in preview & in-game.

The newer bmpsong loader has significant issues but this is a huge bugfix in the right direction. This fix affects how the new loader used an existing piece of code; instruments.cs wasn't equipped properly to deal with octave shifting via track naming. The old loader seemed to ignore this but is missing major features such as processing progchanges for guitars, lyric events, and other special settings / track things, thus cannot (and shouldn't) just be reverted.